### PR TITLE
Persist superseded submit context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,12 +253,14 @@ Key rules:
 - **Parallel compute**: expensive LLM work for `/submit`, `/clarify`, and `/review`
   starts immediately and shares a **global concurrency limit of 8**. Same-user requests
   do not wait for earlier LLM calls to finish.
-- **Pending context**: when a request is admitted, its user input is registered in
-  in-memory pending context keyed by `(group, user, pid)`. Later same-user requests
-  include earlier pending user inputs plus completed `user_submissions`; pending records
-  are not persisted and have no fabricated bot reply. Superseded unanswered `/submit`
-  requests remain visible here with `result="superseded"`, even though their judge work
-  is dropped.
+- **Pending archive context**: when a `/submit`, `/clarify`, or `/review` request is
+  admitted for a target problem, its user input is saved immediately to
+  `scoreboard.json.user_submissions` with `result="pending"` and a `request_id`. Later
+  same-user requests load these pending records plus completed history; the current
+  request's own pending record is excluded by `request_id`. Final handling updates that
+  same record in place. Superseded unanswered `/submit`, timeout, and service-failure
+  records therefore remain historical context across restarts with empty
+  `reason`/`reply`.
 - **Short state critical sections**: JSON read/modify/write endpoints are protected by
   the per-group scheduler async lock. LLM calls never hold this lock.
 - **Submit first-blood serialization only**: incorrect/off-topic/failure replies are
@@ -273,9 +275,11 @@ Key rules:
   older submit is silently dropped, its local compute task is cancelled, and its command
   event logs `status="stale"`. The 👀/[睁眼] ack does not count as a terminal reply.
   This optimization applies only to older `/submit` requests in that exact same-user,
-  same-problem scenario. The older submit's text remains as `result="superseded"`
-  context so a quick correction or addendum can refer to it, and the received `/submit`
-  still counts as a submit attempt in daily achievements.
+  same-problem scenario. When superseded by another `/submit`, the older submit's
+  persisted pending record is updated to `result="superseded"` so a quick correction or
+  addendum can refer to it after a restart, and the received `/submit` still counts as a
+  submit attempt in daily achievements. When superseded by `/clear`, it is removed with
+  the rest of that user's current-problem context.
 - **New problem visibility**: `/newproblem` / `daily_post` pick and summarize a candidate
   without changing `state.json`. Until the new card is successfully delivered, all
   commands still see the old problem. Failed delivery leaves the old current problem
@@ -296,7 +300,7 @@ Status helpers used by `/status`:
 - Targets the caller's stored `user_submissions` records for the **current problem only**
 - Removes that user's saved `/submit`, `/clarify`, and `/review` history for today's pid
 - Runs through the state scheduler and records a clear watermark so earlier in-flight
-  pending context for that user/problem is discarded instead of being written after clear
+  requests for that user/problem cannot write history after clear
 - On success it reacts to the triggering message with the typed `👌` emoji payload
   (`type=2`, `id=128076`) and sends no extra text
 
@@ -372,8 +376,9 @@ achievement reports.
    enqueue
 4. If not blocked, get a sequence number and enqueue the snapshotted pid/solved state
 5. Background compute starts immediately; it loads completed user history plus earlier
-   pending user inputs for the same `(group, user, pid)`, including superseded
-   unanswered `/submit` text as `result="superseded"` context
+   pending user inputs for the same `(group, user, pid)`. The current request's own
+   pending archive record is excluded by `request_id`; superseded unanswered `/submit`
+   text is visible as `result="superseded"` context.
 6. If `SUBMIT_AC_BACKDOOR` is non-empty and the submission contains that string, return a correct verdict before calling the judge LLM
 7. Otherwise load user history, react with 👀/[睁眼] ack, and call `judge_submission()`
    `[睁眼]` is a QQ special emoji reaction (emoji id), not plain message text.
@@ -643,7 +648,7 @@ exactly for backward compatibility with existing `~/.daily-problem` data.
 ### 1. Stateful scheduler state must be truly shared
 All submit/clarify/review/clear entry points in a group must use the SAME scheduler
 state for that group. Do not add an ad hoc lock or side path for one command, or
-pending context, clear watermarks, and first-blood resolution will diverge.
+pending archive updates, clear watermarks, and first-blood resolution will diverge.
 
 ### 2. Judge user_msg format is JSON
 `judge_submission()` sends `json.dumps({"problem": ..., "submission": ..., "history": ...})`.
