### PR TITLE
Reject concurrent newproblem requests as busy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,7 +234,7 @@ No repository-local runtime queue is used.
 | `/scoreboard` | stubs.py | `handle_scoreboard` | ❌ | — | Cumulative weighted leaderboard; shows the formula at the top, then refreshes latest group nicknames at display time |
 | `/help` | help.py | `handle` | ❌ | — | Auto-generated help (forward card) |
 | `/review` (`/rv`) | review.py | `handle` | ✅ state scheduler | per-provider `review_model` | Discuss the latest solved problem by default; quoted problem cards can target older problems |
-| `/status` | stubs.py | `handle_status` | ❌ | — | Check whether this group has active stateful work |
+| `/status` | stubs.py | `handle_status` | ❌ | — | Check whether this group has active `/newproblem`/daily post or stateful work |
 
 ### Stateful Command Runtime
 
@@ -280,10 +280,16 @@ Key rules:
   without changing `state.json`. Until the new card is successfully delivered, all
   commands still see the old problem. Failed delivery leaves the old current problem
   intact.
+- **New problem serialization/status**: `/newproblem`, `/newproblem --force`, and
+  scheduler `daily_post` share a per-group post lock. User-triggered new-problem
+  commands are rejected immediately with a busy reminder while another new problem is
+  being prepared. `/status` reports this post work as busy while the lock holder is
+  building/sending the card.
 
-`submit.py` exports status helpers used by `/status`:
+Status helpers used by `/status`:
 
 - `get_group_lock_status(group_id)` — earliest active stateful request for that group, if any
+- `get_newproblem_status(group_id)` — active `/newproblem`/daily post for that group, if any
 
 ### `/clear` — Clear current-problem user context
 
@@ -444,10 +450,13 @@ newer AC can silently retarget an older review request.
 - Plain `/problem` (or `/pb`) still resends the current problem card.
 
 `/newproblem` and scheduler `daily_post` share the same locked post implementation.
-The command path takes the per-group post lock before checking/updating cooldown, so
-concurrent force requests cannot pass cooldown admission and then post one after
-another. The scheduler path enters via `do_daily_post(group_id, prefix)`, which wraps
-the same locked implementation:
+The command path first checks the per-group post lock. If another `/newproblem` or
+`daily_post` is already preparing a card, the user gets a short "新的题目正在准备中，别急～"
+reply and the request is not queued. Otherwise the command holds the lock while checking
+cooldown, checking whether plain `/newproblem` is allowed, and building/sending the card.
+Cooldown starts only after a new problem card is successfully delivered and committed.
+The scheduler path enters via `do_daily_post(group_id, prefix)`, which waits on the same
+lock and wraps the same locked implementation:
 1. Reveal yesterday's problem via `picker.py reveal`
 2. Pick a candidate problem via `picker.py pick-json --with-statement`; this marks used
    problems and caches statements but does **not** write `state.json`

--- a/src/kouhai_bot/handlers/cmd/newproblem.py
+++ b/src/kouhai_bot/handlers/cmd/newproblem.py
@@ -45,6 +45,7 @@ logger = logging.getLogger("kouhai-bot.cmd.newproblem")
 
 _cooldowns: dict[int, float] = {}
 _newproblem_locks: dict[int, asyncio.Lock] = {}
+_newproblem_active: dict[int, dict] = {}
 
 
 def _has_unsolved_problem(group_id: int) -> bool:
@@ -63,11 +64,20 @@ async def enqueue_force_new_problem(
     message_id: str,
     *,
     command: str,
+    force: bool = True,
 ) -> None:
     """Pick and post a new problem (shared by /newproblem and /newproblem --force)."""
     cfg = get_config()
     nickname = _nickname(sender)
-    async with _newproblem_lock(group_id):
+    lock = _newproblem_lock(group_id)
+    if lock.locked():
+        await send_group_msg(group_id, build_plain_message(
+            f"@{nickname} 新的题目正在准备中，别急～"
+        ))
+        return
+
+    await lock.acquire()
+    try:
         now = time.monotonic()
         last = _cooldowns.get(group_id, 0)
         if now - last < cfg.newproblem_cooldown:
@@ -77,10 +87,35 @@ async def enqueue_force_new_problem(
             ))
             return
 
