### PR TITLE
[codex] drop superseded unanswered submits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,7 +256,9 @@ Key rules:
 - **Pending context**: when a request is admitted, its user input is registered in
   in-memory pending context keyed by `(group, user, pid)`. Later same-user requests
   include earlier pending user inputs plus completed `user_submissions`; pending records
-  are not persisted and have no fabricated bot reply.
+  are not persisted and have no fabricated bot reply. Exception: a later same-user
+  `/submit` or `/clear` for the same current problem discards older unanswered
+  `/submit` requests for that user/problem before they can be used as pending context.
 - **Short state critical sections**: JSON read/modify/write endpoints are protected by
   the per-group scheduler async lock. LLM calls never hold this lock.
 - **Submit first-blood serialization only**: incorrect/off-topic/failure replies are
@@ -266,6 +268,12 @@ Key rules:
   settle updates `scoreboard.json`, sends rank/top5/reveal, and schedules the official
   tutorial. Later correct candidates log `post_solve_correct` and are saved but do not
   send an extra not-counted message.
+- **Same-user submit replacement**: if a user sends another `/submit` or `/clear` for
+  the same problem before an earlier `/submit` has reached terminal reply handling, the
+  older submit is silently dropped, its local compute task is cancelled, and its command
+  event logs `status="stale"`. The 👀/[睁眼] ack does not count as a terminal reply.
+  This optimization applies only to older `/submit` requests in that exact same-user,
+  same-problem scenario.
 - **New problem visibility**: `/newproblem` / `daily_post` pick and summarize a candidate
   without changing `state.json`. Until the new card is successfully delivered, all
   commands still see the old problem. Failed delivery leaves the old current problem
@@ -355,7 +363,8 @@ achievement reports.
    enqueue
 4. If not blocked, get a sequence number and enqueue the snapshotted pid/solved state
 5. Background compute starts immediately; it loads completed user history plus earlier
-   pending user inputs for the same `(group, user, pid)`
+   pending user inputs for the same `(group, user, pid)`, excluding same-user same-problem
+   `/submit` requests that were superseded by a later `/submit` or `/clear`
 6. If `SUBMIT_AC_BACKDOOR` is non-empty and the submission contains that string, return a correct verdict before calling the judge LLM
 7. Otherwise load user history, react with 👀/[睁眼] ack, and call `judge_submission()`
    `[睁眼]` is a QQ special emoji reaction (emoji id), not plain message text.

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -173,7 +173,10 @@ class PendingRequest:
     admitted_at: float = field(default_factory=time.monotonic)
     admitted_wall: datetime = field(default_factory=lambda: datetime.now(timezone(timedelta(hours=8))))
     done_event: asyncio.Event = field(default_factory=asyncio.Event)
+    task: asyncio.Task | None = None
     compute_result: Any = None
+    discarded: bool = False
+    submit_terminal_started: bool = False
     submit_judge_done: bool = False
     submit_correct: bool = False
     submit_score_candidate: bool = False
@@ -471,6 +474,7 @@ class GroupCoordinator:
         req.seq = self.next_seq
         self.next_seq += 1
         self.active[req.seq] = req
+        resolve_pids = self._discard_superseded_submits_locked(req)
         if req.kind in _USER_CONTEXT_WRITERS and req.target_pid:
             self.pending_context.setdefault(
                 (req.group_id, req.user_id, req.target_pid),
@@ -484,10 +488,15 @@ class GroupCoordinator:
             ))
         if req.submit_score_candidate and req.submit_pid:
             self.submit_candidates.setdefault(req.submit_pid, []).append(req)