@@ -672,8 +677,9 @@ silently fails.
 Must pass `json.dump(sb, f, ensure_ascii=False, indent=2)` for backward compatibility
 with old scoreboard files.
 
-### 9. save_user_submission trims to 20
-Per-user submission history is capped at 20 entries to prevent unbounded growth.
+### 9. save_user_submission keeps full history
+Per-user submission history is intentionally unbounded. Records with a `request_id`
+update the matching existing record in place; records without one append normally.
 
 ### 10. Save Chinese summaries by pid if you need later reuse
 The summary shown in the group post is now persisted in `groups/<gid>/problem_summaries.json`.
@@ -917,7 +923,7 @@ When making changes, verify against old bridge.py:
 6. **Contest**: @all notification, 2s delay
 7. **Dispatch**: create_task (not await), skip own messages, extract_text with @mentions
 8. **WS**: bind 0.0.0.0 for Docker, max_size=2**26, ping_interval=30, ping_timeout=10
-9. **Trimming**: save_user_submission trims to 20, save_scoreboard indent=2
+9. **History persistence**: save_user_submission does not trim; records with request_id upsert
 10. **Nickname fallback**: `card or nick or str(user_id)` — never "群友"
 11. **Status visibility**: new stateful commands MUST publish active request metadata
     so `/status` still reports in-flight work correctly

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -193,16 +193,6 @@ class PendingRequest:
         }
 
 
-@dataclass
-class PendingContext:
-    seq: int
-    kind: str
-    content: str
-    problem: str
-    timestamp: str
-    result: str = "pending"
-
-
 def _refresh_runtime() -> None:
     global _runtime_loop, _compute_sem, _coordinators
     try:
@@ -344,16 +334,36 @@ def _unique_user_ids(user_ids: list[int] | None) -> list[int]:
     return result
 
 
-def _pending_context_record(item: PendingContext) -> dict:
-    return {
-        "timestamp": item.timestamp,
-        "type": item.kind,
-        "content": item.content,
-        "result": item.result,
-        "reason": "",
-        "reply": "",
-        "problem": item.problem,
+def _request_id(req: PendingRequest) -> str:
+    request_id = str((req.event_log or {}).get("request_id", "") or "")
+    if request_id:
+        return request_id
+    if req.seq:
+        return f"local-{req.group_id}-{req.user_id}-{req.command}-{req.message_id}-{req.seq}"
+    return ""
+
+
+def _context_record(
+    req: PendingRequest,
+    *,
+    result: str = "pending",
+    reason: str = "",
+    reply: str = "",
+    problem: str = "",
+) -> dict:
+    record = {
+        "timestamp": req.admitted_wall.isoformat(),
+        "type": req.kind,
+        "content": req.payload,
+        "result": result,
+        "reason": reason,
+        "reply": reply,
+        "problem": problem or req.target_pid,
     }
+    request_id = _request_id(req)
+    if request_id:
+        record["request_id"] = request_id
+    return record
 
 
 def _is_problem_solved_in_scoreboard(group_id: int, pid: str) -> bool:
@@ -465,7 +475,6 @@ class GroupCoordinator:
         self.group_id = group_id
         self.lock = asyncio.Lock()
         self.active: dict[int, PendingRequest] = {}
-        self.pending_context: dict[tuple[int, int, str], list[PendingContext]] = {}
         self.clear_watermarks: dict[tuple[int, int, str], int] = {}
         self.submit_candidates: dict[str, list[PendingRequest]] = {}
         self.scoring_pids: set[str] = set()
@@ -477,16 +486,11 @@ class GroupCoordinator:
         self.active[req.seq] = req
         resolve_pids = self._discard_superseded_submits_locked(req)
         if req.kind in _USER_CONTEXT_WRITERS and req.target_pid:
-            self.pending_context.setdefault(
-                (req.group_id, req.user_id, req.target_pid),
-                [],
-            ).append(PendingContext(
-                seq=req.seq,
-                kind=req.kind,
-                content=req.payload,
-                problem=req.target_pid,
-                timestamp=req.admitted_wall.isoformat(),
-            ))
+            save_user_submission(
+                req.group_id,
+                req.user_id,
+                _context_record(req, problem=req.target_pid),
+            )
         if req.submit_score_candidate and req.submit_pid:
             self.submit_candidates.setdefault(req.submit_pid, []).append(req)
         req.task = asyncio.create_task(
@@ -524,41 +528,8 @@ class GroupCoordinator:
             extra=extra,
         )
 
-    def _remove_pending_context_locked(self, req: PendingRequest) -> None:
-        if req.kind not in _USER_CONTEXT_WRITERS or not req.target_pid:
-            return
-        key = (req.group_id, req.user_id, req.target_pid)
-        items = self.pending_context.get(key)
-        if not items:
-            return
-        kept = [item for item in items if item.seq != req.seq]
-        if kept:
-            self.pending_context[key] = kept
-        else:
-            self.pending_context.pop(key, None)
-
-    def _mark_pending_context_result_locked(
-        self,
-        req: PendingRequest,
-        result: str,
-    ) -> None:
-        if req.kind not in _USER_CONTEXT_WRITERS or not req.target_pid:
-            return
-        key = (req.group_id, req.user_id, req.target_pid)
-        for item in self.pending_context.get(key, []):
-            if item.seq == req.seq:
-                item.result = result
-                return
-
-    def _finish_request_locked(
-        self,
-        req: PendingRequest,
-        *,
-        keep_pending_context: bool = False,
-    ) -> str:
+    def _finish_request_locked(self, req: PendingRequest) -> str:
         self.active.pop(req.seq, None)
-        if not keep_pending_context:
-            self._remove_pending_context_locked(req)
         pid = (req.compute_result or {}).get("pid", "") or req.submit_pid
         if pid:
             candidates = self.submit_candidates.get(pid)
@@ -588,9 +559,14 @@ class GroupCoordinator:
 
             old.discarded = True
             old.compute_result = {"kind": "discarded", "pid": old.submit_pid}
-            self._mark_pending_context_result_locked(old, "superseded")
+            if req.kind == "submit":
+                save_user_submission(
+                    old.group_id,
+                    old.user_id,
+                    _context_record(old, result="superseded", problem=old.submit_pid),
+                )
             self._log_finished(old, "stale", problem=old.submit_pid)
-            resolved_pids.add(self._finish_request_locked(old, keep_pending_context=True))
+            resolved_pids.add(self._finish_request_locked(old))
             if old.task and not old.task.done():
                 old.task.cancel()
         return {pid for pid in resolved_pids if pid}
@@ -607,24 +583,19 @@ class GroupCoordinator:
     ) -> list[dict]:
         target_user_id = req.user_id if user_id is None else user_id
         async with self.lock:
