### PR TITLE
fix: /np silent failure on CF API error — add retry + user notification

### DIFF
--- a/src/kouhai_bot/handlers/cmd/newproblem.py
+++ b/src/kouhai_bot/handlers/cmd/newproblem.py
@@ -80,7 +80,7 @@ async def enqueue_force_new_problem(
         _cooldowns[group_id] = now
         logger.info(f"[group_{group_id}] {command} triggered")
 
-        await _do_daily_post_locked(group_id, prefix="刷新了一道新题🌟")
+        await _do_daily_post_locked(group_id, prefix="刷新了一道新题🌟", notify_group=True)
 
 # ── Picker path ─────────────────────────────────────────────────────────
 
@@ -291,7 +291,9 @@ async def do_daily_post(group_id: int, prefix: str | None = None) -> None:
         await _do_daily_post_locked(group_id, prefix)
 
 
-async def _do_daily_post_locked(group_id: int, prefix: str | None = None) -> None:
+async def _do_daily_post_locked(
+    group_id: int, prefix: str | None = None, *, notify_group: bool = False,
+) -> None:
     cfg = get_config()
     python = sys.executable
     state_dir = os.path.join(cfg.data_dir, "groups", str(group_id))
@@ -310,23 +312,47 @@ async def _do_daily_post_locked(group_id: int, prefix: str | None = None) -> Non
     except Exception as e:
         logger.error(f"Reveal error (group {group_id}): {e}")
 
-    # Step 2: Pick today's problem
+    # Step 2: Pick today's problem (w/ retry)
     picked_state: dict = {}
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            python, *_picker_args("pick-json", group_id, "--with-statement"),
-            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
-        if proc.returncode != 0:
-            logger.error(f"Pick failed (group {group_id}): {stderr.decode()[:200]}")
-            return
-        picked_state = json.loads(stdout.decode())
-        if not isinstance(picked_state, dict):
-            logger.error(f"Pick failed (group {group_id}): invalid picker payload")
-            return
-    except Exception as e:
-        logger.error(f"Pick error (group {group_id}): {e}")
+    pick_error_msg = ""
+    for attempt in range(1, 4):
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                python, *_picker_args("pick-json", group_id, "--with-statement"),
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
+            if proc.returncode != 0:
+                err_text = stderr.decode()[:200]
+                logger.error(
+                    f"Pick failed (group {group_id}, attempt {attempt}/3): {err_text}"
+                )
+                pick_error_msg = f"Codeforces API 暂时不可用"
+            else:
+                picked_state = json.loads(stdout.decode())
+                if not isinstance(picked_state, dict):
+                    logger.error(
+                        f"Pick failed (group {group_id}, attempt {attempt}/3): "
+                        f"invalid picker payload"
+                    )
+                    pick_error_msg = "题目选取结果异常"
+                else:
+                    break  # success
+        except Exception as e:
+            logger.error(
+                f"Pick error (group {group_id}, attempt {attempt}/3): {e}"
+            )
+            pick_error_msg = f"Codeforces 连接失败"
+        if attempt < 3:
+            delay = 2 * attempt
+            logger.info(f"Retrying pick in {delay}s...")
+            await asyncio.sleep(delay)
+
+    if not picked_state:
+        if notify_group:
+            await send_group_msg(group_id, build_plain_message(
+                f"刷题失败了…{pick_error_msg}，连试 3 次都没成功，等一会儿再试试吧😢"
+            ))
         return
 
     # Step 3: Generate Chinese summary

--- a/src/kouhai_bot/handlers/cmd/newproblem.py
+++ b/src/kouhai_bot/handlers/cmd/newproblem.py
@@ -128,6 +128,23 @@ def _picker_args(command: str, group_id: int, *extra: str) -> list[str]:
     return args
 
 
+def _classify_pick_error(stderr_text: str) -> str:
+    """Classify picker stderr into a user-friendly Chinese message."""
+    lower = stderr_text.lower()
+    # CF-specific connectivity issues
+    if any(kw in stderr_text for kw in (
+        "codeforces.com", "SSL", "SSLEOFError", "SSLError",
+        "ConnectionError", "Max retries exceeded", "RemoteDisconnected",
+    )):
+        return "Codeforces 连接失败"
+    if any(kw in lower for kw in ("timeout", "timed out")):
+        return "Codeforces 请求超时"
+    if any(kw in lower for kw in ("permission", "access denied", "ioerror", "filenotfound")):
+        return "本地数据读取异常"
+    # fallback — still log the raw text above
+    return "题目选取失败，稍后再试"
+
+
 def _newproblem_lock(group_id: int) -> asyncio.Lock:
     lock = _newproblem_locks.get(group_id)
     if lock is None:
@@ -327,7 +344,7 @@ async def _do_daily_post_locked(
                 logger.error(
                     f"Pick failed (group {group_id}, attempt {attempt}/3): {err_text}"
                 )
-                pick_error_msg = f"Codeforces API 暂时不可用"
+                pick_error_msg = _classify_pick_error(err_text)
             else:
                 picked_state = json.loads(stdout.decode())
                 if not isinstance(picked_state, dict):

--- a/src/kouhai_bot/handlers/cmd/newproblem.py
+++ b/src/kouhai_bot/handlers/cmd/newproblem.py
@@ -336,6 +336,7 @@ async def _do_daily_post_locked(
                         f"invalid picker payload"
                     )
                     pick_error_msg = "题目选取结果异常"
+                    picked_state = {}  # reset to ensure truthiness check catches it
                 else:
                     break  # success
         except Exception as e:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2193,6 +2193,49 @@ def test_newproblem_commit_does_not_settle_unsolved_previous_problem():
     print("✅ newproblem: unsolved previous problem does not change dynamic wait")
 
 
+def test_newproblem_notify_group_on_pick_failure():
+    """After 3 failed pick attempts, notify_group=True sends error msg."""
+    _reset_state()
+    _setup_problem()
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
+
+    async def _mock_pick_fail(*args, **kwargs):
+        """Fail the pick-json subprocess, succeed reveal."""
+        cmd_args = args[1:]  # skip 'python' executable
+        if any("reveal" in str(a) for a in cmd_args):
+            proc = AsyncMock()
+            proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            return proc
+        if any("pick-json" in str(a) for a in cmd_args):
+            proc = AsyncMock()
+            proc.returncode = 1
+            proc.communicate = AsyncMock(return_value=(b"", b"SSL EOF"))
+            return proc
+        raise RuntimeError(f"unexpected subprocess: {cmd_args}")
+
+    with _all_patches(), patch(
+        "asyncio.create_subprocess_exec", _mock_pick_fail
+    ), patch(
+        "asyncio.sleep", AsyncMock()
+    ):
+        from kouhai_bot.handlers.cmd.newproblem import _do_daily_post_locked
+
+        # Test 1: notify_group=True → should send error message
+        _sent.clear()
+        asyncio.run(_do_daily_post_locked(GID, notify_group=True))
+        assert _has_sent("刷题失败了"), f"No error msg: {_last_text()}"
+        assert _has_sent("3 次"), f"No retry mention: {_last_text()}"
+
+        # Test 2: notify_group=False → should NOT send error message
+        _sent.clear()
+        asyncio.run(_do_daily_post_locked(GID, notify_group=False))
+        assert not _sent, f"Unexpected msg with notify_group=False: {_last_text()}"
+
+    _cleanup()
+    print("✅ newproblem: pick failure notifies group when notify_group=True")
+
+
 def test_submit_scoreboard_update_settles_late_old_problem():
     _reset_state()
     _setup_problem_for(GID, PID2)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1974,7 +1974,7 @@ def test_newproblem_cooldown():
         _cooldowns.clear()
         ran: list[int] = []
 
-        async def _mock_post(gid, prefix=None):
+        async def _mock_post(gid, prefix=None, **_):
             ran.append(gid)
 
         with patch("kouhai_bot.handlers.cmd.newproblem._do_daily_post_locked", _mock_post):
@@ -1997,7 +1997,7 @@ def test_newproblem_cooldown_serializes_concurrent_force():
         _newproblem_locks.clear()
         ran: list[int] = []
 
-        async def _mock_post(gid, prefix=None):
+        async def _mock_post(gid, prefix=None, **_):
             ran.append(gid)
             await asyncio.sleep(0.05)
 
@@ -2022,7 +2022,7 @@ def test_newproblem_unsolved_rejects():
         _cooldowns.clear()
         ran: list[int] = []
 
-        async def _mock_post(gid, prefix=None):
+        async def _mock_post(gid, prefix=None, **_):
             ran.append(gid)
 
         with patch("kouhai_bot.handlers.cmd.newproblem._do_daily_post_locked", _mock_post):
@@ -2043,7 +2043,7 @@ def test_newproblem_force_posts_when_unsolved():
         _cooldowns.clear()
         ran: list[int] = []
 
-        async def _mock_post(gid, prefix=None):
+        async def _mock_post(gid, prefix=None, **_):
             ran.append(gid)
 
         with patch("kouhai_bot.handlers.cmd.newproblem._do_daily_post_locked", _mock_post):
@@ -2065,7 +2065,7 @@ def test_newproblem_alias_force_posts_when_unsolved():
         discover_commands()
         ran: list[int] = []
 
-        async def _mock_post(gid, prefix=None):
+        async def _mock_post(gid, prefix=None, **_):
             ran.append(gid)
 
         with patch("kouhai_bot.handlers.cmd.newproblem._do_daily_post_locked", _mock_post):
@@ -2084,7 +2084,7 @@ def test_newproblem_force_requires_space():
         _cooldowns.clear()
         ran: list[int] = []
 
-        async def _mock_post(gid, prefix=None):
+        async def _mock_post(gid, prefix=None, **_):
             ran.append(gid)
 
         with patch("kouhai_bot.handlers.cmd.newproblem._do_daily_post_locked", _mock_post):
@@ -2108,7 +2108,7 @@ def test_newproblem_solved_posts():
         _cooldowns.clear()
         ran: list[int] = []
 
-        async def _mock_post(gid, prefix=None):
+        async def _mock_post(gid, prefix=None, **_):
             ran.append(gid)
 
         with patch("kouhai_bot.handlers.cmd.newproblem._do_daily_post_locked", _mock_post):


### PR DESCRIPTION
## 问题

`/np` 请求在 Codeforces API 不可达时（SSL EOF 等），picker 子进程失败后只打日志不通知用户，造成静默死掉的体验。

具体日志：
```
14:02:57 [kouhai-bot.handlers] INFO: user_251346744 → /np
14:03:04 [kouhai-bot.cmd.newproblem] ERROR: Pick failed: [SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred
```

之后无任何用户提示，直到 5 分钟后用户重新 /np 才成功。

## 修复

1. **Picker 退避重试 3 次**：2s/4s 指数退避，CF 偶发 SSL 错误通常一次重试就能过
2. **notify_group 参数**：区分用户触发（`/np` → `notify_group=True`，发消息提示）和 cron 触发（保持静默）
3. **用户提示**：3 次全失败后发群消息「刷题失败了…Codeforces API 暂时不可用，连试 3 次都没成功，等一会儿再试试吧😢」

## 改动

- `src/kouhai_bot/handlers/cmd/newproblem.py`: pick 步骤改为 for loop + retry，新增 `notify_group` kwarg
- `tests/test_commands.py`: mock 签名适配 `**_` 接受新 kwarg