-        asyncio.create_task(
+        req.task = asyncio.create_task(
             self._run_request(req),
             name=f"stateful_{req.command}_{req.group_id}_{req.seq}",
         )
+        for pid in resolve_pids:
+            asyncio.create_task(
+                self._resolve_submit_scores(pid),
+                name=f"resolve_submit_scores_{req.group_id}_{pid}",
+            )
 
     async def enqueue(self, req: PendingRequest) -> None:
         async with self.lock:
@@ -527,18 +536,47 @@ class GroupCoordinator:
         else:
             self.pending_context.pop(key, None)
 
+    def _finish_request_locked(self, req: PendingRequest) -> str:
+        self.active.pop(req.seq, None)
+        self._remove_pending_context_locked(req)
+        pid = (req.compute_result or {}).get("pid", "") or req.submit_pid
+        if pid:
+            candidates = self.submit_candidates.get(pid)
+            if candidates:
+                candidates[:] = [c for c in candidates if c.seq != req.seq]
+                if not candidates:
+                    self.submit_candidates.pop(pid, None)
+        req.done_event.set()
+        return pid
+
+    def _discard_superseded_submits_locked(self, req: PendingRequest) -> set[str]:
+        if req.kind not in {"submit", "clear"} or not req.target_pid:
+            return set()
+
+        resolved_pids: set[str] = set()
+        for old in list(self.active.values()):
+            if old is req:
+                continue
+            if old.kind != "submit":
+                continue
+            if old.user_id != req.user_id or old.target_pid != req.target_pid:
+                continue
+            if old.seq >= req.seq or old.done_event.is_set():
+                continue
+            if old.discarded or old.submit_terminal_started:
+                continue
+
+            old.discarded = True
+            old.compute_result = {"kind": "discarded", "pid": old.submit_pid}
+            self._log_finished(old, "stale", problem=old.submit_pid)
+            resolved_pids.add(self._finish_request_locked(old))
+            if old.task and not old.task.done():
+                old.task.cancel()
+        return {pid for pid in resolved_pids if pid}
+
     async def _finish_request(self, req: PendingRequest) -> None:
         async with self.lock:
-            self.active.pop(req.seq, None)
-            self._remove_pending_context_locked(req)
-            pid = (req.compute_result or {}).get("pid", "")
-            if pid:
-                candidates = self.submit_candidates.get(pid)
-                if candidates:
-                    candidates[:] = [c for c in candidates if c.seq != req.seq]
-                    if not candidates:
-                        self.submit_candidates.pop(pid, None)
-        req.done_event.set()
+            self._finish_request_locked(req)
 
     async def _load_user_problem_history_for_request(
         self,
@@ -570,6 +608,8 @@ class GroupCoordinator:
 
     async def _run_request(self, req: PendingRequest) -> None:
         try:
+            if req.discarded:
+                return
             if req.kind == "submit":
                 req.compute_result = await self._compute_submit(req)
             elif req.kind == "clarify":
@@ -587,6 +627,8 @@ class GroupCoordinator:
             )
             req.compute_result = {"kind": "error", "error": str(e)}
         try:
+            if req.discarded:
+                return
             if req.kind == "submit":
                 await self._finalize_submit(req)
             elif req.kind == "clarify":
@@ -889,6 +931,9 @@ class GroupCoordinator:
                     self.scoring_pids.discard(pid)
 
     async def _finalize_submit(self, req: PendingRequest) -> None:
+        if req.discarded:
+            return
+        req.submit_terminal_started = True
         result = req.compute_result or {}
         kind = result.get("kind")
         if kind == "no_problem":

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2516,6 +2516,202 @@ def test_submit_same_user_includes_previous_submit_history():
     print("✅ submit: same-user submit history is chained")
 
 
+def test_submit_same_user_later_submit_drops_unanswered_previous_submit():
+    """A same-user same-problem submit replaces an earlier unanswered submit."""
+    _reset_state()
+    _setup_problem()
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
+
+    first_started = asyncio.Event()
+    first_cancelled = asyncio.Event()
+
+    async def _drop_deepseek(messages, model="", task="", temperature=0.7, timeout=120,
+                             response_format=None, thinking=None):
+        payload = json.loads(messages[-1]["content"])
+        submission = payload["submission"]
+        history = payload["history"] or []
+        if submission == "first solution":
+            first_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                first_cancelled.set()
+        if submission == "second solution":
+            assert not any(item.get("content") == "first solution" for item in history), \
+                f"Dropped submit leaked into second history: {history}"
+            return json.dumps({"correct": False, "reason": "R2", "reply": "SECOND"})
+        return json.dumps({"correct": False, "reason": "RX", "reply": "OTHER"})
+
+    async def _run():
+        with _all_patches():
+            from kouhai_bot.eventlog import EVENT_META_KEY, log_command_received, load_events
+            from kouhai_bot.handlers.cmd.submit import handle
+
+            ev1_raw = _make_event("/submit first solution", group_id=GID, user_id=UID, message_id="drop_1")
+            ev2_raw = _make_event("/submit second solution", group_id=GID, user_id=UID, message_id="drop_2")
+            ev1_raw[EVENT_META_KEY] = log_command_received(
+                group_id=GID,
+                user_id=UID,
+                sender=ev1_raw["sender"],
+                command="submit",
+                message_id=ev1_raw["message_id"],
+                raw_text=ev1_raw["raw_message"],
+            )
+            stale_request_id = ev1_raw[EVENT_META_KEY]["request_id"]
+            event_date = ev1_raw[EVENT_META_KEY]["date"]
+
+            with patch("kouhai_bot.handlers.cmd.submit.judge_submission_result", _wrap_deepseek_as_judge_result(_drop_deepseek)):
+                t1 = asyncio.create_task(handle(**_kwargs(ev1_raw)))
+                await asyncio.wait_for(first_started.wait(), timeout=1.0)
+                t2 = asyncio.create_task(handle(**_kwargs(ev2_raw)))
+                await asyncio.wait_for(asyncio.gather(t1, t2), timeout=1.0)
+                await asyncio.sleep(0)
+
+            return [
+                item for item in load_events(GID, event_date)
+                if item.get("request_id") == stale_request_id
+                and item.get("type") == "finished"
+            ]
+
+    stale_events = asyncio.run(_run())
+
+    texts = []
+    for item in _sent:
+        msg = item.get("message", [])
+        text = " ".join(seg.get("data", {}).get("text", "") for seg in msg if seg.get("type") == "text")
+        if "FIRST" in text or "SECOND" in text:
+            texts.append(text)
+    assert texts == [" SECOND"], f"Only the second submit should reply, got: {texts}"
+    assert first_cancelled.is_set(), "First submit task should be cancelled locally"
+    assert stale_events and stale_events[-1]["status"] == "stale", stale_events
+
+    with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
+        saved = json.load(f)
+    records = saved["user_submissions"].get(str(UID), [])
+    assert [item["content"] for item in records] == ["second solution"], records
+
+    _cleanup()
+    print("✅ submit: later same-user submit drops unanswered previous submit")
+
+
+def test_clear_drops_unanswered_same_user_submit():
+    """A same-user /clear drops an earlier unanswered submit for the current problem."""
+    _reset_state()
+    _setup_problem()
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
+
+    first_started = asyncio.Event()
+
+    async def _slow_deepseek(messages, model="", task="", temperature=0.7, timeout=120,
+                             response_format=None, thinking=None):
+        payload = json.loads(messages[-1]["content"])
+        if payload["submission"] == "first solution":
+            first_started.set()
+            await asyncio.Event().wait()
+        return json.dumps({"correct": False, "reason": "RX", "reply": "OTHER"})
+
+    async def _run():
+        with _all_patches():
+            from kouhai_bot.eventlog import EVENT_META_KEY, log_command_received, load_events
+            from kouhai_bot.handlers.cmd.clear import handle as clear_handle
+            from kouhai_bot.handlers.cmd.submit import handle as submit_handle
+
+            ev1_raw = _make_event("/submit first solution", group_id=GID, user_id=UID, message_id="clear_drop_1")
+            ev1_raw[EVENT_META_KEY] = log_command_received(
+                group_id=GID,
+                user_id=UID,
+                sender=ev1_raw["sender"],
+                command="submit",
+                message_id=ev1_raw["message_id"],
+                raw_text=ev1_raw["raw_message"],
+            )
+            stale_request_id = ev1_raw[EVENT_META_KEY]["request_id"]
+            event_date = ev1_raw[EVENT_META_KEY]["date"]
+            ev2 = _kwargs(_make_event("/clear", group_id=GID, user_id=UID, message_id="clear_drop_2"))
+
+            with patch("kouhai_bot.handlers.cmd.submit.judge_submission_result", _wrap_deepseek_as_judge_result(_slow_deepseek)):
+                t1 = asyncio.create_task(submit_handle(**_kwargs(ev1_raw)))
+                await asyncio.wait_for(first_started.wait(), timeout=1.0)
+                t2 = asyncio.create_task(clear_handle(**ev2))
+                await asyncio.wait_for(asyncio.gather(t1, t2), timeout=1.0)
+                await asyncio.sleep(0)
+
+            return [
+                item for item in load_events(GID, event_date)
+                if item.get("request_id") == stale_request_id
+                and item.get("type") == "finished"
+            ]
+
+    stale_events = asyncio.run(_run())
+
+    assert not _sent, f"Discarded submit should not send a verdict: {_sent}"
+    assert ("clear_drop_2", "128076") in _reacted, f"Clear should still react OK: {_reacted}"
+    assert stale_events and stale_events[-1]["status"] == "stale", stale_events
+
+    with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
+        saved = json.load(f)
+    assert saved["user_submissions"].get(str(UID), []) == []
+
+    _cleanup()
+    print("✅ clear: drops unanswered same-user submit")
+
+
+def test_dropping_unanswered_submit_unblocks_score_resolution():
+    """Discarding an earlier unresolved candidate should let later correct submits score."""
+    _reset_state()
+    _setup_problem()
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
+
+    first_started = asyncio.Event()
+
+    async def _mixed_deepseek(messages, model="", task="", temperature=0.7, timeout=120,
+                              response_format=None, thinking=None):
+        payload = json.loads(messages[-1]["content"])
+        submission = payload["submission"]
+        if submission == "first maybe correct":
+            first_started.set()
+            await asyncio.Event().wait()
+        if submission == "second correct":
+            return json.dumps({"correct": True, "reason": "second ok", "reply": ""})
+        return json.dumps({"correct": False, "reason": "RX", "reply": "OTHER"})
+
+    async def _run():
+        with _all_patches(), \
+                patch("kouhai_bot.handlers.cmd.submit.judge_submission_result", _wrap_deepseek_as_judge_result(_mixed_deepseek)), \
+                patch("kouhai_bot.handlers.cmd.submit._reveal_problem_source", AsyncMock(return_value="")):
+            from kouhai_bot.handlers.cmd.clear import handle as clear_handle
+            from kouhai_bot.handlers.cmd.submit import handle as submit_handle
+
+            t1 = asyncio.create_task(submit_handle(**_kwargs(_make_event(
+                "/submit first maybe correct", group_id=GID, user_id=UID, message_id="unblock_1"
+            ))))
+            await asyncio.wait_for(first_started.wait(), timeout=1.0)
+            t2 = asyncio.create_task(submit_handle(**_kwargs(_make_event(
+                "/submit second correct", group_id=GID, user_id=OTHER_UID, message_id="unblock_2"
+            ))))
+            for _ in range(20):
+                if _has_sent("更早发出的提交正在判题"):
+                    break
+                await asyncio.sleep(0.01)
+            assert _has_sent("更早发出的提交正在判题"), f"Later correct submit should wait first: {_sent}"
+            t3 = asyncio.create_task(clear_handle(**_kwargs(_make_event(
+                "/clear", group_id=GID, user_id=UID, message_id="unblock_3"
+            ))))
+            await asyncio.wait_for(asyncio.gather(t1, t2, t3), timeout=1.0)
+
+    asyncio.run(_run())
+
+    with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
+        saved = json.load(f)
+    assert len(saved["solves"]) == 1, saved
+    assert str(saved["solves"][0]["user_id"]) == str(OTHER_UID), saved
+    assert saved["user_submissions"].get(str(UID), []) == []
+    assert saved["user_submissions"][str(OTHER_UID)][-1]["result"] == "correct"
+
+    _cleanup()
+    print("✅ submit: dropping unanswered candidate unblocks scoring")
+
+
 def test_review_history_formats_types_and_submit_numbers():
     """Review context should separate interaction numbers from submit numbers."""
     from kouhai_bot.handlers.cmd.submit import _build_review_history
@@ -2804,6 +3000,9 @@ if __name__ == "__main__":
     test_submit_parallel_late_wrong_results_are_reused_after_first_solve()
     test_submit_parallel_late_correct_result_does_not_update_scoreboard_twice()
     test_submit_same_user_includes_previous_submit_history()
+    test_submit_same_user_later_submit_drops_unanswered_previous_submit()
+    test_clear_drops_unanswered_same_user_submit()
+    test_dropping_unanswered_submit_unblocks_score_resolution()
     test_clarify_prompt_hides_original_problem_identity()
     test_submit_same_user_includes_previous_clarify_history()
     test_submit_parallel_different_groups_do_not_block()


### PR DESCRIPTION
## Summary
- drop older unanswered same-user same-problem /submit requests when a later /submit or /clear arrives
- cancel the local runner task, remove stale pending context/score candidates, and log stale command events
- document the new state scheduler behavior in AGENTS.md

## Why
Users often append a corrected submit or clear context before the first judge response arrives. The older unresolved submit should not keep consuming local wait time, leak into later pending context, or block first-blood score resolution.

## Validation
- uv run python -m pytest tests/test_commands.py
- uv run python -m pytest
- git diff --check