-            history = _load_user_problem_history(req.group_id, target_user_id, pid)
-            key = (req.group_id, target_user_id, pid)
-            watermark = self.clear_watermarks.get(key, 0)
-            pending = [
-                _pending_context_record(item)
-                for item in self.pending_context.get(key, [])
-                if item.seq < req.seq and item.seq > watermark
+            request_id = _request_id(req)
+            history = [
+                item for item in _load_user_problem_history(req.group_id, target_user_id, pid)
+                if not request_id or str(item.get("request_id", "") or "") != request_id
             ]
-        return sorted([*history, *pending], key=lambda item: str(item.get("timestamp", "")))
+        return sorted(history, key=lambda item: str(item.get("timestamp", "")))
 
     async def _save_context_record(self, req: PendingRequest, record: dict) -> bool:
         async with self.lock:
             key = (req.group_id, req.user_id, str(record.get("problem", "") or ""))
             if self.clear_watermarks.get(key, 0) >= req.seq:
-                self._remove_pending_context_locked(req)
                 return False
             save_user_submission(req.group_id, req.user_id, record)
-            self._remove_pending_context_locked(req)
             return True
 
     async def _run_request(self, req: PendingRequest) -> None:
@@ -983,6 +954,10 @@ class GroupCoordinator:
             ))
             req.submit_judge_done = True
             req.submit_correct = False
+            await self._save_context_record(
+                req,
+                _context_record(req, result="no_statement", problem=result.get("pid", "")),
+            )
             await self._resolve_submit_scores(pid=result.get("pid", ""))
             await self._finish_request(req)
             return
@@ -992,6 +967,10 @@ class GroupCoordinator:
             await self._send_llm_failure(req)
             req.submit_judge_done = True
             req.submit_correct = False
+            await self._save_context_record(
+                req,
+                _context_record(req, result=status, problem=result.get("pid", "")),
+            )
             await self._resolve_submit_scores(pid=result.get("pid", ""))
             await self._finish_request(req)
             return
@@ -1013,17 +992,16 @@ class GroupCoordinator:
             await self._finish_request(req)
             return
 
