### PR TITLE
[codex] keep superseded submit text as pending context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,9 +256,9 @@ Key rules:
 - **Pending context**: when a request is admitted, its user input is registered in
   in-memory pending context keyed by `(group, user, pid)`. Later same-user requests
   include earlier pending user inputs plus completed `user_submissions`; pending records
-  are not persisted and have no fabricated bot reply. Exception: a later same-user
-  `/submit` or `/clear` for the same current problem discards older unanswered
-  `/submit` requests for that user/problem before they can be used as pending context.
+  are not persisted and have no fabricated bot reply. Superseded unanswered `/submit`
+  requests remain visible here with `result="superseded"`, even though their judge work
+  is dropped.
 - **Short state critical sections**: JSON read/modify/write endpoints are protected by
   the per-group scheduler async lock. LLM calls never hold this lock.
 - **Submit first-blood serialization only**: incorrect/off-topic/failure replies are
@@ -273,7 +273,9 @@ Key rules:
   older submit is silently dropped, its local compute task is cancelled, and its command
   event logs `status="stale"`. The 👀/[睁眼] ack does not count as a terminal reply.
   This optimization applies only to older `/submit` requests in that exact same-user,
-  same-problem scenario.
+  same-problem scenario. The older submit's text remains as `result="superseded"`
+  context so a quick correction or addendum can refer to it, and the received `/submit`
+  still counts as a submit attempt in daily achievements.
 - **New problem visibility**: `/newproblem` / `daily_post` pick and summarize a candidate
   without changing `state.json`. Until the new card is successfully delivered, all
   commands still see the old problem. Failed delivery leaves the old current problem
@@ -342,7 +344,8 @@ The built-in scheduler job `daily_achievements` runs at 12:00 and reports:
 
 - earliest/latest `/submit`
 - most solved problems (`/submit` finished with `status="correct"`)
-- most `/submit` attempts
+- most `/submit` attempts (counted from received `/submit` commands, so superseded
+  `status="stale"` submits still count as attempts)
 - most `/review`
 - most `/clarify`
 
@@ -363,8 +366,8 @@ achievement reports.
    enqueue
 4. If not blocked, get a sequence number and enqueue the snapshotted pid/solved state
 5. Background compute starts immediately; it loads completed user history plus earlier
-   pending user inputs for the same `(group, user, pid)`, excluding same-user same-problem
-   `/submit` requests that were superseded by a later `/submit` or `/clear`
+   pending user inputs for the same `(group, user, pid)`, including superseded
+   unanswered `/submit` text as `result="superseded"` context
 6. If `SUBMIT_AC_BACKDOOR` is non-empty and the submission contains that string, return a correct verdict before calling the judge LLM
 7. Otherwise load user history, react with 👀/[睁眼] ack, and call `judge_submission()`
    `[睁眼]` is a QQ special emoji reaction (emoji id), not plain message text.

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -200,6 +200,7 @@ class PendingContext:
     content: str
     problem: str
     timestamp: str
+    result: str = "pending"
 
 
 def _refresh_runtime() -> None:
@@ -348,7 +349,7 @@ def _pending_context_record(item: PendingContext) -> dict:
         "timestamp": item.timestamp,
         "type": item.kind,
         "content": item.content,
-        "result": "pending",
+        "result": item.result,
         "reason": "",
         "reply": "",
         "problem": item.problem,
@@ -536,9 +537,28 @@ class GroupCoordinator:
         else:
             self.pending_context.pop(key, None)
 
-    def _finish_request_locked(self, req: PendingRequest) -> str:
+    def _mark_pending_context_result_locked(
+        self,
+        req: PendingRequest,
+        result: str,
+    ) -> None:
+        if req.kind not in _USER_CONTEXT_WRITERS or not req.target_pid:
+            return
+        key = (req.group_id, req.user_id, req.target_pid)
+        for item in self.pending_context.get(key, []):
+            if item.seq == req.seq:
+                item.result = result
+                return
+
+    def _finish_request_locked(
+        self,
+        req: PendingRequest,
+        *,
+        keep_pending_context: bool = False,
+    ) -> str:
         self.active.pop(req.seq, None)
-        self._remove_pending_context_locked(req)
+        if not keep_pending_context:
+            self._remove_pending_context_locked(req)
         pid = (req.compute_result or {}).get("pid", "") or req.submit_pid
         if pid:
             candidates = self.submit_candidates.get(pid)
@@ -568,8 +588,9 @@ class GroupCoordinator:
 
             old.discarded = True
             old.compute_result = {"kind": "discarded", "pid": old.submit_pid}
+            self._mark_pending_context_result_locked(old, "superseded")
             self._log_finished(old, "stale", problem=old.submit_pid)
-            resolved_pids.add(self._finish_request_locked(old))
+            resolved_pids.add(self._finish_request_locked(old, keep_pending_context=True))
             if old.task and not old.task.done():
                 old.task.cancel()
         return {pid for pid in resolved_pids if pid}

--- a/tests/test_achievements.py
+++ b/tests/test_achievements.py
@@ -92,6 +92,13 @@ def test_build_achievement_report_counts_window_and_statuses():
                 status="correct",
             )
             _log_command(
+                user_id=1,
+                nickname="Alice",
+                command="submit",
+                at=datetime(2026, 5, 14, 8, 1, tzinfo=TZ),
+                status="stale",
+            )
+            _log_command(
                 user_id=2,
                 nickname="Bob",
                 command="submit",
@@ -133,7 +140,7 @@ def test_build_achievement_report_counts_window_and_statuses():
         assert "最早 submit：Alice（04:01）" in report
         assert "最晚 submit：Bob（03:50）" in report
         assert "通过题目最多：Alice、Bob（1 次）" in report
-        assert "submit 尝试最多：Alice（2 次）" in report
+        assert "submit 尝试最多：Alice（3 次）" in report
         assert "review 最多：Alice（2 次）" in report
         assert "clarify 最多：Bob（1 次）" in report
         assert "TooEarly" not in report

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2517,7 +2517,7 @@ def test_submit_same_user_includes_previous_submit_history():
 
 
 def test_submit_same_user_later_submit_drops_unanswered_previous_submit():
-    """A same-user same-problem submit replaces an earlier unanswered submit."""
+    """A same-user same-problem submit drops judging but keeps prior text as context."""
     _reset_state()
     _setup_problem()
     _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
@@ -2537,8 +2537,12 @@ def test_submit_same_user_later_submit_drops_unanswered_previous_submit():
             finally:
                 first_cancelled.set()
         if submission == "second solution":
-            assert not any(item.get("content") == "first solution" for item in history), \
-                f"Dropped submit leaked into second history: {history}"
+            assert any(
+                item.get("content") == "first solution"
+                and item.get("result") == "superseded"
+                and item.get("problem") == PID
+                for item in history
+            ), f"Dropped submit should remain visible as superseded context: {history}"
             return json.dumps({"correct": False, "reason": "R2", "reply": "SECOND"})
         return json.dumps({"correct": False, "reason": "RX", "reply": "OTHER"})
 


### PR DESCRIPTION
## Summary
- keep superseded unanswered /submit text in pending context for later same-user same-problem requests
- still cancel the stale submit's local judge work and remove it from score candidates
- update tests and AGENTS.md to document the corrected behavior

## Why
A user may quickly send a corrected or supplemental submit after noticing a typo. The old submit should not continue judging or scoring, but its text should remain visible so the new submit can refer to it.

## Validation
- uv run python -m pytest tests/test_commands.py
- uv run python -m pytest
- git diff --check