-        _cooldowns[group_id] = now
+        if not force and _has_unsolved_problem(group_id):
+            await send_group_msg(group_id, build_plain_message(
+                f"@{nickname} 当前题目还没有人解出来呢～不能直接刷题哦。\n"
+                f"可使用 /problem 查看当前题目。\n"
+                f"如果确定要换题，请发 /newproblem --force"
+            ))
+            return
+
         logger.info(f"[group_{group_id}] {command} triggered")
 
-        await _do_daily_post_locked(group_id, prefix="刷新了一道新题🌟", notify_group=True)
+        _newproblem_active[group_id] = {
+            "group_id": group_id,
+            "user_id": user_id,
+            "message_id": message_id,
+            "command": command,
+            "admitted_at": now,
+        }
+        try:
+            posted = await _do_daily_post_locked(
+                group_id,
+                prefix="刷新了一道新题🌟",
+                notify_group=True,
+            )
+        finally:
+            _newproblem_active.pop(group_id, None)
+        if posted:
+            _cooldowns[group_id] = time.monotonic()
+    finally:
+        lock.release()
 
 # ── Picker path ─────────────────────────────────────────────────────────
 
@@ -151,6 +186,10 @@ def _newproblem_lock(group_id: int) -> asyncio.Lock:
         lock = asyncio.Lock()
         _newproblem_locks[group_id] = lock
     return lock
+
+
+def get_newproblem_status(group_id: int) -> dict | None:
+    return _newproblem_active.get(group_id)
 
 
 async def _commit_problem_state(group_id: int, state: dict) -> None:
@@ -305,12 +344,22 @@ async def do_daily_post(group_id: int, prefix: str | None = None) -> None:
     This is the core logic shared between /newproblem and the daily cron.
     """
     async with _newproblem_lock(group_id):
-        await _do_daily_post_locked(group_id, prefix)
+        _newproblem_active[group_id] = {
+            "group_id": group_id,
+            "user_id": 0,
+            "message_id": "",
+            "command": "daily_post",
+            "admitted_at": time.monotonic(),
+        }
+        try:
+            await _do_daily_post_locked(group_id, prefix)
+        finally:
+            _newproblem_active.pop(group_id, None)
 
 
 async def _do_daily_post_locked(
     group_id: int, prefix: str | None = None, *, notify_group: bool = False,
-) -> None:
+) -> bool:
     cfg = get_config()
     python = sys.executable
     state_dir = os.path.join(cfg.data_dir, "groups", str(group_id))
@@ -371,7 +420,7 @@ async def _do_daily_post_locked(
             await send_group_msg(group_id, build_plain_message(
                 f"刷题失败了…{pick_error_msg}，连试 3 次都没成功，等一会儿再试试吧😢"
             ))
-        return
+        return False
 
     # Step 3: Generate Chinese summary
     desc = ""
@@ -435,9 +484,10 @@ async def _do_daily_post_locked(
             await _commit_problem_state(group_id, picked_state)
             append_group_ctx(group_id, {"role": "assistant", "content": post_msg})
             logger.info(f"[group_{group_id}] Daily post sent (fallback) ✓")
+            return True
         else:
             logger.error(f"[group_{group_id}] Daily post send failed")
-        return
+        return False
     append_group_ctx(group_id, {"role": "assistant", "content": post_msg})
     logger.info(
         f"[group_{group_id}] Daily post forwarded ✓ "
@@ -462,6 +512,7 @@ async def _do_daily_post_locked(
             json.dump(daily_msg, f, ensure_ascii=False, indent=2)
     except Exception as e:
         logger.warning(f"[group_{group_id}] Failed to save daily_msg.json: {e}")
+    return True
 
 
 # ── Command handler ─────────────────────────────────────────────────────
@@ -485,16 +536,8 @@ async def handle(group_id: int, user_id: int, sender: dict,
         return
 
     if text == _CMD_NEWPROBLEM:
-        if _has_unsolved_problem(group_id):
-            nickname = _nickname(sender)
-            await send_group_msg(group_id, build_plain_message(
-                f"@{nickname} 当前题目还没有人解出来呢～不能直接刷题哦。\n"
-                f"可使用 /problem 查看当前题目。\n"
-                f"如果确定要换题，请发 /newproblem --force"
-            ))
-            return
         await enqueue_force_new_problem(
-            group_id, user_id, sender, message_id, command="newproblem",
+            group_id, user_id, sender, message_id, command="newproblem", force=False,
         )
         return
 
@@ -519,5 +562,5 @@ def register() -> None:
         description="刷一道新题（未解须 --force；冷却见配置）",
         usage="[--force]",
         handler=handle,
-        cooldown=300,
+        cooldown=0,
     ))

--- a/src/kouhai_bot/handlers/cmd/stubs.py
+++ b/src/kouhai_bot/handlers/cmd/stubs.py
@@ -211,10 +211,11 @@ async def handle_status(group_id: int, user_id: int, sender: dict,
                         message_id: str, raw_text: str, segments: list,
                         event: dict) -> None:
     """Show bot's current busy/idle status."""