-        record = {
-            "timestamp": req.admitted_wall.isoformat(),
-            "type": "submit",
-            "content": req.payload,
-            "result": "correct" if correct else "incorrect",
-            "reason": reason,
-            "reply": reply,
-            "problem": pid,
-        }
-
-        await self._save_context_record(req, record)
+        await self._save_context_record(
+            req,
+            _context_record(
+                req,
+                result="correct" if correct else "incorrect",
+                reason=reason,
+                reply=reply,
+                problem=pid,
+            ),
+        )
         req.submit_judge_done = True
         req.submit_correct = bool(correct)
 
@@ -1095,12 +1073,20 @@ class GroupCoordinator:
             await send_group_msg(req.group_id, build_plain_message(
                 f"@{req.nickname} 抱歉，题面缓存不可用～"
             ))
+            await self._save_context_record(
+                req,
+                _context_record(req, result="no_statement", problem=result.get("pid", "")),
+            )
             await self._finish_request(req)
             return
         if kind in {"timeout", "service_unavailable", "cancelled", "error", "unavailable"}:
             status = "timeout" if kind == "timeout" else "service_unavailable"
             self._log_finished(req, status, problem=result.get("pid", ""))
             await self._send_llm_failure(req)
+            await self._save_context_record(
+                req,
+                _context_record(req, result=status, problem=result.get("pid", "")),
+            )
             await self._finish_request(req)
             return
 
@@ -1116,6 +1102,10 @@ class GroupCoordinator:
         if not reply:
             self._log_finished(req, "service_unavailable", problem=pid)
             await self._send_llm_failure(req)
+            await self._save_context_record(
+                req,
+                _context_record(req, result="service_unavailable", problem=pid),
+            )
             await self._finish_request(req)
             return
 
@@ -1130,16 +1120,10 @@ class GroupCoordinator:
             build_text(f" {reply}"),
         ])
 
-        record = {
-            "timestamp": req.admitted_wall.isoformat(),
-            "type": "clarify",
-            "content": req.payload,
-            "result": "clarify",
-            "reason": "",
-            "reply": reply,
-            "problem": pid,
-        }
-        await self._save_context_record(req, record)
+        await self._save_context_record(
+            req,
+            _context_record(req, result="clarify", reply=reply, problem=pid),
+        )
         self._log_finished(req, "ok", problem=pid)
         await self._finish_request(req)
 
@@ -1159,12 +1143,20 @@ class GroupCoordinator:
             await send_group_msg(req.group_id, build_plain_message(
                 f"@{req.nickname} 抱歉，题面缓存不可用～"
             ))
+            await self._save_context_record(
+                req,
+                _context_record(req, result="no_statement", problem=result.get("pid", "")),
+            )
             await self._finish_request(req)
             return
         if kind in {"timeout", "service_unavailable", "empty", "cancelled", "error"}:
             status = "timeout" if kind == "timeout" else "service_unavailable"
             self._log_finished(req, status, problem=result.get("pid", ""))
             await self._send_llm_failure(req)
+            await self._save_context_record(
+                req,
+                _context_record(req, result=status, problem=result.get("pid", "")),
+            )
             await self._finish_request(req)
             return
 
@@ -1276,16 +1268,10 @@ class GroupCoordinator:
                 build_text(f" {reply}"),
             ])
 
-        record = {
-            "timestamp": req.admitted_wall.isoformat(),
-            "type": "review",
-            "content": req.payload,
-            "result": "review",
-            "reason": "",
-            "reply": reply,
-            "problem": pid,
-        }
-        await self._save_context_record(req, record)
+        await self._save_context_record(
+            req,
+            _context_record(req, result="review", reply=reply, problem=pid),
+        )
         self._log_finished(req, "ok", problem=pid)
         await self._finish_request(req)
 
@@ -1300,12 +1286,6 @@ class GroupCoordinator:
             clear_user_problem_submissions(req.group_id, req.user_id, pid)
             key = (req.group_id, req.user_id, pid)
             self.clear_watermarks[key] = max(self.clear_watermarks.get(key, 0), req.seq)
-            items = self.pending_context.get(key, [])
-            kept = [item for item in items if item.seq > req.seq]
-            if kept:
-                self.pending_context[key] = kept
-            else:
-                self.pending_context.pop(key, None)
         await react_emoji(req.message_id, "128076")
         self._log_finished(req, "ok", problem=pid)
         await self._finish_request(req)

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -638,10 +638,17 @@ def save_user_submission(group_id: int, user_id: int, submission: dict) -> None:
     uid = str(user_id)
     if uid not in submissions:
         submissions[uid] = []
