### PR TITLE
Keep problem resend cache in sync after fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,8 +228,8 @@ No repository-local runtime queue is used.
 | `/submit` (`/sbm`) | submit.py | `handle` | ✅ state scheduler | per-provider `judge_model` | Judge solution, save history, serialize only first-blood/scoreboard; configured user-group delay checked before enqueue |
 | `/clarify` (`/clrf`) | clarify.py | `handle` | ✅ state scheduler | per-provider `clarify_model` | Clarify problem details (JSON output, anti-spoiler, no original problem identity), using admission-time pid |
 | `/clear` | clear.py | `handle` | ✅ state scheduler | — | Clear the current user's stored submit/clarify/review history for the admission-time current problem |
-| `/newproblem` (`/np`) | newproblem.py | `handle` | ✅ post lock | per-provider `summary_model` | Force new problem when solved (or none); unsolved needs exact `/newproblem --force`; samples are forwarded as separate nodes; if statement has `notes`, translate+symbol-normalize and append as a dedicated notes node; commits state only after card delivery succeeds |
-| `/problem` (`/pb`) | stubs.py | `handle_problem` | ❌ | — | Resend via forward card (falls back to text); if solved, add a friendly `/newproblem` hint |
+| `/newproblem` (`/np`) | newproblem.py | `handle` | ✅ post lock | per-provider `summary_model` | Force new problem when solved (or none); unsolved needs exact `/newproblem --force`; samples are forwarded as separate nodes; if statement has `notes`, translate+symbol-normalize and append as a dedicated notes node; commits state only after card delivery succeeds and keeps `daily_msg.json` in sync even on direct-text fallback |
+| `/problem` (`/pb`) | stubs.py | `handle_problem` | ❌ | — | Resend current problem via forward card only when `daily_msg.json.pid` matches `state.json.today`; if solved, add a friendly `/newproblem` hint |
 | `/tag` | stubs.py | `handle_tag` | ❌ | — | Show CF tags |
 | `/scoreboard` | stubs.py | `handle_scoreboard` | ❌ | — | Cumulative weighted leaderboard; shows the formula at the top, then refreshes latest group nicknames at display time |
 | `/help` | help.py | `handle` | ❌ | — | Auto-generated help (forward card) |
@@ -472,7 +472,10 @@ lock and wraps the same locked implementation:
    artifacts normalized to readable symbols such as `→`, `≤`, `<`, `>`); then append snake
    image and forward all nodes as one merged card to group
 5. If delivery succeeds, commit `state.json` with `posted_at` and save `daily_msg.json`
-   for `/problem` to resend. If delivery fails, keep the old current problem.
+   for `/problem` to resend. A direct-text fallback after forward-card failure still
+   counts as successful delivery and must save `daily_msg.json` with `pid`, `post_msg`,
+   `sample_messages`, `notes_message`, and `snake_enabled` so `/problem` can rebuild a
+   card later. If delivery fails completely, keep the old current problem.
 6. Save the Chinese summary to `problem_summaries.json` keyed by pid for later reuse
 7. `schedule_prefetch_editorial(pid)` — background editorial translation (not sent yet)
 
@@ -690,7 +693,10 @@ translation. Do not force synchronous translation on detail-page clicks.
 `do_daily_post()` self-sends summary text, sample nodes, optional translated notes node,
 and snake image, then forwards them as one merged card. `daily_msg.json` must persist
 all node references (`msg_id`, `sample_msg_ids`, optional `note_msg_id`, `snake_msg_id`)
-so `/problem` can resend the same card.
+so `/problem` can resend the same card. If merged-forward fails but direct group text
+succeeds, `daily_msg.json` must still persist the current `pid` and rebuild inputs.
+`/problem` must ignore stale `daily_msg.json` whose `pid` does not match
+`state.json.today`.
 Complicated but essential for good UX.
 
 ### 12. Dispatch uses create_task
@@ -904,7 +910,9 @@ selected by the `--group` flag.
   started after 12:00 with no problem. This was intentionally REMOVED — it makes
   workflow unpredictable. Missed is missed; don't auto-recover.
 - **Daily post delivery**: Must use merged-forward (self-send text + snake image →
-  forward card + daily_msg.json). The plain-text simplification was rejected.
+  forward card + daily_msg.json). Plain-text direct send is fallback-only; if it
+  succeeds, it still needs current-problem `daily_msg.json` so `/problem` never resends
+  stale cached cards.
 - **Old bridge.py behavior is the ground truth**: All behavior, message text, data
   formats, and edge cases must match the legacy bridge implementation. When in doubt,
   compare against the old code if it is available in your local environment.

--- a/src/kouhai_bot/handlers/cmd/newproblem.py
+++ b/src/kouhai_bot/handlers/cmd/newproblem.py
@@ -215,6 +215,32 @@ async def _commit_problem_state(group_id: int, state: dict) -> None:
     await run_group_state_update(group_id, _write)
 
 