+    from .newproblem import get_newproblem_status
     from .submit import get_group_lock_status
     from ...napcat.client import build_plain_message, build_reply, send_group_msg
 
-    status = get_group_lock_status(group_id)
+    status = get_newproblem_status(group_id) or get_group_lock_status(group_id)
     if status is None:
         await send_group_msg(group_id, build_plain_message("🟢 bot 当前空闲，没有在处理请求～"))
         return

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1976,6 +1976,7 @@ def test_newproblem_cooldown():
 
         async def _mock_post(gid, prefix=None, **_):
             ran.append(gid)
+            return True
 
         with patch("kouhai_bot.handlers.cmd.newproblem._do_daily_post_locked", _mock_post):
             ev = _kwargs(_make_event("/newproblem"))
@@ -1987,19 +1988,26 @@ def test_newproblem_cooldown():
     print("✅ newproblem: cooldown")
 
 
-def test_newproblem_cooldown_serializes_concurrent_force():
+def test_newproblem_busy_rejects_concurrent_force():
     _reset_state()
     _setup_problem()
     _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
     with _all_patches():
-        from kouhai_bot.handlers.cmd.newproblem import handle, _cooldowns, _newproblem_locks
+        from kouhai_bot.handlers.cmd.newproblem import (
+            handle,
+            _cooldowns,
+            _newproblem_active,
+            _newproblem_locks,
+        )
         _cooldowns.clear()
+        _newproblem_active.clear()
         _newproblem_locks.clear()
         ran: list[int] = []
 
         async def _mock_post(gid, prefix=None, **_):
             ran.append(gid)
             await asyncio.sleep(0.05)
+            return True
 
         async def _run():
             ev = _kwargs(_make_event("/newproblem --force"))
@@ -2008,9 +2016,9 @@ def test_newproblem_cooldown_serializes_concurrent_force():
         with patch("kouhai_bot.handlers.cmd.newproblem._do_daily_post_locked", _mock_post):
             asyncio.run(_run())
     assert ran == [GID], f"Concurrent force should post once: {ran}"
-    assert "太频繁" in _last_text(), f"No cooldown rejection: {_last_text()}"
+    assert "正在准备中" in _last_text(), f"No busy rejection: {_last_text()}"
     _cleanup()
-    print("✅ newproblem --force: concurrent cooldown")
+    print("✅ newproblem --force: concurrent busy rejection")
 
 
 def test_newproblem_unsolved_rejects():
@@ -2024,6 +2032,7 @@ def test_newproblem_unsolved_rejects():
 
         async def _mock_post(gid, prefix=None, **_):
             ran.append(gid)
+            return True
 
         with patch("kouhai_bot.handlers.cmd.newproblem._do_daily_post_locked", _mock_post):
             asyncio.run(handle(**_kwargs(_make_event("/newproblem"))))
@@ -2045,6 +2054,7 @@ def test_newproblem_force_posts_when_unsolved():
 
         async def _mock_post(gid, prefix=None, **_):
             ran.append(gid)
+            return True
 
         with patch("kouhai_bot.handlers.cmd.newproblem._do_daily_post_locked", _mock_post):
             asyncio.run(handle(**_kwargs(_make_event("/newproblem --force"))))
@@ -2067,6 +2077,7 @@ def test_newproblem_alias_force_posts_when_unsolved():
 
         async def _mock_post(gid, prefix=None, **_):
             ran.append(gid)
+            return True
 
         with patch("kouhai_bot.handlers.cmd.newproblem._do_daily_post_locked", _mock_post):
             asyncio.run(process_event(_make_event("/np --force"), spawn_handlers=False))