-    submissions[uid].append(submission)
-    # Trim to last 20
-    if len(submissions[uid]) > 20:
-        submissions[uid] = submissions[uid][-20:]
+    request_id = str(submission.get("request_id", "") or "")
+    if request_id:
+        for idx in range(len(submissions[uid]) - 1, -1, -1):
+            existing = submissions[uid][idx]
+            if str(existing.get("request_id", "") or "") == request_id:
+                submissions[uid][idx] = submission
+                break
+        else:
+            submissions[uid].append(submission)
+    else:
+        submissions[uid].append(submission)
     sb["user_submissions"] = submissions
     save_scoreboard(group_id, sb)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -798,8 +798,37 @@ def test_submit_llm_failure_shows_admin_message():
 
     assert "模型服务出故障了，联系一下管理员帮帮忙吧～" in _last_text()
     assert ("msg_001", "268") in _reacted
+    with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
+        saved = json.load(f)
+    records = saved["user_submissions"][str(UID)]
+    assert records[-1]["content"] == "brute force from 1 to A"
+    assert records[-1]["result"] == "service_unavailable"
+    assert records[-1]["reply"] == ""
     _cleanup()
     print("✅ submit: llm failure shows admin message")
+
+
+def test_submit_timeout_is_saved_as_context():
+    _reset_state()
+    _setup_problem()
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
+
+    async def _timeout_judge(problem_text, submission, history=None):
+        return ChatCompletionResult(text=None, failure_kind="timeout")
+
+    with _all_patches(), patch("kouhai_bot.handlers.cmd.submit.judge_submission_result", _timeout_judge):
+        from kouhai_bot.handlers.cmd.submit import handle
+        asyncio.run(handle(**_kwargs(_make_event("/submit maybe too slow"))))
+
+    with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
+        saved = json.load(f)
+    records = saved["user_submissions"][str(UID)]
+    assert records[-1]["content"] == "maybe too slow"
+    assert records[-1]["result"] == "timeout"
+    assert records[-1]["reason"] == ""
+    assert records[-1]["reply"] == ""
+    _cleanup()
+    print("✅ submit: timeout saved as context")
 
 
 def test_submit_ac_backdoor_accepts_before_judge():
@@ -1301,6 +1330,12 @@ def test_review_llm_failure_shows_admin_message():
 
     assert "模型服务出故障了，联系一下管理员帮帮忙吧～" in _last_text()
     assert ("msg_001", "268") in _reacted
+    with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
+        saved = json.load(f)
+    records = saved["user_submissions"][str(UID)]
+    assert records[-1]["type"] == "review"
+    assert records[-1]["result"] == "service_unavailable"
+    assert records[-1]["content"] == "细讲一下这题"
     _cleanup()
     print("✅ review: llm failure shows admin message")
 
@@ -1369,7 +1404,7 @@ def test_review_parallel_same_group():
     print("✅ review: same-group compute runs in parallel")
 
 
-def test_review_same_user_runs_in_parallel_with_pending_context():
+def test_review_same_user_runs_in_parallel_with_pending_archive_context():
     """Two reviews from the same user should not serialize on the earlier LLM call."""
     _reset_state()
     _setup_problem_for(GID, PID2)
@@ -1598,6 +1633,12 @@ def test_clarify_llm_failure_shows_admin_message():
 
     assert "模型服务出故障了，联系一下管理员帮帮忙吧～" in _last_text()
     assert ("msg_001", "268") in _reacted
+    with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
+        saved = json.load(f)
+    records = saved["user_submissions"][str(UID)]
+    assert records[-1]["type"] == "clarify"
+    assert records[-1]["result"] == "service_unavailable"
+    assert records[-1]["content"] == "Joker函数是什么"
     _cleanup()
     print("✅ clarify: llm failure shows admin message")
 
@@ -2604,12 +2645,14 @@ def test_submit_same_user_later_submit_drops_unanswered_previous_submit():
             finally:
                 first_cancelled.set()
         if submission == "second solution":
-            assert any(
+            superseded = [
                 item.get("content") == "first solution"
                 and item.get("result") == "superseded"
                 and item.get("problem") == PID
                 for item in history
-            ), f"Dropped submit should remain visible as superseded context: {history}"
+            ]
+            assert sum(1 for matched in superseded if matched) == 1, \
+                f"Dropped submit should remain visible once as superseded context: {history}"
             return json.dumps({"correct": False, "reason": "R2", "reply": "SECOND"})
         return json.dumps({"correct": False, "reason": "RX", "reply": "OTHER"})
 