+def _save_daily_msg(
+    state_dir: str,
+    *,
+    pid: str,
+    post_msg: str,
+    sample_messages: list[str],
+    notes_message: str,
+    snake_enabled: bool,
+    node_payload: dict | None = None,
+    fwd_message_id: int | None = None,
+) -> None:
+    daily_msg = {
+        **(node_payload or {}),
+        "pid": pid,
+        "post_msg": post_msg,
+        "sample_messages": sample_messages,
+        "notes_message": notes_message,
+        "snake_enabled": snake_enabled,
+    }
+    if fwd_message_id is not None:
+        daily_msg["fwd_message_id"] = fwd_message_id
+    daily_msg_path = os.path.join(state_dir, "daily_msg.json")
+    with open(daily_msg_path, "w", encoding="utf-8") as f:
+        json.dump(daily_msg, f, ensure_ascii=False, indent=2)
+
+
 def _load_statement_json(cfg, group_id: int, pid: str) -> dict:
     """Load statement JSON from runtime dir, then fallback dir."""
     candidate_paths = [
@@ -478,10 +504,22 @@ async def _do_daily_post_locked(
         snake_enabled=True,
     )
     if not fwd_resp:
-        logger.error(f"[group_{group_id}] Self-send failed, falling back to direct")
+        logger.error(f"[group_{group_id}] Problem forward-card send failed, falling back to direct")
         ok = await send_group_msg(group_id, build_plain_message(post_msg))
         if ok:
             await _commit_problem_state(group_id, picked_state)
+            try:
+                _save_daily_msg(
+                    state_dir,
+                    pid=pid,
+                    post_msg=post_msg,
+                    sample_messages=sample_messages,
+                    notes_message=notes_message,
+                    snake_enabled=True,
+                    node_payload=node_payload,
+                )
+            except Exception as e:
+                logger.warning(f"[group_{group_id}] Failed to save fallback daily_msg.json: {e}")
             append_group_ctx(group_id, {"role": "assistant", "content": post_msg})
             logger.info(f"[group_{group_id}] Daily post sent (fallback) ✓")
             return True
@@ -498,18 +536,16 @@ async def _do_daily_post_locked(
         save_problem_card_ref(group_id, fwd_resp, pid, "daily_post" if prefix is None else "newproblem")
 
     try:
-        daily_msg_path = os.path.join(state_dir, "daily_msg.json")
-        daily_msg = {
-            **node_payload,
-            "fwd_message_id": fwd_resp,
-            "pid": pid,
-            "post_msg": post_msg,
-            "sample_messages": sample_messages,
-            "notes_message": notes_message,
-            "snake_enabled": True,
-        }
-        with open(daily_msg_path, "w") as f:
-            json.dump(daily_msg, f, ensure_ascii=False, indent=2)
+        _save_daily_msg(
+            state_dir,
+            pid=pid,
+            post_msg=post_msg,
+            sample_messages=sample_messages,
+            notes_message=notes_message,
+            snake_enabled=True,
+            node_payload=node_payload,
+            fwd_message_id=fwd_resp,
+        )
     except Exception as e:
         logger.warning(f"[group_{group_id}] Failed to save daily_msg.json: {e}")
     return True

--- a/src/kouhai_bot/handlers/cmd/stubs.py
+++ b/src/kouhai_bot/handlers/cmd/stubs.py
@@ -57,7 +57,9 @@ async def handle_problem(group_id: int, user_id: int, sender: dict,
     daily_msg_path = os.path.join(state_dir, "daily_msg.json")
     nickname = _nick(sender)
 
-    if not get_today_problem(group_id):
+    current_problem = get_today_problem(group_id)
+    current_pid = str(current_problem.get("today", "") or "") if current_problem else ""
+    if not current_problem:
         await send_group_msg(group_id, build_plain_message(
             f"@{nickname} 暂时不能查看当前题目，可能是暂时还不存在当前题目，试试 /newproblem？"
         ))
@@ -69,6 +71,8 @@ async def handle_problem(group_id: int, user_id: int, sender: dict,
             with open(daily_msg_path) as f:
                 daily_msg = json.load(f)
             pid = str(daily_msg.get("pid", "") or "")
+            if pid != current_pid:
+                raise ValueError(f"stale daily_msg pid={pid}, current={current_pid}")
             msg_id = daily_msg.get("msg_id")
             if msg_id:
                 fwd_nodes = [{"type": "node", "data": {"id": str(msg_id)}}]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1785,6 +1785,27 @@ def test_problem_rebuilds_forward_card_when_node_ids_are_stale():
     print("✅ problem: rebuilds stale forward card")
 
 
+def test_problem_ignores_stale_daily_msg_pid():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _write_group_file(GID, "daily_msg.json", {
+        "msg_id": 1111,
+        "pid": PID2,
+        "post_msg": "旧题正文",
+        "sample_messages": ["旧样例"],
+        "snake_enabled": True,
+    })
+
+    with _all_patches():
+        from kouhai_bot.handlers.cmd.stubs import handle_problem
+        asyncio.run(handle_problem(**_kwargs(_make_event("/problem"))))
+
+    assert not _forwarded, f"Should not resend stale problem card: {_forwarded}"
+    assert "暂时无法重新发送" in _last_text(), f"Expected fallback: {_last_text()}"
+    _cleanup()
+    print("✅ problem: ignores stale daily_msg pid")
+
+
 def test_problem_solved_resend_shows_next_problem_hint():
     _reset_state()
     _setup_problem()
@@ -2288,6 +2309,67 @@ def test_newproblem_notify_group_on_pick_failure():
 
     _cleanup()
     print("✅ newproblem: pick failure notifies group when notify_group=True")
+
+
+def test_newproblem_fallback_direct_saves_daily_msg_for_current_pid():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _setup_problem_for(GID, PID2)
+    _write_state(GID, {"today": PID, "contestId": 542, "index": "D"})
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
+    _write_group_file(GID, "daily_msg.json", {
+        "msg_id": 1111,
+        "pid": PID,
+        "post_msg": "旧题正文",
+        "sample_messages": ["旧样例"],
+        "snake_enabled": True,
+    })
+
+    picked = {
+        "today": PID2,
+        "contestId": 100,
+        "index": "A",
+        "name": "Next",
+        "rating": 2000,
+        "tags": ["dp"],
+    }
+
+    async def _mock_subprocess(*args, **kwargs):
+        cmd_args = args[1:]
+        proc = AsyncMock()
+        if any("reveal" in str(a) for a in cmd_args):
+            proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            return proc
+        if any("pick-json" in str(a) for a in cmd_args):
+            proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(json.dumps(picked).encode(), b""))
+            return proc
+        raise RuntimeError(f"unexpected subprocess: {cmd_args}")
+
+    async def _fail_forward(group_id, messages):
+        return None
+
+    with _all_patches(), \
+            patch("asyncio.create_subprocess_exec", _mock_subprocess), \
+            patch("kouhai_bot.handlers.cmd.newproblem.send_group_forward_msg", _fail_forward), \
+            patch("kouhai_bot.handlers.cmd.newproblem.asyncio.sleep", AsyncMock()):
+        from kouhai_bot.handlers.cmd.newproblem import _do_daily_post_locked
+        posted = asyncio.run(_do_daily_post_locked(GID, prefix="刷新了一道新题🌟", notify_group=True))
+
+    assert posted is True
+    assert _has_sent("刷新了一道新题"), _sent
+    with open(os.path.join(_data_dir(), "groups", str(GID), "state.json")) as f:
+        state = json.load(f)
+    assert state["today"] == PID2
+    with open(os.path.join(_data_dir(), "groups", str(GID), "daily_msg.json")) as f:
+        daily = json.load(f)
+    assert daily["pid"] == PID2, daily
+    assert daily["post_msg"].startswith("刷新了一道新题"), daily
+    assert "sample_messages" in daily
+    assert "fwd_message_id" not in daily
+    _cleanup()
+    print("✅ newproblem: fallback direct saves daily_msg for current pid")
 
 
 def test_submit_scoreboard_update_settles_late_old_problem():
@@ -3136,6 +3218,7 @@ if __name__ == "__main__":
     test_clarify_alias_dispatches_to_clarify_handler()
     test_problem_with_data()
     test_problem_rebuilds_forward_card_when_node_ids_are_stale()
+    test_problem_ignores_stale_daily_msg_pid()
     test_problem_solved_resend_shows_next_problem_hint()
     test_problem_unsolved_resend_does_not_show_next_problem_hint()
     test_problem_alias_dispatches_to_problem_handler()
@@ -3150,6 +3233,7 @@ if __name__ == "__main__":
     test_newproblem_alias_force_posts_when_unsolved()
     test_newproblem_force_requires_space()
     test_newproblem_solved_posts()
+    test_newproblem_fallback_direct_saves_daily_msg_for_current_pid()
     test_do_daily_post_does_not_switch_state_when_send_fails()
     test_status_ignores_other_groups_and_reports_idle()
     test_status_reports_newproblem_busy()


### PR DESCRIPTION
## Summary
- save daily_msg.json even when /newproblem falls back to direct group text after forward-card failure
- prevent /problem from resending stale daily_msg.json when its pid no longer matches state.json today
- improve the fallback log message to identify forward-card failure accurately

## Tests
- uv run python -m pytest tests/test_commands.py -k "problem_ or newproblem_"
- uv run python -m pytest tests/test_commands.py
- uv run python -m pytest