@@ -2086,6 +2097,7 @@ def test_newproblem_force_requires_space():
 
         async def _mock_post(gid, prefix=None, **_):
             ran.append(gid)
+            return True
 
         with patch("kouhai_bot.handlers.cmd.newproblem._do_daily_post_locked", _mock_post):
             asyncio.run(handle(**_kwargs(_make_event("/newproblem--force"))))
@@ -2110,6 +2122,7 @@ def test_newproblem_solved_posts():
 
         async def _mock_post(gid, prefix=None, **_):
             ran.append(gid)
+            return True
 
         with patch("kouhai_bot.handlers.cmd.newproblem._do_daily_post_locked", _mock_post):
             asyncio.run(handle(**_kwargs(_make_event("/newproblem"))))
@@ -2313,6 +2326,60 @@ def test_status_ignores_other_groups_and_reports_idle():
     assert "当前空闲" in _last_text(), f"Expected idle status, got: {_last_text()}"
     _cleanup()
     print("✅ status: only considers current group")
+
+
+def test_status_reports_newproblem_busy():
+    _reset_state()
+    _setup_problem()
+    _write_scoreboard(GID, {
+        "solves": [{"user_id": UID, "nickname": "Alice", "date": "2026-05-14",
+                    "problem": PID, "order": 1}],
+        "user_submissions": {},
+    })
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _mock_post(gid, prefix=None, **_):
+        started.set()
+        await release.wait()
+        return True
+
+    async def _run():
+        with _all_patches(), \
+                patch("kouhai_bot.handlers.cmd.submit.get_group_lock_status", return_value=None), \
+                patch("kouhai_bot.handlers.cmd.newproblem._do_daily_post_locked", _mock_post):
+            from kouhai_bot.handlers.cmd.newproblem import (
+                handle as newproblem_handle,
+                _cooldowns,
+                _newproblem_active,
+                _newproblem_locks,
+            )
+            from kouhai_bot.handlers.cmd.stubs import handle_status
+            _cooldowns.clear()
+            _newproblem_active.clear()
+            _newproblem_locks.clear()
+            task = asyncio.create_task(newproblem_handle(**_kwargs(_make_event(
+                "/newproblem", message_id="np_busy"
+            ))))
+            await asyncio.wait_for(started.wait(), timeout=1.0)
+            await handle_status(**_kwargs(_make_event("/status", message_id="status_busy")))
+            release.set()
+            await asyncio.wait_for(task, timeout=1.0)
+
+    asyncio.run(_run())
+
+    assert any(
+        "newproblem" in (
+            " ".join(
+                seg.get("data", {}).get("text", "")
+                for seg in item.get("message", [])
+                if seg.get("type") == "text"
+            )
+        )
+        for item in _sent
+    ), f"Expected status to report newproblem busy: {_sent}"
+    _cleanup()
+    print("✅ status: reports newproblem busy")
 
 
 def test_submit_parallel_replies_follow_completion_order():
@@ -2992,7 +3059,7 @@ if __name__ == "__main__":
     test_scoreboard_splits_default_and_starred_groups()
     test_help_shows_short_aliases_and_configured_newproblem_cooldown()
     test_newproblem_cooldown()
-    test_newproblem_cooldown_serializes_concurrent_force()
+    test_newproblem_busy_rejects_concurrent_force()
     test_newproblem_unsolved_rejects()
     test_newproblem_force_posts_when_unsolved()
     test_newproblem_alias_force_posts_when_unsolved()
@@ -3000,6 +3067,7 @@ if __name__ == "__main__":
     test_newproblem_solved_posts()
     test_do_daily_post_does_not_switch_state_when_send_fails()
     test_status_ignores_other_groups_and_reports_idle()
+    test_status_reports_newproblem_busy()
     test_submit_parallel_replies_follow_completion_order()
     test_submit_parallel_late_wrong_results_are_reused_after_first_solve()
     test_submit_parallel_late_correct_result_does_not_update_scoreboard_twice()


### PR DESCRIPTION
## Summary
- reject user-triggered /newproblem requests immediately while another new problem is being prepared
- include active newproblem/daily_post work in /status
- start /newproblem cooldown only after successful card delivery and state commit
- update AGENTS.md and command tests for the new busy behavior

## Tests
- uv run python -m pytest tests/test_commands.py
- uv run python -m pytest