@@ -2659,7 +2702,11 @@ def test_submit_same_user_later_submit_drops_unanswered_previous_submit():
     with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
         saved = json.load(f)
     records = saved["user_submissions"].get(str(UID), [])
-    assert [item["content"] for item in records] == ["second solution"], records
+    assert [item["content"] for item in records] == ["first solution", "second solution"], records
+    assert records[0]["result"] == "superseded", records
+    assert records[0]["reason"] == "", records
+    assert records[0]["reply"] == "", records
+    assert records[1]["result"] == "incorrect", records
 
     _cleanup()
     print("✅ submit: later same-user submit drops unanswered previous submit")
@@ -2816,6 +2863,42 @@ def test_review_history_formats_types_and_submit_numbers():
     assert "--- 交互 #3 | type=submit | submit #2 | result=correct ---" in text
     assert "提交 #2 [incorrect]" not in text
     print("✅ review: history format separates interaction and submit numbers")
+
+
+def test_user_submission_history_is_unbounded_and_upserts_by_request_id():
+    _reset_state()
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
+    from kouhai_bot.handlers.shared import load_user_submissions, save_user_submission
+
+    for i in range(25):
+        save_user_submission(GID, UID, {
+            "timestamp": f"2026-05-14T00:00:{i:02d}+08:00",
+            "type": "submit",
+            "content": f"idea {i}",
+            "result": "incorrect",
+            "reason": "",
+            "reply": "",
+            "problem": PID,
+            "request_id": f"req-{i}",
+        })
+    save_user_submission(GID, UID, {
+        "timestamp": "2026-05-14T00:00:03+08:00",
+        "type": "submit",
+        "content": "idea 3 updated",
+        "result": "superseded",
+        "reason": "",
+        "reply": "",
+        "problem": PID,
+        "request_id": "req-3",
+    })
+
+    records = load_user_submissions(GID, UID)
+    assert len(records) == 25, records
+    assert records[0]["content"] == "idea 0", records
+    assert records[3]["content"] == "idea 3 updated", records
+    assert records[3]["result"] == "superseded", records
+    _cleanup()
+    print("✅ history: user submissions are unbounded and upsert by request id")
 
 
 def test_clarify_prompt_hides_original_problem_identity():
@@ -3031,6 +3114,8 @@ def test_submit_user_group_blocked_uses_dynamic_wait():
 if __name__ == "__main__":
     test_submit_correct()
     test_submit_incorrect()
+    test_submit_llm_failure_shows_admin_message()
+    test_submit_timeout_is_saved_as_context()
     test_submit_already_solved()
     test_review_uses_latest_solved_problem()
     test_review_alias_dispatches_to_review_handler()
@@ -3041,7 +3126,7 @@ if __name__ == "__main__":
     test_review_unknown_referenced_card_is_friendly()
     test_review_long_reply_is_chunked_into_one_forward_card()
     test_review_parallel_same_group()
-    test_review_same_user_runs_in_parallel_with_pending_context()
+    test_review_same_user_runs_in_parallel_with_pending_archive_context()
     test_review_after_pending_submit_uses_snapshotted_solved_problem()
     test_submit_off_topic()
     test_submit_operation_not_blocked()
@@ -3075,6 +3160,8 @@ if __name__ == "__main__":
     test_submit_same_user_later_submit_drops_unanswered_previous_submit()
     test_clear_drops_unanswered_same_user_submit()
     test_dropping_unanswered_submit_unblocks_score_resolution()
+    test_review_history_formats_types_and_submit_numbers()
+    test_user_submission_history_is_unbounded_and_upserts_by_request_id()
     test_clarify_prompt_hides_original_problem_identity()
     test_submit_same_user_includes_previous_clarify_history()
     test_submit_parallel_different_groups_do_not_block()


### PR DESCRIPTION
## Summary
- persist same-user same-problem submits superseded by a later /submit as user history
- store superseded records with empty reason/reply so they remain context without creating a bot verdict
- keep /clear semantics unchanged: clearing current-problem context does not preserve superseded pending submit text
- update AGENTS.md and submit replacement tests

## Tests
- uv run python -m pytest tests/test_commands.py -k "drops_unanswered or superseded or pending_context"
- uv run python -m pytest tests/test_commands.py
- uv run python -m pytest