### PR TITLE
[codex] Add private judge workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -869,6 +869,13 @@ problem, the card title should stay generic. Do not include the original problem
 title, contest id, or rating there; anti-spoiler clarification also assumes the bot does
 not reveal the original problem identity to the user.
 
+### 27.5. High-rating problem cards need a caution
+After sending a problem card for a problem with rating greater than 2800, send a short
+follow-up warning that the problem is hard, the bot's reasoning may be limited, and the
+user should check the official/editorial solution if the bot seems wrong. Keep this as
+a separate message after the card, not inside private card titles where source identity
+could leak.
+
 ### 28. Private judge state writes must be atomic
 `private_judge/users/<uid>.json` is user history, not a disposable cache. Write it via a
 same-directory temp file and `os.replace`, and log JSON/IO load failures before falling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,6 +345,10 @@ Private commands do not require @mentions and should not send @ segments back.
   correct after an earlier admitted submit had already solved the same problem; it is
   saved to user history but not counted as a new solve and does not send an extra
   user-visible message.
+- Group `/sync` writes `status="synced"` or `status="correct"` itself on success. Its
+  finished event includes `synced_submit_count`, `synced_clarify_count`,
+  `synced_review_count`, and `synced_correct_count` so private-judge records imported
+  into the group count in daily achievements.
 - Event files are partitioned by the event's real Asia/Shanghai date. Do not store
   04:00 logical-day values in the log; achievement/reporting code should read the
   relevant real-date files and filter by `timestamp`.
@@ -369,12 +373,12 @@ only. The event log still stores real timestamps and real local-date file partit
 
 The built-in scheduler job `daily_achievements` runs at 12:00 and reports:
 
-- earliest/latest `/submit`
-- most solved problems (`/submit` finished with `status="correct"`)
-- most `/submit` attempts (counted from received `/submit` commands, so superseded
-  `status="stale"` submits still count as attempts)
-- most `/review`
-- most `/clarify`
+- earliest/latest `/submit`, including group `/sync` commands that import submit records
+- most solved problems (`/submit status="correct"` plus successful scoring `/sync`)
+- most `/submit` attempts (received `/submit` commands plus submit records imported by
+  `/sync`; superseded `status="stale"` submits still count as attempts)
+- most `/review`, including review records imported by `/sync`
+- most `/clarify`, including clarify records imported by `/sync`
 
 Existing group scheduler configs that already enable `daily_post` are normalized to
 run `daily_achievements` immediately before it. Set
@@ -508,11 +512,14 @@ commands are rejected in private with a friendly message.
   only user-visible content as `👤：...` followed by `🤖：...` on the next line, omitting
   internal type/result/reason fields. If the history is too long for one node, chunk it
   like long `/review` output. If the source is empty, it sends only the friendly abort
-  message.
+  message. On successful group sync, react to the triggering message with `👌`
+  (`id=128076`) instead of sending a generic success message; private sync sends no
+  extra success text.
 - A normal user's private correct submit for the current group problem can score through
   group `/sync` if the group has not already solved that pid. Scoring is performed under
-  the group coordinator lock, schedules the official editorial follow-up, and writes the
-  private records into group `scoreboard.json`.
+  the group coordinator lock, reveals the original problem source, schedules the official
+  editorial follow-up, writes the private records into group `scoreboard.json`, and logs
+  the imported records for daily achievements.
 - Dynamic-wait/starred users redirected to private judge can still `/sync`, but only
   `clarify` records are copied; submit/review/correct records are ignored and never
   score.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -863,6 +863,11 @@ problem, the card title should stay generic. Do not include the original problem
 title, contest id, or rating there; anti-spoiler clarification also assumes the bot does
 not reveal the original problem identity to the user.
 
+### 28. Private judge state writes must be atomic
+`private_judge/users/<uid>.json` is user history, not a disposable cache. Write it via a
+same-directory temp file and `os.replace`, and log JSON/IO load failures before falling
+back to defaults so corruption or permission problems are diagnosable.
+
 ## Testing
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,107 @@ NapCat runs in a Docker container and connects to the host via `host.docker.inte
 (Docker bridge IP: 172.17.0.1). If the bot binds to `127.0.0.1`, Docker containers
 CANNOT connect — they'll get ECONNREFUSED. Always use `0.0.0.0` when NapCat is in Docker.
 
+### NapCat Docker wiring checklist
+
+This bot is a **reverse WebSocket server** plus a **NapCat HTTP API client**:
+
+- `kouhai_bot.napcat.client.NapCatServer` listens on `napcat_ws_host:napcat_ws_port`;
+  NapCat must connect to it through a OneBot11 `websocketClients` entry.
+- Message sending uses `napcat_http_host:napcat_http_port` and calls NapCat OneBot11
+  HTTP actions such as `send_group_msg`, `send_private_msg`, and
+  `get_group_member_info`; NapCat must expose an enabled OneBot11 `httpServers`
+  entry on that port.
+
+When NapCat is deployed with Docker Compose, prefer this pattern:
+
+```yaml
+services:
+  napcat:
+    environment:
+      ACCOUNT: "<bot_qq>"  # enables fast login after the first successful login
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "3000:3000"  # OneBot HTTP API for bot -> NapCat actions
+      - "8095:8095"  # optional NapCat WS server ports for other clients
+      - "8096:8096"
+      - "8097:8097"
+      - "6099:6099"  # WebUI
+```
+
+NapCat OneBot11 config should include both sides:
+
+```json
+{
+  "network": {
+    "httpServers": [
+      {
+        "enable": true,
+        "name": "kouhai-http-api",
+        "host": "0.0.0.0",
+        "port": 3000,
+        "enableCors": true,
+        "enableWebsocket": false,
+        "messagePostFormat": "array",
+        "token": "",
+        "debug": false
+      }
+    ],
+    "websocketClients": [
+      {
+        "enable": true,
+        "name": "kouhai-bot-reverse-ws",
+        "url": "ws://host.docker.internal:<napcat_ws_port>",
+        "messagePostFormat": "array",
+        "reportSelfMessage": false,
+        "reconnectInterval": 5000,
+        "token": "",
+        "debug": false,
+        "heartInterval": 30000
+      }
+    ]
+  }
+}
+```
+
+Avoid using a bot `napcat_ws_port` that is already published by the NapCat container
+as a WebSocket **server** port. If Docker publishes `8095:8095`, `8096:8096`, and
+`8097:8097`, then the bot cannot also listen on host `8097`; `uv run restart` will
+fail with `OSError: [Errno 98] ... address already in use` or
+`Detached bot failed to bind NapCat WS port ...`. Pick a free host port such as
+`8098` for `config.yaml` and point NapCat `websocketClients[].url` at that same port.
+
+Troubleshooting symptoms:
+
+- `getaddrinfo ENOTFOUND host.docker.internal` in NapCat logs means the container
+  cannot resolve the host alias. Add Compose `extra_hosts:
+  ["host.docker.internal:host-gateway"]` and recreate the container.
+- Bot logs show `NapCat connected from ...`, but group replies do not send and
+  `send_group_msg failed: Server disconnected`: reverse WS is working, but NapCat's
+  OneBot HTTP server is missing or not loaded. Enable `httpServers` on
+  `napcat_http_port` and restart NapCat.
+- NapCat asks for a QR code after every restart even after a successful login:
+  set Compose `ACCOUNT: "<bot_qq>"` so the container starts QQ with `-q <bot_qq>`.
+
+Useful checks:
+
+```bash
+uv run status
+tail -n 80 ~/.kouhai-bot/logs/<group_id>/$(TZ=Asia/Shanghai date +%F).log
+docker logs --tail 160 napcat
+docker exec napcat getent hosts host.docker.internal
+curl -sS -X POST http://127.0.0.1:3000/get_status \
+  -H 'Content-Type: application/json' -d '{}'
+```
+
+Healthy state:
+
+- `uv run status` reports `occupied=yes` and `current_worktree_running=yes`.
+- Bot log contains `NapCat connected from ...`.
+- NapCat log contains `HTTP服务: 0.0.0.0:3000` and
+  `WebSocket反向服务: ws://host.docker.internal:<napcat_ws_port>`.
+- `get_status` returns JSON with `"online": true` and `"good": true`.
+
 ### LLM fallback
 
 Providers in `llm.providers` are tried **in list order**. Each provider is retried

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -492,7 +492,9 @@ commands are rejected in private with a friendly message.
   review as available. It sends a private problem card, preferring the current group's
   cached forward-card payload when the pid is the current group problem. Generated
   private cards must not expose the original CF id, title, contest id, or rating in the
-  card title.
+  card title. If an explicit pid/link fails because the statement fetcher detects
+  non-formula images (`tex-graphics` diagrams), tell the user the bot has limited
+  ability on image-dependent statements and suggest choosing another problem.
 - `/problem` in private resends the selected private problem card. `/tag`, `/status`,
   `/clear`, `/submit`, `/clarify`, and `/review` all operate on private state and do
   not emit group @mentions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,9 @@ NapCat (QQ) ──WS──> worker.py
 ## Key Design Decisions
 
 - **Command auto-discovery**: Each command in `handlers/cmd/*.py` calls `register()` at module load. The `registry.discover_commands()` scans with `pkgutil.iter_modules`. Adding a new command = create a `.py` file with a `register()` function.
-- **Limited aliases**: Only five short aliases are supported: `/newproblem`→`/np`, `/problem`→`/pb`, `/submit`→`/sbm`, `/review`→`/rv`, `/clarify`→`/clrf`. Old aliases such as `/sb`, `/排名`, and Chinese aliases remain unsupported. New commands default to `aliases=[]` unless explicitly approved.
+- **Limited aliases**: Only six short aliases are supported: `/newproblem`→`/np`, `/problem`→`/pb`, `/submit`→`/sbm`, `/review`→`/rv`, `/clarify`→`/clrf`, `/setproblem`→`/sp`. Old aliases such as `/sb`, `/排名`, and Chinese aliases remain unsupported. New commands default to `aliases=[]` unless explicitly approved.
 - **Help auto-generation**: `handlers/cmd/help.py` reads `registry.all_commands()` and builds the help text dynamically. Descriptions must match old bridge.py wording.
-  `usage` field = args suffix in /help display (e.g. `usage="你的做法"` → `/submit 你的做法`).
+  `usage` field = args suffix in /help display (e.g. `usage="你的做法"` → `/submit 你的做法`). Group help hides private-only details for `/setproblem` and `/sync` and only briefly mentions private judge; private help lists the private-judge command set.
 - **Scheduler current-group config**: `~/.kouhai-bot/scheduler_config.json` stores job list + time overrides for `CURRENT_GROUP`. Jobs are defined in `scheduler/jobs.py`.
 - **Command event log**: `eventlog.py` writes append-only JSONL command events by real local date. `achievements.py` reads those events for the 04:00-to-04:00 daily report. `eventlog_backfill.py` and `tools/backfill_command_events.py` can reconstruct recent saved submit/clarify/review events from `scoreboard.json`.
 - **Formula VL**: `problems/fetcher.py` handles CF formula images → Qwen-VL → inline LaTeX. Has white-bg preprocessing, hallucination detection, retry.
@@ -31,7 +31,8 @@ NapCat (QQ) ──WS──> worker.py
   configured users' waits halve down to the floor. Runtime wait state lives in
   `scoreboard.json.user_group_waits`; real QQ IDs belong only in local config/runtime data.
   `do_daily_post` writes `state.json` `posted_at`; if missing, cooldown falls back
-  to matching `daily_msg.json` mtime.
+  to matching `daily_msg.json` mtime. Dynamic-wait users who submit before their group
+  wait expires are redirected to private judge instead of being judged in the group.
 - **Curfew (宵禁)**: `curfew.py` — `/submit` is blocked during a daily quiet window defined
   by `CURFEW_START_HOUR` and `CURFEW_DURATION_HOURS`. Other commands (clarify, review,
   scoreboard, etc.) are unaffected. Curfew wraps past midnight correctly (e.g. start=22,
@@ -205,6 +206,7 @@ groups/<gid>/used.json       # used problem IDs
 groups/<gid>/groupctx_*.json # group message context
 groups/<gid>/command_events/YYYY-MM-DD.jsonl # structured command event log by real local date
 groups/<gid>/problem_ratings.json # cached problem rating by pid for weighted scoreboard totals
+private_judge/users/<uid>.json # per-user private judge current problem, history, solved markers, redirect state
 annotations/pending/<gid>/<pid>.json # pending human-label bundle for solved problems
 annotations/labeled/<gid>/<pid>.json # completed human-label bundle for solved problems
 statements/<pid>.json        # cached problem statements
@@ -225,44 +227,52 @@ No repository-local runtime queue is used.
 
 | Command | File | Handler | Lock | Model | Notes |
 |---------|------|---------|------|-------|-------|
-| `/submit` (`/sbm`) | submit.py | `handle` | ✅ state scheduler | per-provider `judge_model` | Judge solution, save history, serialize only first-blood/scoreboard; configured user-group delay checked before enqueue |
-| `/clarify` (`/clrf`) | clarify.py | `handle` | ✅ state scheduler | per-provider `clarify_model` | Clarify problem details (JSON output, anti-spoiler, no original problem identity), using admission-time pid |
-| `/clear` | clear.py | `handle` | ✅ state scheduler | — | Clear the current user's stored submit/clarify/review history for the admission-time current problem |
+| `/submit` (`/sbm`) | submit.py | `handle` | ✅ state scheduler | per-provider `judge_model` | Judge solution, save history, serialize only first-blood/scoreboard; configured dynamic-wait group submits redirect to private judge; private AC does not score until synced |
+| `/clarify` (`/clrf`) | clarify.py | `handle` | ✅ state scheduler | per-provider `clarify_model` | Clarify problem details (JSON output, anti-spoiler, no original problem identity), using admission-time pid; private uses pid-specific summary |
+| `/clear` | clear.py | `handle` | ✅ state scheduler | — | Clear the current user's stored submit/clarify/review history for the admission-time current problem or current private problem |
 | `/newproblem` (`/np`) | newproblem.py | `handle` | ✅ post lock | per-provider `summary_model` | Force new problem when solved (or none); unsolved needs exact `/newproblem --force`; samples are forwarded as separate nodes; if statement has `notes`, translate+symbol-normalize and append as a dedicated notes node; commits state only after card delivery succeeds and keeps `daily_msg.json` in sync even on direct-text fallback |
-| `/problem` (`/pb`) | stubs.py | `handle_problem` | ❌ | — | Resend current problem via forward card only when `daily_msg.json.pid` matches `state.json.today`; if solved, add a friendly `/newproblem` hint |
-| `/tag` | stubs.py | `handle_tag` | ❌ | — | Show CF tags |
+| `/problem` (`/pb`) | stubs.py | `handle_problem` | ❌ | — | Resend current group/private problem via forward card; group path only uses `daily_msg.json` when pid matches `state.json.today`; if solved, add a friendly `/newproblem` hint |
+| `/tag` | stubs.py | `handle_tag` | ❌ | — | Show current group/private problem CF tags |
 | `/scoreboard` | stubs.py | `handle_scoreboard` | ❌ | — | Cumulative weighted leaderboard; shows the formula at the top, then refreshes latest group nicknames at display time |
 | `/help` | help.py | `handle` | ❌ | — | Auto-generated help (forward card) |
-| `/review` (`/rv`) | review.py | `handle` | ✅ state scheduler | per-provider `review_model` | Discuss the latest solved problem by default; quoted problem cards can target older problems |
-| `/status` | stubs.py | `handle_status` | ❌ | — | Check whether this group has active `/newproblem`/daily post or stateful work |
+| `/review` (`/rv`) | review.py | `handle` | ✅ state scheduler | per-provider `review_model` | Discuss the latest solved group/private problem by default; quoted group problem cards can target older problems |
+| `/status` | stubs.py | `handle_status` | ❌ | — | Check whether this group or private judge has active stateful work |
+| `/setproblem` (`/sp`) | setproblem.py | `handle` | ❌ | — | Private-only; set current private problem from current group problem, CF pid/link, or `random` |
+| `/sync` | sync.py | `handle` | ✅ short group state lock for group writes | — | Sync current group problem history between group and private judge; empty source aborts without overwrite |
 
 ### Stateful Command Runtime
 
 Stateful commands (`/submit`, `/clarify`, `/review`, `/clear`) no longer serialize
-through one global lock or one per-group FIFO execution queue. They run through a
-**per-group state scheduler** implemented in `submit.py`; `/newproblem` and
+through one global lock or one per-group FIFO execution queue. Group requests run
+through a **per-group state scheduler** implemented in `submit.py`; private judge
+requests run through a separate **per-user private coordinator**. `/newproblem` and
 `daily_post` use their own per-group post lock and commit current-problem state only
 after delivery.
 
 Key rules:
 
 - **Admission-time snapshots**: every stateful request receives a monotonically
-  increasing per-group sequence and snapshots its target pid at admission. `/submit`,
-  `/clarify`, and `/clear` use the then-current problem; `/review` uses the then-latest
-  solved problem.
+  increasing per-coordinator sequence and snapshots its target pid at admission.
+  Group `/submit`, `/clarify`, and `/clear` use the then-current group problem;
+  private versions use the then-current private problem. Group `/review` uses the
+  then-latest solved group problem; private `/review` uses the current private problem
+  if solved privately or already solved by the group, otherwise the user's latest
+  private solved problem.
 - **Parallel compute**: expensive LLM work for `/submit`, `/clarify`, and `/review`
   starts immediately and shares a **global concurrency limit of 8**. Same-user requests
   do not wait for earlier LLM calls to finish.
 - **Pending archive context**: when a `/submit`, `/clarify`, or `/review` request is
   admitted for a target problem, its user input is saved immediately to
-  `scoreboard.json.user_submissions` with `result="pending"` and a `request_id`. Later
-  same-user requests load these pending records plus completed history; the current
-  request's own pending record is excluded by `request_id`. Final handling updates that
-  same record in place. Superseded unanswered `/submit`, timeout, and service-failure
-  records therefore remain historical context across restarts with empty
-  `reason`/`reply`.
+  group `scoreboard.json.user_submissions` or private
+  `private_judge/users/<uid>.json.user_submissions` with `result="pending"` and a
+  `request_id`. Later same-user requests load these pending records plus completed
+  history; the current request's own pending record is excluded by `request_id`.
+  Final handling updates that same record in place. Superseded unanswered `/submit`,
+  timeout, and service-failure records therefore remain historical context across
+  restarts with empty `reason`/`reply`.
 - **Short state critical sections**: JSON read/modify/write endpoints are protected by
-  the per-group scheduler async lock. LLM calls never hold this lock.
+  the relevant group/private coordinator async lock. LLM calls never hold this lock.
+  `/sync` also uses the group coordinator lock when it writes group `scoreboard.json`.
 - **Submit first-blood serialization only**: incorrect/off-topic/failure replies are
   sent as soon as they finish. Correct submits are saved immediately; if earlier
   admission-order submit candidates are still unresolved, the user first gets a short
@@ -278,8 +288,8 @@ Key rules:
   same-problem scenario. When superseded by another `/submit`, the older submit's
   persisted pending record is updated to `result="superseded"` so a quick correction or
   addendum can refer to it after a restart, and the received `/submit` still counts as a
-  submit attempt in daily achievements. When superseded by `/clear`, it is removed with
-  the rest of that user's current-problem context.
+  submit attempt in daily achievements for group commands. When superseded by `/clear`,
+  it is removed with the rest of that user's current-problem context.
 - **New problem visibility**: `/newproblem` / `daily_post` pick and summarize a candidate
   without changing `state.json`. Until the new card is successfully delivered, all
   commands still see the old problem. Failed delivery leaves the old current problem
@@ -293,6 +303,7 @@ Key rules:
 Status helpers used by `/status`:
 
 - `get_group_lock_status(group_id)` — earliest active stateful request for that group, if any
+- `get_private_lock_status(user_id, group_id)` — earliest active private request for that user, if any
 - `get_newproblem_status(group_id)` — active `/newproblem`/daily post for that group, if any
 
 ### `/clear` — Clear current-problem user context
@@ -301,8 +312,9 @@ Status helpers used by `/status`:
 - Removes that user's saved `/submit`, `/clarify`, and `/review` history for today's pid
 - Runs through the state scheduler and records a clear watermark so earlier in-flight
   requests for that user/problem cannot write history after clear
-- On success it reacts to the triggering message with the typed `👌` emoji payload
-  (`type=2`, `id=128076`) and sends no extra text
+- On group success it reacts to the triggering message with the typed `👌` emoji payload
+  (`type=2`, `id=128076`) and sends no extra text. In private chats it sends the same
+  face instead of a message reaction.
 
 ### Dispatch Pattern
 
@@ -312,16 +324,21 @@ handlers. Tests may pass `spawn_handlers=False` to await a handler directly.
 
 Read-only commands (`/problem`, `/tag`, `/scoreboard`, `/help`, `/status`) still do
 not enter the state scheduler.
+Private dispatch maps DMs to `CURRENT_GROUP`, requires the sender to be a member of that
+service group, and only allows the private command whitelist: `/setproblem`, `/problem`,
+`/tag`, `/submit`, `/clarify`, `/review`, `/clear`, `/sync`, `/status`, and `/help`.
+Private commands do not require @mentions and should not send @ segments back.
 
 ### Command Event Log
 
 `eventlog.py` owns the append-only structured command log under
 `groups/<gid>/command_events/YYYY-MM-DD.jsonl`.
 
-- Dispatch writes a `received` event after a command is recognized.
+- Dispatch writes a `received` event after a group command is recognized. Private
+  commands are not written to group command event logs.
 - Dispatch writes generic `finished` events (`ok` / `error`) for commands that do not
   publish detailed status themselves.
-- `/submit`, `/clarify`, and `/review` carry the same event metadata through the group
+- Group `/submit`, `/clarify`, and `/review` carry the same event metadata through the group
   state scheduler and write detailed final statuses such as `correct`, `incorrect`,
   `post_solve_correct`, `timeout`, `offtopic`, `stale`, `no_problem`, and
   `no_review_problem`. `post_solve_correct` means a concurrent `/submit` was judged
@@ -372,8 +389,11 @@ achievement reports.
 3. Enter the group's state scheduler long enough to atomically check dynamic user-group
    submit wait, snapshot today's pid, and snapshot solved state. If the user is still
    inside the effective wait window (`max(submit_delay_sec, saved wait_sec)` after
-   `posted_at`), reply with that group's delay message plus remaining wait time; do not
-   enqueue
+   `posted_at`) and belongs to a dynamic-wait group, redirect the submit to private
+   judge instead of judging/scoring in the group. If the private intro or repeated
+   submit text cannot be sent, do not recall the group message, do not judge, and do not
+   consume the first-notice marker. Non-dynamic waits still reply with the group's delay
+   message and do not enqueue.
 4. If not blocked, get a sequence number and enqueue the snapshotted pid/solved state
 5. Background compute starts immediately; it loads completed user history plus earlier
    pending user inputs for the same `(group, user, pid)`. The current request's own
@@ -381,7 +401,8 @@ achievement reports.
    text is visible as `result="superseded"` context.
 6. If `SUBMIT_AC_BACKDOOR` is non-empty and the submission contains that string, return a correct verdict before calling the judge LLM
 7. Otherwise load user history, react with 👀/[睁眼] ack, and call `judge_submission()`
-   `[睁眼]` is a QQ special emoji reaction (emoji id), not plain message text.
+   `[睁眼]` is a QQ special emoji reaction (emoji id), not plain message text. In private
+   judge, send face messages instead of group message reactions.
 8. Incorrect/off-topic/failure results finalize immediately when compute finishes
 9. If the problem was already solved when this `/submit` entered the queue: reply
    "已经有人解出..." without calling the judge.
@@ -401,6 +422,12 @@ achievement reports.
     not-counted message and **do not** send the official tutorial again.
 15. If incorrect: reply with judge's reason.
 
+Private `/submit` uses the same judge path and private history, but a correct result
+only marks the problem solved in `private_judge/users/<uid>.json`; it does not update
+the group scoreboard or daily achievements. If the private problem is the current group
+problem, the success message tells the user they can `/sync` in the service group to
+score it if the group has not already solved it.
+
 ### `/clarify` — Anti-Spoiler Clarification
 
 LLM `timeout=600` (10 minutes per HTTP attempt; retries in `shared.py` can extend total wait).
@@ -412,7 +439,9 @@ Timeout comes from `llm.clarify_timeout_sec`. Output:
 - Normal: reply text only, must not leak solution hints
 - Must not reveal the original problem identity, including problem ID, title, or contest ID
 
-Loads **Chinese summary from group context** (last assistant message) for LLM grounding.
+Group `/clarify` loads **Chinese summary from group context** (last assistant message)
+for LLM grounding. Private `/clarify` uses `problem_summaries.json` for the selected
+pid, so a private CF link/random problem is not paired with the current group summary.
 The target pid is snapshotted at admission. Final saving is protected by the state
 scheduler lock, but final reply is not ordered behind unrelated same-group requests.
 
@@ -438,6 +467,47 @@ scheduler lock, but final reply is not ordered behind unrelated same-group reque
   editorial via `format_editorial_for_review()` (truncated to 12k chars). `REVIEW_PROMPT` states
   that this is official editorial **only the model sees** — do not paste it to the user or spoil
   that the group received a tutorial card. Use it to validate the user's approach and explain WAs.
+
+Private `/review` targets the current private problem when it was solved privately or
+the group has solved that same current problem. Otherwise it targets the user's latest
+private solved problem. This lets private review become available automatically after
+someone solves the current group problem, even if the user only set that problem in
+private judge.
+
+### Private Judge
+
+Private judge lives in `private_judge.py` plus `/setproblem` and `/sync` command
+modules. It is available only in DMs from members of `CURRENT_GROUP`; group-only
+commands are rejected in private with a friendly message.
+
+- Private state is per user in `private_judge/users/<uid>.json`: current problem,
+  `user_submissions`, solved markers, latest solved pid, and starred-submit redirect
+  notification markers.
+- Private and group contexts are independent by default. `copy_records()` is used when
+  copying history between sides so later writes do not share dict instances.
+- `/setproblem` (`/sp`) is private-only. Empty args select the current group problem;
+  `CF2234B`, `2234B`, Codeforces problemset/contest links, and `random` are supported.
+  If private history is empty and group history exists for the selected pid, it copies
+  group history into private. If the group has already solved that pid, it marks private
+  review as available. It sends a private problem card, preferring the current group's
+  cached forward-card payload when the pid is the current group problem.
+- `/problem` in private resends the selected private problem card. `/tag`, `/status`,
+  `/clear`, `/submit`, `/clarify`, and `/review` all operate on private state and do
+  not emit group @mentions.
+- `/sync` copies the **current group problem only** between group and private judge.
+  In a group chat it copies private → group; in private it copies group → private.
+  If the source side has no relevant records, it aborts and does not overwrite the
+  target side. It rejects while there is an active group or private stateful request
+  for the same user/problem.
+- `/sync` sends the source history as one forward-card-style history card to the target
+  chat after copying. If the source is empty, it sends only the friendly abort message.
+- A normal user's private correct submit for the current group problem can score through
+  group `/sync` if the group has not already solved that pid. Scoring is performed under
+  the group coordinator lock, schedules the official editorial follow-up, and writes the
+  private records into group `scoreboard.json`.
+- Dynamic-wait/starred users redirected to private judge can still `/sync`, but only
+  `clarify` records are copied; submit/review/correct records are ignored and never
+  score.
 
 ### 8.5. Review parallelism depends on enqueue-time pid snapshot
 If `/review` is meant to compute in parallel with later same-group requests, do not
@@ -581,7 +651,10 @@ Local HTML labeling UI:
 5. If the command mutates group state or appends to submission history, route it through
    the state scheduler helpers in `submit.py`; read/modify/write JSON sections must
    use the same per-group scheduler lock
-6. That's it — auto-discovered, auto-listed in /help
+6. If the command is usable in private chat, add it to the private whitelist in
+   `handlers/__init__.py`, update private `/help` filtering, and avoid group @mentions
+   or message reactions in private replies
+7. That's it — auto-discovered, auto-listed in /help
 
 ## Adding a Scheduled Job
 
@@ -645,6 +718,10 @@ records do not settle waits.
 
 Existing `solves` and submission record fields MUST match the old bridge's format
 exactly for backward compatibility with existing `~/.daily-problem` data.
+Private judge submission records use the same record shape inside
+`private_judge/users/<uid>.json.user_submissions` so group/private history can be copied
+without conversion. Do not add private-only fields to individual history records unless
+all sync paths intentionally preserve or strip them.
 
 ## Pitfalls & Lessons Learned
 
@@ -652,6 +729,8 @@ exactly for backward compatibility with existing `~/.daily-problem` data.
 All submit/clarify/review/clear entry points in a group must use the SAME scheduler
 state for that group. Do not add an ad hoc lock or side path for one command, or
 pending archive updates, clear watermarks, and first-blood resolution will diverge.
+Private judge has separate per-user coordinators; do not route private stateful commands
+through the group coordinator except for the short group write section inside `/sync`.
 
 ### 2. Judge user_msg format is JSON
 `judge_submission()` sends `json.dumps({"problem": ..., "submission": ..., "history": ...})`.
@@ -765,6 +844,16 @@ cache file to force re-translation after updating prompts or rescraping editoria
 `/review` gets English source (+ code in extracted text) for internal grounding.
 The post-AC card gets Chinese translation without code. Do not send Chinese translation
 into review unless product requirements change.
+
+### 25. Private judge sync must not erase on empty source
+`/sync` uses the other side as source and overwrites the current side for the current
+group problem only. If the source side has no records, abort with a friendly message and
+leave the target untouched. This protects users from accidental history loss.
+
+### 26. Private chats use messages, not group affordances
+Private command handlers must not send @ segments or call `react_emoji`. Use plain
+private messages or face segments (`build_face`) instead. Long private review/history
+responses can use private merged-forward cards.
 
 ## Testing
 
@@ -937,3 +1026,6 @@ When making changes, verify against old bridge.py:
     so `/status` still reports in-flight work correctly
 12. **Official tutorial**: first AC only; congrats + separate forward card; translation
     omits code; review uses English editorial in LLM context only, not user-visible spoiler
+13. **Private judge**: private commands are service-group-member only, private history is
+    independent, `/sync` aborts on empty source, and private AC never scores unless a
+    normal user syncs the current group problem back to the group before it is solved

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -502,7 +502,10 @@ commands are rejected in private with a friendly message.
   target side. It rejects while there is an active group or private stateful request
   for the same user/problem.
 - `/sync` sends the source history as one forward-card-style history card to the target
-  chat after copying. If the source is empty, it sends only the friendly abort message.
+  chat after copying. The card title is `<群昵称>在当前的历史记录如下：`; each record shows
+  only user-visible content as `👤：...   🤖：...`, omitting internal type/result/reason
+  fields. If the history is too long for one node, chunk it like long `/review` output.
+  If the source is empty, it sends only the friendly abort message.
 - A normal user's private correct submit for the current group problem can score through
   group `/sync` if the group has not already solved that pid. Scoring is performed under
   the group coordinator lock, schedules the official editorial follow-up, and writes the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -503,9 +503,10 @@ commands are rejected in private with a friendly message.
   for the same user/problem.
 - `/sync` sends the source history as one forward-card-style history card to the target
   chat after copying. The card title is `<群昵称>在当前的历史记录如下：`; each record shows
-  only user-visible content as `👤：...   🤖：...`, omitting internal type/result/reason
-  fields. If the history is too long for one node, chunk it like long `/review` output.
-  If the source is empty, it sends only the friendly abort message.
+  only user-visible content as `👤：...` followed by `🤖：...` on the next line, omitting
+  internal type/result/reason fields. If the history is too long for one node, chunk it
+  like long `/review` output. If the source is empty, it sends only the friendly abort
+  message.
 - A normal user's private correct submit for the current group problem can score through
   group `/sync` if the group has not already solved that pid. Scoring is performed under
   the group coordinator lock, schedules the official editorial follow-up, and writes the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ NapCat (QQ) ──WS──> worker.py
 - **Limited aliases**: Only six short aliases are supported: `/newproblem`→`/np`, `/problem`→`/pb`, `/submit`→`/sbm`, `/review`→`/rv`, `/clarify`→`/clrf`, `/setproblem`→`/sp`. Old aliases such as `/sb`, `/排名`, and Chinese aliases remain unsupported. New commands default to `aliases=[]` unless explicitly approved.
 - **Help auto-generation**: `handlers/cmd/help.py` reads `registry.all_commands()` and builds the help text dynamically. Descriptions must match old bridge.py wording.
   `usage` field = args suffix in /help display (e.g. `usage="你的做法"` → `/submit 你的做法`). Group help hides private-only details for `/setproblem` and `/sync` and only briefly mentions private judge; private help lists the private-judge command set.
+  Group and private help are both delivered as merged-forward cards, with direct text
+  only as fallback.
 - **Scheduler current-group config**: `~/.kouhai-bot/scheduler_config.json` stores job list + time overrides for `CURRENT_GROUP`. Jobs are defined in `scheduler/jobs.py`.
 - **Command event log**: `eventlog.py` writes append-only JSONL command events by real local date. `achievements.py` reads those events for the 04:00-to-04:00 daily report. `eventlog_backfill.py` and `tools/backfill_command_events.py` can reconstruct recent saved submit/clarify/review events from `scoreboard.json`.
 - **Formula VL**: `problems/fetcher.py` handles CF formula images → Qwen-VL → inline LaTeX. Has white-bg preprocessing, hallucination detection, retry.
@@ -490,7 +492,8 @@ commands are rejected in private with a friendly message.
 - Private and group contexts are independent by default. `copy_records()` is used when
   copying history between sides so later writes do not share dict instances.
 - `/setproblem` (`/sp`) is private-only. Empty args select the current group problem;
-  `CF2234B`, `2234B`, Codeforces problemset/contest links, and `random` are supported.
+  `CF2234B`, `2234B`, Codeforces problemset/contest links, path fragments such as
+  `/contest/2233/problem/F` and `problem/2230/F`, and `random` are supported.
   If private history is empty and group history exists for the selected pid, it copies
   group history into private. If the group has already solved that pid, it marks private
   review as available. It sends a private problem card, preferring the current group's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -490,7 +490,9 @@ commands are rejected in private with a friendly message.
   If private history is empty and group history exists for the selected pid, it copies
   group history into private. If the group has already solved that pid, it marks private
   review as available. It sends a private problem card, preferring the current group's
-  cached forward-card payload when the pid is the current group problem.
+  cached forward-card payload when the pid is the current group problem. Generated
+  private cards must not expose the original CF id, title, contest id, or rating in the
+  card title.
 - `/problem` in private resends the selected private problem card. `/tag`, `/status`,
   `/clear`, `/submit`, `/clarify`, and `/review` all operate on private state and do
   not emit group @mentions.
@@ -854,6 +856,12 @@ leave the target untouched. This protects users from accidental history loss.
 Private command handlers must not send @ segments or call `react_emoji`. Use plain
 private messages or face segments (`build_face`) instead. Long private review/history
 responses can use private merged-forward cards.
+
+### 27. Private problem cards should not reveal source identity
+When `/setproblem` builds a private card for an explicitly selected or random CF
+problem, the card title should stay generic. Do not include the original problem id,
+title, contest id, or rating there; anti-spoiler clarification also assumes the bot does
+not reveal the original problem identity to the user.
 
 ## Testing
 

--- a/src/kouhai_bot/achievements.py
+++ b/src/kouhai_bot/achievements.py
@@ -29,6 +29,10 @@ class CommandRecord:
     received_at: datetime
     problem: str = ""
     status: str = ""
+    synced_submit_count: int = 0
+    synced_clarify_count: int = 0
+    synced_review_count: int = 0
+    synced_correct_count: int = 0
 
 
 def achievement_window(now: datetime | None = None) -> AchievementWindow:
@@ -105,6 +109,18 @@ def _command_records(
 def _apply_finished(record: CommandRecord, item: dict[str, Any]) -> None:
     record.status = str(item.get("status", ""))
     record.problem = str(item.get("problem", "")) or record.problem
+    record.synced_submit_count = _non_negative_int(item.get("synced_submit_count"))
+    record.synced_clarify_count = _non_negative_int(item.get("synced_clarify_count"))
+    record.synced_review_count = _non_negative_int(item.get("synced_review_count"))
+    record.synced_correct_count = _non_negative_int(item.get("synced_correct_count"))
+
+
+def _non_negative_int(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(parsed, 0)
 
 
 def _name(record: CommandRecord) -> str:
@@ -142,17 +158,35 @@ def build_achievement_report(
     names = {record.user_id: _name(record) for record in records}
 
     submits = [record for record in records if record.command == "submit"]
+    submit_like_records = [
+        record for record in records
+        if record.command == "submit"
+        or (record.command == "sync" and record.synced_submit_count > 0)
+    ]
     clarifies = [record for record in records if record.command == "clarify"]
     reviews = [record for record in records if record.command == "review"]
 
     submit_attempts = Counter(record.user_id for record in submits)
+    for record in records:
+        if record.command != "sync":
+            continue
+        submit_attempts[record.user_id] += record.synced_submit_count
     solves = Counter(
         record.user_id
         for record in submits
         if record.status == "correct"
     )
+    for record in records:
+        if record.command == "sync":
+            solves[record.user_id] += record.synced_correct_count
     clarify_counts = Counter(record.user_id for record in clarifies)
+    for record in records:
+        if record.command == "sync":
+            clarify_counts[record.user_id] += record.synced_clarify_count
     review_counts = Counter(record.user_id for record in reviews)
+    for record in records:
+        if record.command == "sync":
+            review_counts[record.user_id] += record.synced_review_count
 
     title_date = window.start.strftime("%Y-%m-%d")
     lines = [
@@ -165,9 +199,9 @@ def build_achievement_report(
         lines.append("昨日还没有可统计的指令记录。")
         return "\n".join(lines)
 
-    if submits:
-        first = submits[0]
-        last = submits[-1]
+    if submit_like_records:
+        first = submit_like_records[0]
+        last = submit_like_records[-1]
         lines.append(f"最早 submit：{_name(first)}（{_format_time(first.received_at)}）")
         lines.append(f"最晚 submit：{_name(last)}（{_format_time(last.received_at)}）")
     else:

--- a/src/kouhai_bot/handlers/__init__.py
+++ b/src/kouhai_bot/handlers/__init__.py
@@ -25,6 +25,19 @@ from ..napcat.client import (
 
 logger = logging.getLogger("kouhai-bot.handlers")
 
+_PRIVATE_ALLOWED_COMMANDS = {
+    "setproblem",
+    "problem",
+    "submit",
+    "clarify",
+    "review",
+    "clear",
+    "sync",
+    "status",
+    "help",
+    "tag",
+}
+
 
 # ── Message parsing ─────────────────────────────────────────────────────
 
@@ -56,6 +69,26 @@ def should_respond(msg_type: str, was_mentioned: bool) -> bool:
         return True
     # Group: only respond when mentioned
     return was_mentioned
+
+
+async def _is_service_group_member(group_id: int, user_id: int) -> bool:
+    from ..napcat import client as napcat_client
+
+    try:
+        resp = await napcat_client._http_post(
+            "get_group_member_info",
+            {"group_id": group_id, "user_id": user_id, "no_cache": True},
+        )
+        if isinstance(resp, dict) and resp.get("status") == "ok" and isinstance(resp.get("data"), dict):
+            return bool(resp["data"])
+    except Exception:
+        pass
+    try:
+        resp = await napcat_client._http_post("get_group_member_list", {"group_id": group_id})
+        members = resp.get("data", []) if isinstance(resp, dict) and resp.get("status") == "ok" else []
+        return any(str(item.get("user_id", "")) == str(user_id) for item in members if isinstance(item, dict))
+    except Exception:
+        return False
 
 
 def _normalize_leading_command_junk(text: str) -> str:
@@ -111,6 +144,8 @@ async def process_event(
     # The bot serves exactly one configured group.
     if msg_type == "group" and group_id != cfg.current_group:
         return
+    if msg_type == "private":
+        group_id = cfg.current_group
 
     raw_text, was_mentioned = extract_text(segments)
     raw_text = _normalize_leading_command_junk(raw_text)
@@ -130,7 +165,23 @@ async def process_event(
     cmd_def: CommandDef | None = registry.get(cmd_name)
 
     if cmd_def is None:
+        if msg_type == "private":
+            await send_private_msg(user_id, build_plain_message(
+                "这个 private judge 指令我还不会哦～可用 /help 看支持的命令。"
+            ))
         return  # Unknown command, silently ignore
+
+    if msg_type == "private":
+        if cmd_def.name not in _PRIVATE_ALLOWED_COMMANDS:
+            await send_private_msg(user_id, build_plain_message(
+                "这个命令暂时只能在服务群里使用～private judge 可用 /help 查看支持的命令。"
+            ))
+            return
+        if not await _is_service_group_member(group_id, user_id):
+            await send_private_msg(user_id, build_plain_message(
+                "private judge 目前只服务当前服务群成员。如果你已经在群里，稍后再试试。"
+            ))
+            return
 
     if cmd_def.handler is None:
         logger.warning(f"Command '{cmd_name}' has no handler")
@@ -147,14 +198,15 @@ async def process_event(
         handler_raw_text = f"/{cmd_def.name}{raw_text[len(cmd_token):]}"
 
     try:
-        event[EVENT_META_KEY] = log_command_received(
-            group_id=group_id,
-            user_id=user_id,
-            sender=sender,
-            command=cmd_def.name,
-            message_id=message_id,
-            raw_text=raw_text,
-        )
+        if msg_type == "group":
+            event[EVENT_META_KEY] = log_command_received(
+                group_id=group_id,
+                user_id=user_id,
+                sender=sender,
+                command=cmd_def.name,
+                message_id=message_id,
+                raw_text=raw_text,
+            )
     except Exception as e:
         logger.warning(f"Failed to write received event for /{cmd_name}: {e}")
 

--- a/src/kouhai_bot/handlers/cmd/clarify.py
+++ b/src/kouhai_bot/handlers/cmd/clarify.py
@@ -12,7 +12,9 @@ from ...eventlog import EVENT_META_KEY
 from ...napcat.client import (
     build_plain_message,
     send_group_msg,
+    send_private_msg,
 )
+from ...private_judge import GROUP_SCOPE, PRIVATE_SCOPE
 from .submit import enqueue_clarify_request
 
 logger = logging.getLogger("kouhai-bot.cmd.clarify")
@@ -22,20 +24,27 @@ async def handle(group_id: int, user_id: int, sender: dict,
                  message_id: str, raw_text: str, segments: list,
                  event: dict) -> None:
     nickname = get_display_name(sender)
+    scope = PRIVATE_SCOPE if event.get("message_type") == "private" else GROUP_SCOPE
 
     stripped = raw_text.lstrip()
     match = re.match(r'/clarify\s+', stripped)
     if not match:
-        await send_group_msg(group_id, build_plain_message(
-            f"@{nickname} 用法：/clarify 你的问题～"
-        ))
+        if scope == PRIVATE_SCOPE:
+            await send_private_msg(user_id, build_plain_message("用法：/clarify 你的问题～"))
+        else:
+            await send_group_msg(group_id, build_plain_message(
+                f"@{nickname} 用法：/clarify 你的问题～"
+            ))
         return
 
     question = stripped[match.end():].strip()
     if not question:
-        await send_group_msg(group_id, build_plain_message(
-            f"@{nickname} /clarify 后面要写你的问题呀～"
-        ))
+        if scope == PRIVATE_SCOPE:
+            await send_private_msg(user_id, build_plain_message("/clarify 后面要写你的问题呀～"))
+        else:
+            await send_group_msg(group_id, build_plain_message(
+                f"@{nickname} /clarify 后面要写你的问题呀～"
+            ))
         return
 
     await enqueue_clarify_request(
@@ -45,6 +54,7 @@ async def handle(group_id: int, user_id: int, sender: dict,
         message_id,
         question,
         event_log=event.get(EVENT_META_KEY),
+        scope=scope,
     )
 
 

--- a/src/kouhai_bot/handlers/cmd/clear.py
+++ b/src/kouhai_bot/handlers/cmd/clear.py
@@ -9,8 +9,11 @@ from .. import registry
 from ..registry import CommandDef
 from ...eventlog import EVENT_META_KEY
 from ...napcat.client import (
+    build_face,
+    send_private_msg,
     react_emoji,
 )
+from ...private_judge import GROUP_SCOPE, PRIVATE_SCOPE
 from .submit import enqueue_clear_request
 
 logger = logging.getLogger("kouhai-bot.cmd.clear")
@@ -19,9 +22,13 @@ logger = logging.getLogger("kouhai-bot.cmd.clear")
 async def handle(group_id: int, user_id: int, sender: dict,
                  message_id: str, raw_text: str, segments: list,
                  event: dict) -> None:
+    scope = PRIVATE_SCOPE if event.get("message_type") == "private" else GROUP_SCOPE
     stripped = raw_text.strip()
     if not re.fullmatch(r"/clear(?:\s+)?", stripped):
-        await react_emoji(message_id, "10060")
+        if scope == PRIVATE_SCOPE:
+            await send_private_msg(user_id, [build_face("10060")])
+        else:
+            await react_emoji(message_id, "10060")
         return
 
     await enqueue_clear_request(
@@ -30,6 +37,7 @@ async def handle(group_id: int, user_id: int, sender: dict,
         sender,
         message_id,
         event_log=event.get(EVENT_META_KEY),
+        scope=scope,
     )
 
 

--- a/src/kouhai_bot/handlers/cmd/help.py
+++ b/src/kouhai_bot/handlers/cmd/help.py
@@ -3,6 +3,20 @@
 from .. import registry
 from ..registry import CommandDef, all_commands
 
+_PRIVATE_HELP_COMMANDS = {
+    "setproblem",
+    "problem",
+    "tag",
+    "submit",
+    "clarify",
+    "review",
+    "clear",
+    "sync",
+    "status",
+    "help",
+}
+_GROUP_HELP_HIDDEN_COMMANDS = {"setproblem", "sync"}
+
 
 def _format_command_name(cmd: CommandDef) -> str:
     if not cmd.aliases:
@@ -28,6 +42,15 @@ def _description_for_help(cmd: CommandDef, newproblem_cooldown: int) -> str:
     return cmd.description
 
 
+def _command_lines(cmds: list[CommandDef], newproblem_cooldown: int) -> list[str]:
+    lines: list[str] = []
+    for cmd in cmds:
+        args = f" {cmd.usage}" if cmd.usage else ""
+        description = _description_for_help(cmd, newproblem_cooldown)
+        lines.append(f"{_format_command_name(cmd)}{args} — {description}")
+    return lines
+
+
 async def handle(group_id: int, user_id: int, sender: dict,
                  message_id: str, raw_text: str, segments: list,
                  event: dict) -> None:
@@ -42,15 +65,33 @@ async def handle(group_id: int, user_id: int, sender: dict,
     )
     cfg = get_config()
     cmds = all_commands()
-    lines = ["可用指令："]
-    for cmd in cmds:
-        args = f" {cmd.usage}" if cmd.usage else ""
-        description = _description_for_help(cmd, cfg.newproblem_cooldown)
-        lines.append(f"{_format_command_name(cmd)}{args} — {description}")
-    lines.append("")
-    lines.append("💡 每天中午12点，如果当前题还没人做出来会提醒大家继续肝；做出来了就自动刷新一道新题～")
+    is_private = event.get("message_type") == "private"
+    if is_private:
+        visible = [cmd for cmd in cmds if cmd.name in _PRIVATE_HELP_COMMANDS]
+        lines = ["private judge 可用指令："]
+        lines.extend(_command_lines(visible, cfg.newproblem_cooldown))
+        lines.append("")
+        lines.append(
+            "🔒 private judge：私聊可用 /setproblem(/sp) 选当前群题、CF题号/链接或 random；"
+            "private 通过不自动加分，只有当前群题可在群里 /sync 同步。"
+            "/sync 会用另一侧记录覆盖当前侧，可能丢掉当前侧这题交流历史；打星用户只同步 clarify。"
+        )
+    else:
+        visible = [cmd for cmd in cmds if cmd.name not in _GROUP_HELP_HIDDEN_COMMANDS]
+        lines = ["可用指令："]
+        lines.extend(_command_lines(visible, cfg.newproblem_cooldown))
+        lines.append("")
+        lines.append(
+            "🔒 private judge：可以私聊我单独选题、提交和复盘；当前群题可同步回来，详细用法请私聊发 /help。"
+        )
+        lines.append("")
+        lines.append("💡 每天中午12点，如果当前题还没人做出来会提醒大家继续肝；做出来了就自动刷新一道新题～")
     text = "\n".join(lines)
     msg = build_plain_message(text)
+
+    if is_private:
+        await send_private_msg(user_id, msg)
+        return
 
     # Send to self → forward to group (merged-forward card)
     self_resp = await send_private_msg(cfg.bot_qq, msg)

--- a/src/kouhai_bot/handlers/cmd/help.py
+++ b/src/kouhai_bot/handlers/cmd/help.py
@@ -61,6 +61,7 @@ async def handle(group_id: int, user_id: int, sender: dict,
         build_plain_message,
         send_group_msg,
         send_private_msg,
+        send_private_forward_msg,
         send_group_forward_msg,
     )
     cfg = get_config()
@@ -90,6 +91,14 @@ async def handle(group_id: int, user_id: int, sender: dict,
     msg = build_plain_message(text)
 
     if is_private:
+        self_resp = await send_private_msg(cfg.bot_qq, msg)
+        if self_resp:
+            await asyncio.sleep(0.5)
+            fwd_resp = await send_private_forward_msg(user_id, [
+                {"type": "node", "data": {"id": str(self_resp)}},
+            ])
+            if fwd_resp:
+                return
         await send_private_msg(user_id, msg)
         return
 

--- a/src/kouhai_bot/handlers/cmd/newproblem.py
+++ b/src/kouhai_bot/handlers/cmd/newproblem.py
@@ -16,6 +16,7 @@ from .. import registry
 from ..registry import CommandDef
 from ..shared import (
     get_today_problem,
+    high_difficulty_notice,
     is_already_solved,
     load_scoreboard,
     save_problem_card_ref,
@@ -55,6 +56,16 @@ def _has_unsolved_problem(group_id: int) -> bool:
 
 def _nickname(sender: dict) -> str:
     return sender.get("card") or sender.get("nickname") or str(sender.get("user_id", "?"))
+
+
+async def _send_high_difficulty_notice_group(group_id: int, problem: dict | None) -> None:
+    notice = high_difficulty_notice(problem)
+    if not notice:
+        return
+    try:
+        await send_group_msg(group_id, build_plain_message(notice))
+    except Exception as e:
+        logger.warning("[group_%s] Failed to send high-difficulty notice: %s", group_id, e)
 
 
 async def enqueue_force_new_problem(
@@ -507,6 +518,7 @@ async def _do_daily_post_locked(
         logger.error(f"[group_{group_id}] Problem forward-card send failed, falling back to direct")
         ok = await send_group_msg(group_id, build_plain_message(post_msg))
         if ok:
+            await _send_high_difficulty_notice_group(group_id, picked_state)
             await _commit_problem_state(group_id, picked_state)
             try:
                 _save_daily_msg(
@@ -534,6 +546,7 @@ async def _do_daily_post_locked(
     await _commit_problem_state(group_id, picked_state)
     if pid:
         save_problem_card_ref(group_id, fwd_resp, pid, "daily_post" if prefix is None else "newproblem")
+    await _send_high_difficulty_notice_group(group_id, picked_state)
 
     try:
         _save_daily_msg(

--- a/src/kouhai_bot/handlers/cmd/review.py
+++ b/src/kouhai_bot/handlers/cmd/review.py
@@ -13,9 +13,10 @@ from ..shared import (
     get_today_problem,
     is_already_solved,
 )
-from ...napcat.client import build_plain_message, send_group_msg
+from ...napcat.client import build_plain_message, send_group_msg, send_private_msg
 from ...context import get_display_name
 from ...eventlog import EVENT_META_KEY
+from ...private_judge import GROUP_SCOPE, PRIVATE_SCOPE, get_private_review_pid
 from .submit import enqueue_review_request
 
 logger = logging.getLogger("kouhai-bot.cmd.review")
@@ -50,20 +51,27 @@ async def handle(group_id: int, user_id: int, sender: dict,
                  message_id: str, raw_text: str, segments: list,
                  event: dict) -> None:
     nickname = get_display_name(sender)
+    scope = PRIVATE_SCOPE if event.get("message_type") == "private" else GROUP_SCOPE
 
     stripped = raw_text.lstrip()
     match = re.match(r'/review\s+', stripped)
     if not match:
-        await send_group_msg(group_id, build_plain_message(
-            f"@{nickname} 用法：/review 你的问题～"
-        ))
+        if scope == PRIVATE_SCOPE:
+            await send_private_msg(user_id, build_plain_message("用法：/review 你的问题～"))
+        else:
+            await send_group_msg(group_id, build_plain_message(
+                f"@{nickname} 用法：/review 你的问题～"
+            ))
         return
 
     question = stripped[match.end():].strip()
     if not question:
-        await send_group_msg(group_id, build_plain_message(
-            f"@{nickname} /review 后面要写你的问题呀，想聊什么直接说～"
-        ))
+        if scope == PRIVATE_SCOPE:
+            await send_private_msg(user_id, build_plain_message("/review 后面要写你的问题呀，想聊什么直接说～"))
+        else:
+            await send_group_msg(group_id, build_plain_message(
+                f"@{nickname} /review 后面要写你的问题呀，想聊什么直接说～"
+            ))
         return
 
     reply_to = ""
@@ -73,7 +81,9 @@ async def handle(group_id: int, user_id: int, sender: dict,
             break
 
     review_pid = ""
-    if reply_to:
+    if scope == PRIVATE_SCOPE:
+        review_pid = get_private_review_pid(user_id, group_id)
+    elif reply_to:
         review_pid = get_problem_card_ref_pid(group_id, reply_to)
         if not review_pid:
             await send_group_msg(group_id, build_plain_message(
@@ -98,6 +108,7 @@ async def handle(group_id: int, user_id: int, sender: dict,
         review_pid=review_pid,
         mentioned_user_ids=_mentioned_user_ids(segments, requester_id=user_id),
         event_log=event.get(EVENT_META_KEY),
+        scope=scope,
     )
 
 

--- a/src/kouhai_bot/handlers/cmd/setproblem.py
+++ b/src/kouhai_bot/handlers/cmd/setproblem.py
@@ -1,0 +1,141 @@
+"""/setproblem — choose the current private-judge problem."""
+
+from __future__ import annotations
+
+import logging
+import re
+import asyncio
+
+from .. import registry
+from ..registry import CommandDef
+from ...napcat.client import build_plain_message, send_group_msg, send_private_msg
+from ...private_judge import (
+    copy_records,
+    current_group_pid,
+    group_problem_history,
+    is_group_problem_solved,
+    load_private_problem_history,
+    mark_private_solved,
+    parse_problem_ref,
+    problem_id_from_ref,
+    replace_private_problem_history,
+    resolve_problem_by_pid,
+    resolve_random_problem,
+    send_problem_card_private,
+    set_private_current_problem,
+)
+from ..shared import get_today_problem
+
+logger = logging.getLogger("kouhai-bot.cmd.setproblem")
+
+_RANDOM_ARGS = {"random", "rand", "r"}
+
+
+def _strip_command(raw_text: str) -> str:
+    text = raw_text.lstrip()
+    match = re.match(r"/setproblem(?:\s+|$)", text)
+    if not match:
+        return ""
+    return text[match.end():].strip()
+
+
+def _history_message(*, private_count: int, group_count: int, copied: bool) -> str:
+    if copied:
+        return "目前你正在使用来自群聊的历史记录。"
+    if private_count and group_count:
+        return "你在群聊和 private judge 中都有记录，目前正在使用 private judge 中的记录；想改用群聊记录可在私聊发 /sync。"
+    if private_count:
+        return "目前你正在使用 private judge 中已有的记录。"
+    return "你目前此题的记录是干净的。"
+
+
+async def handle(group_id: int, user_id: int, sender: dict,
+                 message_id: str, raw_text: str, segments: list,
+                 event: dict) -> None:
+    if event.get("message_type") != "private":
+        await send_group_msg(group_id, build_plain_message(
+            "private judge 题目请私聊我使用 /setproblem 设置～"
+        ))
+        return
+
+    arg = _strip_command(raw_text)
+    problem: dict | None = None
+    prefer_group_card = False
+
+    if not arg:
+        problem = get_today_problem(group_id)
+        if not problem:
+            await send_private_msg(user_id, build_plain_message(
+                "当前服务群还没有题目可以同步到 private judge～"
+            ))
+            return
+        prefer_group_card = True
+    elif arg.lower() in _RANDOM_ARGS:
+        await send_private_msg(user_id, build_plain_message("正在随机挑一道题，稍等一下～"))
+        try:
+            problem = await asyncio.to_thread(resolve_random_problem, group_id)
+        except Exception as e:
+            logger.warning("private random problem failed: %s", e, exc_info=True)
+            await send_private_msg(user_id, build_plain_message(
+                "随机题目暂时拉不到，可能是 Codeforces 或题面缓存不太稳定，稍后再试试？"
+            ))
+            return
+    else:
+        parsed = parse_problem_ref(arg)
+        if not parsed:
+            await send_private_msg(user_id, build_plain_message(
+                "我没认出这道题～可以发 CF2234B、2234B，或者 Codeforces 题目链接。"
+            ))
+            return
+        pid = problem_id_from_ref(*parsed)
+        await send_private_msg(user_id, build_plain_message(f"正在设置 CF{pid}，稍等一下～"))
+        try:
+            problem = await asyncio.to_thread(resolve_problem_by_pid, pid)
+        except Exception as e:
+            logger.warning("private setproblem resolve failed for %s: %s", pid, e, exc_info=True)
+            await send_private_msg(user_id, build_plain_message(
+                f"CF{pid} 的题面暂时拉不到，稍后再试试？"
+            ))
+            return
+
+    if not problem:
+        await send_private_msg(user_id, build_plain_message("题目信息为空，稍后再试试？"))
+        return
+
+    set_private_current_problem(user_id, problem)
+    pid = str(problem.get("today", "") or "")
+    group_records = group_problem_history(group_id, user_id, pid)
+    private_records = load_private_problem_history(user_id, pid)
+    copied = False
+    if not private_records and group_records:
+        replace_private_problem_history(user_id, pid, copy_records(group_records))
+        copied = True
+        private_records = load_private_problem_history(user_id, pid)
+
+    if is_group_problem_solved(group_id, pid):
+        mark_private_solved(user_id, pid, source="group")
+
+    await send_problem_card_private(
+        user_id,
+        group_id,
+        problem,
+        prefer_group_card=prefer_group_card or pid == current_group_pid(group_id),
+    )
+    await send_private_msg(user_id, build_plain_message(
+        _history_message(
+            private_count=len(private_records),
+            group_count=len(group_records),
+            copied=copied,
+        )
+    ))
+
+
+def register() -> None:
+    registry.register(CommandDef(
+        name="setproblem",
+        aliases=["sp"],
+        description="设置 private judge 当前题（题号/链接/random；空参数使用当前群题）",
+        usage="[题号|链接|random]",
+        handler=handle,
+        cooldown=3,
+    ))

--- a/src/kouhai_bot/handlers/cmd/setproblem.py
+++ b/src/kouhai_bot/handlers/cmd/setproblem.py
@@ -10,6 +10,7 @@ from .. import registry
 from ..registry import CommandDef
 from ...napcat.client import build_plain_message, send_group_msg, send_private_msg
 from ...private_judge import (
+    NonFormulaImageProblem,
     copy_records,
     current_group_pid,
     group_problem_history,
@@ -91,6 +92,12 @@ async def handle(group_id: int, user_id: int, sender: dict,
         await send_private_msg(user_id, build_plain_message(f"正在设置 CF{pid}，稍等一下～"))
         try:
             problem = await asyncio.to_thread(resolve_problem_by_pid, pid)
+        except NonFormulaImageProblem:
+            await send_private_msg(user_id, build_plain_message(
+                f"CF{pid} 的题面里包含非公式图片，我现在对这类题目的处理能力有限，"
+                "可能看不完整题意。建议先换一道题～"
+            ))
+            return
         except Exception as e:
             logger.warning("private setproblem resolve failed for %s: %s", pid, e, exc_info=True)
             await send_private_msg(user_id, build_plain_message(

--- a/src/kouhai_bot/handlers/cmd/setproblem.py
+++ b/src/kouhai_bot/handlers/cmd/setproblem.py
@@ -85,7 +85,8 @@ async def handle(group_id: int, user_id: int, sender: dict,
         parsed = parse_problem_ref(arg)
         if not parsed:
             await send_private_msg(user_id, build_plain_message(
-                "我没认出这道题～可以发 CF2234B、2234B，或者 Codeforces 题目链接。"
+                "我没认出这道题～可以发 CF2234B、2234B、Codeforces 题目链接，"
+                "或者 /contest/2233/problem/F 这样的路径。"
             ))
             return
         pid = problem_id_from_ref(*parsed)

--- a/src/kouhai_bot/handlers/cmd/stubs.py
+++ b/src/kouhai_bot/handlers/cmd/stubs.py
@@ -7,6 +7,7 @@ from ..shared import (
     fetch_group_member_nickname_map,
     format_points,
     get_today_problem,
+    high_difficulty_notice,
     is_already_solved,
     load_scoreboard,
 )
@@ -36,6 +37,16 @@ async def _send_solved_problem_hint(group_id: int, nickname: str) -> None:
         await send_group_msg(group_id, build_plain_message(
             f"@{nickname} 这题已经通过啦，可以发 /newproblem 挑战下一题～"
         ))
+    except Exception:
+        return
+
+
+async def _send_high_difficulty_notice_group(group_id: int, problem: dict | None) -> None:
+    notice = high_difficulty_notice(problem)
+    if not notice:
+        return
+    try:
+        await send_group_msg(group_id, build_plain_message(notice))
     except Exception:
         return
 
@@ -114,6 +125,7 @@ async def handle_problem(group_id: int, user_id: int, sender: dict,
                 if fwd_resp:
                     if pid:
                         save_problem_card_ref(group_id, fwd_resp, pid, "problem_resend")
+                    await _send_high_difficulty_notice_group(group_id, current_problem)
                     await _send_solved_problem_hint(group_id, nickname)
                     return
             post_msg = daily_msg.get("post_msg")
@@ -135,6 +147,7 @@ async def handle_problem(group_id: int, user_id: int, sender: dict,
                     daily_msg["fwd_message_id"] = fwd_resp
                     with open(daily_msg_path, "w") as f:
                         json.dump(daily_msg, f, ensure_ascii=False, indent=2)
+                    await _send_high_difficulty_notice_group(group_id, current_problem)
                     await _send_solved_problem_hint(group_id, nickname)
                     return
         except Exception:

--- a/src/kouhai_bot/handlers/cmd/stubs.py
+++ b/src/kouhai_bot/handlers/cmd/stubs.py
@@ -13,6 +13,11 @@ from ..shared import (
 from ...napcat.client import (
     build_plain_message,
     send_group_msg,
+    send_private_msg,
+)
+from ...private_judge import (
+    get_private_current_problem,
+    send_problem_card_private,
 )
 
 
@@ -43,6 +48,24 @@ async def handle_problem(group_id: int, user_id: int, sender: dict,
     """Resend today's problem as the original merged-forward card.
     Falls back to regenerating problem text if daily_msg.json is missing."""
     if raw_text.lstrip() != "/problem":
+        return
+    if event.get("message_type") == "private":
+        problem = get_private_current_problem(user_id)
+        if not problem:
+            await send_private_msg(user_id, build_plain_message(
+                "你还没有 private judge 题目～先发 /setproblem 设置一道吧。"
+            ))
+            return
+        ok = await send_problem_card_private(
+            user_id,
+            group_id,
+            problem,
+            prefer_group_card=True,
+        )
+        if not ok:
+            await send_private_msg(user_id, build_plain_message(
+                "暂时无法重新发送题目，稍后再试试？"
+            ))
         return
 
     from ...config import get_config
@@ -129,15 +152,26 @@ async def handle_tag(group_id: int, user_id: int, sender: dict,
                      message_id: str, raw_text: str, segments: list,
                      event: dict) -> None:
     nickname = _nick(sender)
-    problem = get_today_problem(group_id)
+    is_private = event.get("message_type") == "private"
+    problem = get_private_current_problem(user_id) if is_private else get_today_problem(group_id)
     if not problem:
-        await send_group_msg(group_id, build_plain_message(f"@{nickname} 还没有今日题目～"))
+        if is_private:
+            await send_private_msg(user_id, build_plain_message("你还没有 private judge 题目～"))
+        else:
+            await send_group_msg(group_id, build_plain_message(f"@{nickname} 还没有今日题目～"))
         return
     tags = problem.get("tags", [])
     if not tags:
-        await send_group_msg(group_id, build_plain_message(f"@{nickname} 当前题目没有 tag 信息～"))
+        if is_private:
+            await send_private_msg(user_id, build_plain_message("当前题目没有 tag 信息～"))
+        else:
+            await send_group_msg(group_id, build_plain_message(f"@{nickname} 当前题目没有 tag 信息～"))
         return
-    await send_group_msg(group_id, build_plain_message(f"@{nickname} 当前题目的 tags：{'、'.join(tags)}"))
+    text = f"当前题目的 tags：{'、'.join(tags)}"
+    if is_private:
+        await send_private_msg(user_id, build_plain_message(text))
+    else:
+        await send_group_msg(group_id, build_plain_message(f"@{nickname} {text}"))
 
 
 # ── /scoreboard ─────────────────────────────────────────────────────────
@@ -216,15 +250,27 @@ async def handle_status(group_id: int, user_id: int, sender: dict,
                         event: dict) -> None:
     """Show bot's current busy/idle status."""
     from .newproblem import get_newproblem_status
-    from .submit import get_group_lock_status
-    from ...napcat.client import build_plain_message, build_reply, send_group_msg
+    from .submit import get_group_lock_status, get_private_lock_status
+    from ...napcat.client import build_plain_message, build_reply, send_group_msg, send_private_msg
 
-    status = get_newproblem_status(group_id) or get_group_lock_status(group_id)
+    is_private = event.get("message_type") == "private"
+    status = get_private_lock_status(user_id, group_id) if is_private else (
+        get_newproblem_status(group_id) or get_group_lock_status(group_id)
+    )
     if status is None:
-        await send_group_msg(group_id, build_plain_message("🟢 bot 当前空闲，没有在处理请求～"))
+        text = "🟢 bot 当前空闲，没有在处理请求～"
+        if is_private:
+            await send_private_msg(user_id, build_plain_message(text))
+        else:
+            await send_group_msg(group_id, build_plain_message(text))
         return
 
     cmd = status["command"]
+    if is_private:
+        await send_private_msg(user_id, build_plain_message(
+            f"🔴 private judge 当前有 {cmd} 请求还在处理中～"
+        ))
+        return
     if status.get("message_id"):
         await send_group_msg(group_id, build_reply(
             f"🔴 bot 当前有 {cmd} 请求还在处理中～",

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -28,6 +28,7 @@ from ..shared import (
     fetch_group_member_nickname_map,
     format_points,
     get_problem_posted_at,
+    get_problem_summary,
     get_today_problem,
     judge_submission_result,
     load_known_problem_ratings,
@@ -45,20 +46,42 @@ from ...context import get_display_name, load_group_ctx
 from ...user_groups import (
     effective_submit_delay_sec_for_scoreboard,
     get_user_group,
+    is_dynamic_submit_delay_enabled,
     is_default_group,
     settle_dynamic_submit_wait_for_problem,
 )
 from ...curfew import is_curfew_active, format_curfew_message
 from ...eventlog import EVENT_META_KEY, log_command_finished
 from ...editorial_followup import schedule_post_solve_editorial_followup
+from ...private_judge import (
+    GROUP_SCOPE,
+    PRIVATE_SCOPE,
+    clear_private_problem_history,
+    copy_records,
+    get_private_current_problem,
+    group_problem_history,
+    has_group_problem_private_notified,
+    is_group_problem_solved,
+    is_private_solved,
+    load_private_problem_history,
+    mark_group_problem_private_notified,
+    mark_private_solved,
+    replace_private_problem_history,
+    save_private_submission,
+    send_problem_card_private,
+    set_private_current_problem,
+)
 from ...tutorials import format_editorial_for_review, get_official_editorial
 from ...napcat.client import (
     build_at,
+    build_face,
     build_plain_message,
     build_text,
+    delete_msg,
     react_emoji,
     send_group_forward_msg,
     send_group_msg,
+    send_private_forward_msg,
     send_private_msg,
 )
 
@@ -67,7 +90,7 @@ logger = logging.getLogger("kouhai-bot.cmd.submit")
 _COMPUTE_CONCURRENCY = 8
 _runtime_loop: asyncio.AbstractEventLoop | None = None
 _compute_sem: asyncio.Semaphore | None = None
-_coordinators: dict[int, "GroupCoordinator"] = {}
+_coordinators: dict[tuple[str, int], "GroupCoordinator"] = {}
 _USER_CONTEXT_WRITERS = {"submit", "clarify", "review"}
 _REVIEW_FORWARD_THRESHOLD = 200
 _REVIEW_CHUNK_SIZE = 3000
@@ -161,6 +184,7 @@ class PendingRequest:
     message_id: str
     command: str
     nickname: str
+    scope: str = GROUP_SCOPE
     payload: str = ""
     submit_pid: str = ""
     submit_problem: dict | None = None
@@ -185,12 +209,17 @@ class PendingRequest:
 
     def status_dict(self) -> dict:
         return {
+            "scope": self.scope,
             "group_id": self.group_id,
             "user_id": self.user_id,
             "message_id": self.message_id,
             "command": self.command,
             "admitted_at": self.admitted_at,
         }
+
+    @property
+    def is_private(self) -> bool:
+        return self.scope == PRIVATE_SCOPE
 
 
 def _refresh_runtime() -> None:
@@ -211,12 +240,24 @@ def _compute_limit() -> asyncio.Semaphore:
     return _compute_sem
 
 
-def _get_coordinator(group_id: int) -> "GroupCoordinator":
+def _coordinator_key(group_id: int, *, scope: str = GROUP_SCOPE, user_id: int = 0) -> tuple[str, int]:
+    if scope == PRIVATE_SCOPE:
+        return (PRIVATE_SCOPE, int(user_id))
+    return (GROUP_SCOPE, int(group_id))
+
+
+def _get_coordinator(
+    group_id: int,
+    *,
+    scope: str = GROUP_SCOPE,
+    user_id: int = 0,
+) -> "GroupCoordinator":
     _refresh_runtime()
-    coord = _coordinators.get(group_id)
+    key = _coordinator_key(group_id, scope=scope, user_id=user_id)
+    coord = _coordinators.get(key)
     if coord is None:
-        coord = GroupCoordinator(group_id)
-        _coordinators[group_id] = coord
+        coord = GroupCoordinator(group_id, scope=scope, owner_id=key[1])
+        _coordinators[key] = coord
     return coord
 
 
@@ -232,6 +273,33 @@ async def _judge_llm_limited(
 ):
     async with _compute_limit():
         return await judge_submission_result(problem_text, submission, history)
+
+
+async def _send_req_plain(req: PendingRequest, text: str, *, mention: bool = True) -> int | None:
+    if req.is_private:
+        return await send_private_msg(req.user_id, build_plain_message(text.strip()))
+    if mention:
+        return await send_group_msg(req.group_id, [
+            build_at(req.user_id),
+            build_text(f" {text.strip()}"),
+        ])
+    return await send_group_msg(req.group_id, build_plain_message(text))
+
+
+async def _send_req_segments(req: PendingRequest, segments: list[dict]) -> int | None:
+    if req.is_private:
+        cleaned = [seg for seg in segments if seg.get("type") != "at"]
+        if not cleaned:
+            cleaned = build_plain_message("")
+        return await send_private_msg(req.user_id, cleaned)
+    return await send_group_msg(req.group_id, segments)
+
+
+async def _react_req(req: PendingRequest, emoji_id: str) -> None:
+    if req.is_private:
+        await send_private_msg(req.user_id, [build_face(emoji_id)])
+        return
+    await react_emoji(req.message_id, emoji_id)
 
 
 def _load_latest_group_summary(group_id: int) -> str:
@@ -313,8 +381,17 @@ def _build_review_history(history: list[dict]) -> str:
     return "\n".join([stats, *parts])
 
 
-def _load_user_problem_history(group_id: int, user_id: int, pid: str) -> list[dict]:
-    history = load_user_submissions(group_id, user_id)
+def _load_user_problem_history(
+    group_id: int,
+    user_id: int,
+    pid: str,
+    *,
+    scope: str = GROUP_SCOPE,
+) -> list[dict]:
+    if scope == PRIVATE_SCOPE:
+        history = load_private_problem_history(user_id, pid)
+    else:
+        history = load_user_submissions(group_id, user_id)
     items = [item for item in history if item.get("problem") == pid]
     return sorted(items, key=lambda item: str(item.get("timestamp", "")))
 
@@ -471,11 +548,13 @@ async def _reveal_problem_source(group_id: int) -> str:
 
 
 class GroupCoordinator:
-    def __init__(self, group_id: int):
+    def __init__(self, group_id: int, *, scope: str = GROUP_SCOPE, owner_id: int | None = None):
         self.group_id = group_id
+        self.scope = scope
+        self.owner_id = int(owner_id if owner_id is not None else group_id)
         self.lock = asyncio.Lock()
         self.active: dict[int, PendingRequest] = {}
-        self.clear_watermarks: dict[tuple[int, int, str], int] = {}
+        self.clear_watermarks: dict[tuple[str, int, int, str], int] = {}
         self.submit_candidates: dict[str, list[PendingRequest]] = {}
         self.scoring_pids: set[str] = set()
         self.next_seq = 1
@@ -486,11 +565,11 @@ class GroupCoordinator:
         self.active[req.seq] = req
         resolve_pids = self._discard_superseded_submits_locked(req)
         if req.kind in _USER_CONTEXT_WRITERS and req.target_pid:
-            save_user_submission(
-                req.group_id,
-                req.user_id,
-                _context_record(req, problem=req.target_pid),
-            )
+            record = _context_record(req, problem=req.target_pid)
+            if req.is_private:
+                save_private_submission(req.user_id, record)
+            else:
+                save_user_submission(req.group_id, req.user_id, record)
         if req.submit_score_candidate and req.submit_pid:
             self.submit_candidates.setdefault(req.submit_pid, []).append(req)
         req.task = asyncio.create_task(
@@ -560,11 +639,11 @@ class GroupCoordinator:
             old.discarded = True
             old.compute_result = {"kind": "discarded", "pid": old.submit_pid}
             if req.kind == "submit":
-                save_user_submission(
-                    old.group_id,
-                    old.user_id,
-                    _context_record(old, result="superseded", problem=old.submit_pid),
-                )
+                record = _context_record(old, result="superseded", problem=old.submit_pid)
+                if old.is_private:
+                    save_private_submission(old.user_id, record)
+                else:
+                    save_user_submission(old.group_id, old.user_id, record)
             self._log_finished(old, "stale", problem=old.submit_pid)
             resolved_pids.add(self._finish_request_locked(old))
             if old.task and not old.task.done():
@@ -585,17 +664,25 @@ class GroupCoordinator:
         async with self.lock:
             request_id = _request_id(req)
             history = [
-                item for item in _load_user_problem_history(req.group_id, target_user_id, pid)
+                item for item in _load_user_problem_history(
+                    req.group_id,
+                    target_user_id,
+                    pid,
+                    scope=req.scope if target_user_id == req.user_id else GROUP_SCOPE,
+                )
                 if not request_id or str(item.get("request_id", "") or "") != request_id
             ]
         return sorted(history, key=lambda item: str(item.get("timestamp", "")))
 
     async def _save_context_record(self, req: PendingRequest, record: dict) -> bool:
         async with self.lock:
-            key = (req.group_id, req.user_id, str(record.get("problem", "") or ""))
+            key = (req.scope, req.group_id, req.user_id, str(record.get("problem", "") or ""))
             if self.clear_watermarks.get(key, 0) >= req.seq:
                 return False
-            save_user_submission(req.group_id, req.user_id, record)
+            if req.is_private:
+                save_private_submission(req.user_id, record)
+            else:
+                save_user_submission(req.group_id, req.user_id, record)
             return True
 
     async def _run_request(self, req: PendingRequest) -> None:
@@ -637,10 +724,7 @@ class GroupCoordinator:
                 self.group_id, req.command, req.seq, e, exc_info=True,
             )
             self._log_finished(req, "error", extra={"error": str(e)[:500]})
-            await send_group_msg(
-                req.group_id,
-                build_plain_message(f"@{req.nickname} 处理 /{req.command} 时出了点问题，稍后再试试？"),
-            )
+            await _send_req_plain(req, f"处理 /{req.command} 时出了点问题，稍后再试试？")
             await self._finish_request(req)
 
     async def _compute_submit(self, req: PendingRequest) -> dict:
@@ -668,7 +752,7 @@ class GroupCoordinator:
             }
 
         history = await self._load_user_problem_history_for_request(req, pid)
-        await react_emoji(req.message_id, random.choice(["128064", "289"]))
+        await _react_req(req, random.choice(["128064", "289"]))
         result = await _judge_llm_limited(problem_text, req.payload, history)
         if not result.text:
             return {"kind": result.failure_kind or "error", "pid": pid}
@@ -683,8 +767,12 @@ class GroupCoordinator:
             return {"kind": "no_statement", "pid": pid}
 
         cfg = get_config()
-        summary = _load_latest_group_summary(req.group_id)
-        await react_emoji(req.message_id, random.choice(["128064", "289"]))
+        summary = (
+            get_problem_summary(req.group_id, pid)
+            if req.is_private
+            else _load_latest_group_summary(req.group_id)
+        )
+        await _react_req(req, random.choice(["128064", "289"]))
         result = await _call_llm_limited(
             [
                 {"role": "system", "content": CLARIFY_PROMPT},
@@ -750,7 +838,7 @@ class GroupCoordinator:
         user_parts.append(f"用户的问题：\n{req.payload}")
 
         cfg = get_config()
-        await react_emoji(req.message_id, random.choice(["128064", "289"]))
+        await _react_req(req, random.choice(["128064", "289"]))
         result = await _call_llm_limited(
             [
                 {"role": "system", "content": REVIEW_PROMPT},
@@ -770,17 +858,17 @@ class GroupCoordinator:
         return {"kind": "review", "pid": pid, "reply": reply, "model_tag": result.model_tag}
 
     async def _send_already_solved(self, req: PendingRequest) -> None:
-        await send_group_msg(req.group_id, [
-            build_at(req.user_id),
-            build_text(" 已经有人解出本题了～想刷下一道可以发 /newproblem 哦"),
-        ])
+        if req.is_private:
+            await _send_req_plain(req, "这题已经通过啦，可以直接 /review 复盘。")
+        else:
+            await send_group_msg(req.group_id, [
+                build_at(req.user_id),
+                build_text(" 已经有人解出本题了～想刷下一道可以发 /newproblem 哦"),
+            ])
 
     async def _send_llm_failure(self, req: PendingRequest) -> None:
-        await react_emoji(req.message_id, "268")
-        await send_group_msg(req.group_id, [
-            build_at(req.user_id),
-            build_text(_LLM_FAILURE_TEXT),
-        ])
+        await _react_req(req, "268")
+        await _send_req_plain(req, _LLM_FAILURE_TEXT)
 
     async def _send_correct_only(
         self,
@@ -797,10 +885,7 @@ class GroupCoordinator:
             text = " 做法被判定为正确了～"
         if model_tag:
             text = text.rstrip() + model_tag
-        await send_group_msg(req.group_id, [
-            build_at(req.user_id),
-            build_text(text),
-        ])
+        await _send_req_plain(req, text)
         req.submit_waiting_reply_sent = True
 
     def _problem_source_from_snapshot(self, req: PendingRequest, pid: str) -> str:
@@ -813,6 +898,24 @@ class GroupCoordinator:
         if rating and rating != "?":
             parts.append(rating)
         return f"本题来自 {' '.join(parts)}✨" if parts else ""
+
+    async def _send_private_success(self, req: PendingRequest, pid: str, model_tag: str = "") -> None:
+        mark_private_solved(req.user_id, pid, source="private")
+        current_pid = ""
+        current = get_today_problem(req.group_id)
+        if current:
+            current_pid = str(current.get("today", "") or "")
+        if current_pid and current_pid == pid:
+            text = (
+                "做对了！🎉 private judge 不直接加分。"
+                "如果群里还没人通过这题，可以到服务群发 /sync，把这次通过同步到群榜。"
+            )
+        else:
+            text = "做对了！🎉 这次通过只记录在 private judge，不计入群榜。"
+        if model_tag:
+            text = text.rstrip() + model_tag
+        self._log_finished(req, "correct", problem=pid, extra={"scope": PRIVATE_SCOPE})
+        await _send_req_plain(req, text)
 
     async def _send_scoreboard_success(self, req: PendingRequest, pid: str, model_tag: str = "") -> None:
         async with self.lock:
@@ -930,16 +1033,17 @@ class GroupCoordinator:
         kind = result.get("kind")
         if kind == "no_problem":
             self._log_finished(req, "no_problem")
-            await send_group_msg(req.group_id, build_plain_message(
-                f"@{req.nickname} 当前还没有题目可以提交～发 /newproblem 刷新一道？"
-            ))
+            if req.is_private:
+                await _send_req_plain(req, "当前还没有 private judge 题目～先发 /setproblem 设置一道题吧。")
+            else:
+                await send_group_msg(req.group_id, build_plain_message(
+                    f"@{req.nickname} 当前还没有题目可以提交～发 /newproblem 刷新一道？"
+                ))
             await self._finish_request(req)
             return
         if kind == "bad_pid":
             self._log_finished(req, "bad_pid")
-            await send_group_msg(req.group_id, build_plain_message(
-                f"@{req.nickname} 加载题目信息失败，稍后再试试？"
-            ))
+            await _send_req_plain(req, "加载题目信息失败，稍后再试试？")
             await self._finish_request(req)
             return
         if kind == "already_solved":
@@ -949,9 +1053,7 @@ class GroupCoordinator:
             return
         if kind == "no_statement":
             self._log_finished(req, "no_statement", problem=result.get("pid", ""))
-            await send_group_msg(req.group_id, build_plain_message(
-                f"@{req.nickname} 加载题目信息失败，稍后再试试？"
-            ))
+            await _send_req_plain(req, "加载题目信息失败，稍后再试试？")
             req.submit_judge_done = True
             req.submit_correct = False
             await self._save_context_record(
@@ -985,7 +1087,7 @@ class GroupCoordinator:
 
         if reaction == "123":
             self._log_finished(req, "offtopic", problem=pid)
-            await react_emoji(req.message_id, "123")
+            await _react_req(req, "123")
             req.submit_judge_done = True
             req.submit_correct = False
             await self._resolve_submit_scores(pid)
@@ -1006,6 +1108,10 @@ class GroupCoordinator:
         req.submit_correct = bool(correct)
 
         if correct:
+            if req.is_private:
+                await self._send_private_success(req, pid, model_tag)
+                await self._finish_request(req)
+                return
             if req.submit_score_candidate:
                 async with self.lock:
                     earlier_waiting = any(
@@ -1032,10 +1138,7 @@ class GroupCoordinator:
             if model_tag:
                 reply = reply.rstrip() + model_tag
             self._log_finished(req, "incorrect", problem=pid)
-            await send_group_msg(req.group_id, [
-                build_at(req.user_id),
-                build_text(f" {reply}"),
-            ])
+            await _send_req_plain(req, reply)
             await self._resolve_submit_scores(pid)
             await self._finish_request(req)
             return
@@ -1044,10 +1147,7 @@ class GroupCoordinator:
         if model_tag:
             reason = reason.rstrip() + model_tag
         self._log_finished(req, "incorrect", problem=pid)
-        await send_group_msg(req.group_id, [
-            build_at(req.user_id),
-            build_text(f" {reason}。再想想？🤔"),
-        ])
+        await _send_req_plain(req, f"{reason}。再想想？🤔")
         await self._resolve_submit_scores(pid)
         await self._finish_request(req)
 
@@ -1056,23 +1156,22 @@ class GroupCoordinator:
         kind = result.get("kind")
         if kind == "no_problem":
             self._log_finished(req, "no_problem")
-            await send_group_msg(req.group_id, build_plain_message(
-                f"@{req.nickname} 还没有今日题目哦～"
-            ))
+            if req.is_private:
+                await _send_req_plain(req, "当前还没有 private judge 题目～先发 /setproblem 设置一道题吧。")
+            else:
+                await send_group_msg(req.group_id, build_plain_message(
+                    f"@{req.nickname} 还没有今日题目哦～"
+                ))
             await self._finish_request(req)
             return
         if kind == "bad_pid":
             self._log_finished(req, "bad_pid")
-            await send_group_msg(req.group_id, build_plain_message(
-                f"@{req.nickname} 读取题目信息失败～"
-            ))
+            await _send_req_plain(req, "读取题目信息失败～")
             await self._finish_request(req)
             return
         if kind == "no_statement":
             self._log_finished(req, "no_statement", problem=result.get("pid", ""))
-            await send_group_msg(req.group_id, build_plain_message(
-                f"@{req.nickname} 抱歉，题面缓存不可用～"
-            ))
+            await _send_req_plain(req, "抱歉，题面缓存不可用～")
             await self._save_context_record(
                 req,
                 _context_record(req, result="no_statement", problem=result.get("pid", "")),
@@ -1094,7 +1193,7 @@ class GroupCoordinator:
         parsed = result.get("parsed", {})
         if parsed.get("reaction") == "123":
             self._log_finished(req, "offtopic", problem=pid)
-            await react_emoji(req.message_id, "123")
+            await _react_req(req, "123")
             await self._finish_request(req)
             return
 
@@ -1115,10 +1214,7 @@ class GroupCoordinator:
         model_tag = result.get("model_tag", "")
         if model_tag:
             reply = reply.rstrip() + model_tag
-        await send_group_msg(req.group_id, [
-            build_at(req.user_id),
-            build_text(f" {reply}"),
-        ])
+        await _send_req_plain(req, reply)
 
         await self._save_context_record(
             req,
@@ -1132,17 +1228,12 @@ class GroupCoordinator:
         kind = result.get("kind")
         if kind == "no_review_problem":
             self._log_finished(req, "no_review_problem")
-            await send_group_msg(req.group_id, [
-                build_at(req.user_id),
-                build_text(" 还没有已通过的题目可以 review 哦～先做出一道再来聊吧！"),
-            ])
+            await _send_req_plain(req, "还没有已通过的题目可以 review 哦～先做出一道再来聊吧！")
             await self._finish_request(req)
             return
         if kind == "no_statement":
             self._log_finished(req, "no_statement", problem=result.get("pid", ""))
-            await send_group_msg(req.group_id, build_plain_message(
-                f"@{req.nickname} 抱歉，题面缓存不可用～"
-            ))
+            await _send_req_plain(req, "抱歉，题面缓存不可用～")
             await self._save_context_record(
                 req,
                 _context_record(req, result="no_statement", problem=result.get("pid", "")),
@@ -1163,9 +1254,7 @@ class GroupCoordinator:
         pid = result.get("pid", "")
         if not pid:
             self._log_finished(req, "error")
-            await send_group_msg(req.group_id, build_plain_message(
-                f"@{req.nickname} 读取题目信息失败～"
-            ))
+            await _send_req_plain(req, "读取题目信息失败～")
             await self._finish_request(req)
             return
 
@@ -1211,10 +1300,16 @@ class GroupCoordinator:
                 node_ids.append(str(self_resp))
             if node_ids:
                 await asyncio.sleep(0.5)
-                fwd_resp = await send_group_forward_msg(
-                    req.group_id,
-                    [{"type": "node", "data": {"id": node_id}} for node_id in node_ids],
-                )
+                if req.is_private:
+                    fwd_resp = await send_private_forward_msg(
+                        req.user_id,
+                        [{"type": "node", "data": {"id": node_id}} for node_id in node_ids],
+                    )
+                else:
+                    fwd_resp = await send_group_forward_msg(
+                        req.group_id,
+                        [{"type": "node", "data": {"id": node_id}} for node_id in node_ids],
+                    )
                 if fwd_resp:
                     logger.info(
                         "[group_%s] /review seq=%s forward-card send ok: fwd_msg_id=%s node_count=%s",
@@ -1223,10 +1318,11 @@ class GroupCoordinator:
                         fwd_resp,
                         len(node_ids),
                     )
-                    await send_group_msg(req.group_id, [
-                        build_at(req.user_id),
-                        build_text(" 回复较长，已折叠到卡片里啦 👆"),
-                    ])
+                    if not req.is_private:
+                        await send_group_msg(req.group_id, [
+                            build_at(req.user_id),
+                            build_text(" 回复较长，已折叠到卡片里啦 👆"),
+                        ])
                 else:
                     logger.warning(
                         "[group_%s] /review seq=%s forward-card send failed after self-send; falling back to direct group messages",
@@ -1242,7 +1338,10 @@ class GroupCoordinator:
                             len(chunks),
                             len(chunk),
                         )
-                        await send_group_msg(req.group_id, build_plain_message(chunk))
+                        if req.is_private:
+                            await send_private_msg(req.user_id, build_plain_message(chunk))
+                        else:
+                            await send_group_msg(req.group_id, build_plain_message(chunk))
             else:
                 for idx, chunk in enumerate(chunks, 1):
                     logger.info(
@@ -1253,7 +1352,10 @@ class GroupCoordinator:
                         len(chunks),
                         len(chunk),
                     )
-                    await send_group_msg(req.group_id, build_plain_message(chunk))
+                    if req.is_private:
+                        await send_private_msg(req.user_id, build_plain_message(chunk))
+                    else:
+                        await send_group_msg(req.group_id, build_plain_message(chunk))
         else:
             logger.info(
                 "[group_%s] /review seq=%s user=%s pid=%s using direct-send path: reply_len=%s",
@@ -1263,10 +1365,7 @@ class GroupCoordinator:
                 pid,
                 len(reply),
             )
-            await send_group_msg(req.group_id, [
-                build_at(req.user_id),
-                build_text(f" {reply}"),
-            ])
+            await _send_req_plain(req, reply)
 
         await self._save_context_record(
             req,
@@ -1278,23 +1377,54 @@ class GroupCoordinator:
     async def _finalize_clear(self, req: PendingRequest) -> None:
         pid = req.target_pid
         if not pid:
-            await react_emoji(req.message_id, "10060")
+            await _react_req(req, "10060")
             await self._finish_request(req)
             return
 
         async with self.lock:
-            clear_user_problem_submissions(req.group_id, req.user_id, pid)
-            key = (req.group_id, req.user_id, pid)
+            if req.is_private:
+                clear_private_problem_history(req.user_id, pid)
+            else:
+                clear_user_problem_submissions(req.group_id, req.user_id, pid)
+            key = (req.scope, req.group_id, req.user_id, pid)
             self.clear_watermarks[key] = max(self.clear_watermarks.get(key, 0), req.seq)
-        await react_emoji(req.message_id, "128076")
+        await _react_req(req, "128076")
         self._log_finished(req, "ok", problem=pid)
         await self._finish_request(req)
 
 
 def get_group_lock_status(group_id: int) -> dict | None:
     _refresh_runtime()
-    coord = _coordinators.get(group_id)
+    coord = _coordinators.get(_coordinator_key(group_id))
     return coord.status() if coord else None
+
+
+def get_private_lock_status(user_id: int, group_id: int | None = None) -> dict | None:
+    _refresh_runtime()
+    coord = _coordinators.get(_coordinator_key(group_id or 0, scope=PRIVATE_SCOPE, user_id=user_id))
+    return coord.status() if coord else None
+
+
+def has_active_problem_request(
+    *,
+    scope: str,
+    group_id: int,
+    user_id: int,
+    pid: str,
+) -> bool:
+    _refresh_runtime()
+    coord = _coordinators.get(_coordinator_key(group_id, scope=scope, user_id=user_id))
+    if coord is None:
+        return False
+    target = str(pid or "")
+    for req in coord.active.values():
+        if req.user_id != user_id:
+            continue
+        if req.kind not in _USER_CONTEXT_WRITERS:
+            continue
+        if req.target_pid == target or req.submit_pid == target or req.review_pid == target:
+            return True
+    return False
 
 
 async def run_group_state_update(group_id: int, fn: Callable[[], T | Awaitable[T]]) -> T:
@@ -1314,23 +1444,37 @@ async def enqueue_submit_request(
     message_id: str,
     submission: str,
     event_log: dict | None = None,
+    *,
+    scope: str = GROUP_SCOPE,
 ) -> str:
-    coord = _get_coordinator(group_id)
+    coord = _get_coordinator(group_id, scope=scope, user_id=user_id)
     req: PendingRequest | None = None
     async with coord.lock:
         sb = load_scoreboard(group_id)
-        wait_window = effective_submit_delay_sec_for_scoreboard(user_id, sb)
-        posted_at = get_problem_posted_at(group_id)
-        if wait_window > 0 and posted_at is not None:
-            remaining = wait_window - (time.time() - posted_at)
-            if remaining > 0:
-                return _format_group_submit_message_for_remaining(
-                    user_id,
-                    int(math.ceil(remaining)),
-                )
-        problem = get_today_problem(group_id)
+        if scope == GROUP_SCOPE:
+            wait_window = effective_submit_delay_sec_for_scoreboard(user_id, sb)
+            posted_at = get_problem_posted_at(group_id)
+            if wait_window > 0 and posted_at is not None:
+                remaining = wait_window - (time.time() - posted_at)
+                if remaining > 0:
+                    return _format_group_submit_message_for_remaining(
+                        user_id,
+                        int(math.ceil(remaining)),
+                    )
+            problem = get_today_problem(group_id)
+        else:
+            problem = get_private_current_problem(user_id)
         submit_pid = problem.get("today", "") if problem else ""
-        already_solved = bool(submit_pid and _scoreboard_has_problem_solve(sb, submit_pid))
+        if scope == PRIVATE_SCOPE:
+            already_solved = bool(
+                submit_pid
+                and (
+                    is_private_solved(user_id, submit_pid)
+                    or is_group_problem_solved(group_id, submit_pid)
+                )
+            )
+        else:
+            already_solved = bool(submit_pid and _scoreboard_has_problem_solve(sb, submit_pid))
         req = PendingRequest(
             kind="submit",
             group_id=group_id,
@@ -1339,12 +1483,13 @@ async def enqueue_submit_request(
             message_id=message_id,
             command="submit",
             nickname=get_display_name(sender),
+            scope=scope,
             payload=submission,
             submit_pid=submit_pid,
             submit_problem=problem,
             target_pid=submit_pid,
             submit_already_solved_at_enqueue=already_solved,
-            submit_score_candidate=bool(submit_pid and not already_solved),
+            submit_score_candidate=bool(scope == GROUP_SCOPE and submit_pid and not already_solved),
             event_log=event_log,
         )
         coord._enqueue_locked(req)
@@ -1359,9 +1504,11 @@ async def enqueue_clarify_request(
     message_id: str,
     question: str,
     event_log: dict | None = None,
+    *,
+    scope: str = GROUP_SCOPE,
 ) -> None:
-    coord = _get_coordinator(group_id)
-    problem = get_today_problem(group_id)
+    coord = _get_coordinator(group_id, scope=scope, user_id=user_id)
+    problem = get_private_current_problem(user_id) if scope == PRIVATE_SCOPE else get_today_problem(group_id)
     pid = problem.get("today", "") if problem else ""
     req = PendingRequest(
         kind="clarify",
@@ -1371,6 +1518,7 @@ async def enqueue_clarify_request(
         message_id=message_id,
         command="clarify",
         nickname=get_display_name(sender),
+        scope=scope,
         payload=question,
         target_pid=pid,
         event_log=event_log,
@@ -1388,8 +1536,10 @@ async def enqueue_review_request(
     review_pid: str,
     mentioned_user_ids: list[int] | None = None,
     event_log: dict | None = None,
+    *,
+    scope: str = GROUP_SCOPE,
 ) -> None:
-    coord = _get_coordinator(group_id)
+    coord = _get_coordinator(group_id, scope=scope, user_id=user_id)
     req = PendingRequest(
         kind="review",
         group_id=group_id,
@@ -1398,6 +1548,7 @@ async def enqueue_review_request(
         message_id=message_id,
         command="review",
         nickname=get_display_name(sender),
+        scope=scope,
         payload=question,
         review_pid=review_pid,
         review_mentioned_user_ids=_unique_user_ids(mentioned_user_ids),
@@ -1414,9 +1565,11 @@ async def enqueue_clear_request(
     sender: dict,
     message_id: str,
     event_log: dict | None = None,
+    *,
+    scope: str = GROUP_SCOPE,
 ) -> None:
-    coord = _get_coordinator(group_id)
-    problem = get_today_problem(group_id)
+    coord = _get_coordinator(group_id, scope=scope, user_id=user_id)
+    problem = get_private_current_problem(user_id) if scope == PRIVATE_SCOPE else get_today_problem(group_id)
     pid = problem.get("today", "") if problem else ""
     req = PendingRequest(
         kind="clear",
@@ -1426,6 +1579,7 @@ async def enqueue_clear_request(
         message_id=message_id,
         command="clear",
         nickname=get_display_name(sender),
+        scope=scope,
         target_pid=pid,
         event_log=event_log,
     )
@@ -1433,31 +1587,102 @@ async def enqueue_clear_request(
     await req.done_event.wait()
 
 
+async def _redirect_blocked_group_submit_to_private(
+    group_id: int,
+    user_id: int,
+    sender: dict,
+    message_id: str,
+    submission: str,
+) -> bool:
+    problem = get_today_problem(group_id)
+    pid = str(problem.get("today", "") or "") if problem else ""
+    if not problem or not pid:
+        return False
+
+    set_private_current_problem(user_id, problem)
+    if not load_private_problem_history(user_id, pid):
+        group_history = group_problem_history(group_id, user_id, pid)
+        if group_history:
+            replace_private_problem_history(user_id, pid, copy_records(group_history))
+    first = not has_group_problem_private_notified(user_id, pid)
+    if first:
+        intro_id = await send_private_msg(user_id, build_plain_message(
+            "你现在还在群提交等待期，这次提交已转到 private judge；我也帮你把当前群题设好了。"
+        ))
+        if intro_id is None:
+            await send_group_msg(group_id, [
+                build_at(user_id),
+                build_text(" 我想把这次提交转到 private judge，但私聊发送失败了；这次先不撤回也不判题，检查一下是否能接收临时会话？"),
+            ])
+            return True
+        mark_group_problem_private_notified(user_id, pid)
+        await send_problem_card_private(user_id, group_id, problem, prefer_group_card=True)
+    else:
+        mark_group_problem_private_notified(user_id, pid)
+
+    repeated = await send_private_msg(user_id, build_plain_message(
+        f"刚才被撤回的提交内容：\n{submission}\n\n开始 judge～"
+    ))
+    if repeated is None:
+        await send_group_msg(group_id, [
+            build_at(user_id),
+            build_text(" 私聊复述提交失败了；这次先不撤回也不判题，联系管理员看一下私聊权限吧。"),
+        ])
+        return True
+
+    try:
+        await delete_msg(message_id)
+    except Exception:
+        logger.warning("[group_%s] failed to delete early starred submit %s", group_id, message_id)
+
+    await enqueue_submit_request(
+        group_id,
+        user_id,
+        sender,
+        message_id,
+        submission,
+        event_log=None,
+        scope=PRIVATE_SCOPE,
+    )
+    return True
+
+
 async def handle(group_id: int, user_id: int, sender: dict,
                  message_id: str, raw_text: str, segments: list,
                  event: dict) -> None:
     """Handle /submit command."""
     nickname = get_display_name(sender)
+    scope = PRIVATE_SCOPE if event.get("message_type") == "private" else GROUP_SCOPE
 
     stripped = raw_text.lstrip()
     match = re.match(r'/submit\s+', stripped)
     if not match:
-        await send_group_msg(group_id, build_plain_message(
-            f"@{nickname} 用法：/submit 你的做法。试试看？"
-        ))
+        if scope == PRIVATE_SCOPE:
+            await send_private_msg(user_id, build_plain_message("用法：/submit 你的做法。试试看？"))
+        else:
+            await send_group_msg(group_id, build_plain_message(
+                f"@{nickname} 用法：/submit 你的做法。试试看？"
+            ))
         return
 
     submission = stripped[match.end():].strip()
     if not submission:
-        await send_group_msg(group_id, build_plain_message(
-            f"@{nickname} /submit 后面要写你的做法呀，只发 /submit 我不知道你做了啥 😅"
-        ))
+        if scope == PRIVATE_SCOPE:
+            await send_private_msg(user_id, build_plain_message(
+                "/submit 后面要写你的做法呀，只发 /submit 我不知道你做了啥 ❤️"
+            ))
+        else:
+            await send_group_msg(group_id, build_plain_message(
+                f"@{nickname} /submit 后面要写你的做法呀，只发 /submit 我不知道你做了啥 😅"
+            ))
         return
 
     if is_curfew_active():
-        await send_group_msg(group_id, build_plain_message(
-            format_curfew_message()
-        ))
+        msg = format_curfew_message()
+        if scope == PRIVATE_SCOPE:
+            await send_private_msg(user_id, build_plain_message(msg))
+        else:
+            await send_group_msg(group_id, build_plain_message(msg))
         return
 
     blocked_message = await enqueue_submit_request(
@@ -1467,8 +1692,19 @@ async def handle(group_id: int, user_id: int, sender: dict,
         message_id,
         submission,
         event_log=event.get(EVENT_META_KEY),
+        scope=scope,
     )
     if blocked_message:
+        user_group = get_user_group(user_id)
+        if scope == GROUP_SCOPE and is_dynamic_submit_delay_enabled(user_group):
+            if await _redirect_blocked_group_submit_to_private(
+                group_id,
+                user_id,
+                sender,
+                message_id,
+                submission,
+            ):
+                return
         await send_group_msg(group_id, [
             build_at(user_id),
             build_text(f" {blocked_message}"),

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -1615,10 +1615,7 @@ async def _redirect_blocked_group_submit_to_private(
                 build_text(" 我想把这次提交转到 private judge，但私聊发送失败了；这次先不撤回也不判题，检查一下是否能接收临时会话？"),
             ])
             return True
-        mark_group_problem_private_notified(user_id, pid)
         await send_problem_card_private(user_id, group_id, problem, prefer_group_card=True)
-    else:
-        mark_group_problem_private_notified(user_id, pid)
 
     repeated = await send_private_msg(user_id, build_plain_message(
         f"刚才被撤回的提交内容：\n{submission}\n\n开始 judge～"
@@ -1629,6 +1626,8 @@ async def _redirect_blocked_group_submit_to_private(
             build_text(" 私聊复述提交失败了；这次先不撤回也不判题，联系管理员看一下私聊权限吧。"),
         ])
         return True
+
+    mark_group_problem_private_notified(user_id, pid)
 
     try:
         await delete_msg(message_id)

--- a/src/kouhai_bot/handlers/cmd/sync.py
+++ b/src/kouhai_bot/handlers/cmd/sync.py
@@ -1,0 +1,220 @@
+"""/sync — copy current-problem history between group and private judge."""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from .. import registry
+from ..registry import CommandDef
+from ...napcat.client import build_at, build_plain_message, build_text, send_group_msg, send_private_msg
+from ...private_judge import (
+    GROUP_SCOPE,
+    PRIVATE_SCOPE,
+    copy_records,
+    current_group_pid,
+    get_private_current_pid,
+    group_problem_history,
+    is_group_problem_solved,
+    load_private_problem_history,
+    mark_private_solved,
+    private_record_has_correct,
+    replace_group_problem_clarifies,
+    replace_group_problem_history,
+    replace_private_problem_clarifies,
+    replace_private_problem_history,
+    send_history_card,
+)
+from ...user_groups import get_user_group, is_dynamic_submit_delay_enabled
+from ..shared import (
+    fetch_group_member_nickname_map,
+    format_points,
+    get_today_problem,
+    load_known_problem_ratings,
+    load_scoreboard,
+    rating_to_points,
+)
+from .submit import (
+    _update_scoreboard_for_pid,
+    has_active_problem_request,
+    run_group_state_update,
+)
+from ...editorial_followup import schedule_post_solve_editorial_followup
+
+logger = logging.getLogger("kouhai-bot.cmd.sync")
+
+
+def _is_starred_limited(user_id: int) -> bool:
+    return is_dynamic_submit_delay_enabled(get_user_group(user_id))
+
+
+def _only_clarifies(records: list[dict]) -> list[dict]:
+    return [item for item in records if item.get("type") == "clarify"]
+
+
+async def _send_text(scope: str, group_id: int, user_id: int, text: str) -> None:
+    if scope == PRIVATE_SCOPE:
+        await send_private_msg(user_id, build_plain_message(text))
+    else:
+        await send_group_msg(group_id, [build_at(user_id), build_text(f" {text}")])
+
+
+async def _score_synced_private_ac(group_id: int, user_id: int, sender: dict, pid: str) -> str:
+    problem = get_today_problem(group_id)
+    if not problem or str(problem.get("today", "") or "") != pid:
+        return ""
+    if is_group_problem_solved(group_id, pid):
+        return "群里已经有人先通过这题了，本次只同步记录，不再加分。"
+
+    nickname = sender.get("card") or sender.get("nickname") or str(user_id)
+
+    def _update():
+        sb = load_scoreboard(group_id)
+        if any(str(item.get("problem", "") or "") == pid for item in sb.get("solves", [])):
+            return None
+        return _update_scoreboard_for_pid(group_id, user_id, nickname, pid, problem)
+
+    updated = await run_group_state_update(group_id, _update)
+    if updated is None:
+        return "群里已经有人先通过这题了，本次只同步记录，不再加分。"
+    is_fb, solved, top5, sb = updated
+    ranked = []
+    try:
+        user_group = get_user_group(user_id)
+        from ..shared import build_scoreboard_entries
+        ranked = build_scoreboard_entries(group_id, sb, user_group_name=user_group.name)
+    except Exception:
+        ranked = []
+    current_entry = next((entry for entry in ranked if str(entry["user_id"]) == str(user_id)), None)
+    rating = load_known_problem_ratings(group_id, {pid}).get(pid)
+    rank = int(current_entry["rank"]) if current_entry else 1
+    total_score = format_points(float(current_entry["score"])) if current_entry else "0"
+    score_gain = format_points(rating_to_points(rating)) if rating is not None else "0"
+    cheer = (
+        f"恭喜拿下本题一血！🎉 本题 +{score_gain} 分（共 {solved} 题，总分 {total_score}），当前第 {rank}"
+        if is_fb
+        else f"做对了！🎉 本题 +{score_gain} 分（共 {solved} 题，总分 {total_score}），当前第 {rank}"
+    )
+    lines = [cheer]
+    if top5:
+        nickname_map = await fetch_group_member_nickname_map(group_id)
+        lines.extend(["", "🏆 Top 5："])
+        for entry in top5:
+            uid = str(entry["user_id"])
+            name = nickname_map.get(uid) or entry["nickname"] or uid
+            lines.append(
+                f"{entry['rank']}. {name} ({entry['solved']} 题，{format_points(entry['score'])} 分)"
+            )
+    schedule_post_solve_editorial_followup(group_id, pid)
+    return "\n".join(lines)
+
+
+async def handle(group_id: int, user_id: int, sender: dict,
+                 message_id: str, raw_text: str, segments: list,
+                 event: dict) -> None:
+    if not re.fullmatch(r"/sync(?:\s+)?", raw_text.strip()):
+        await _send_text(
+            PRIVATE_SCOPE if event.get("message_type") == "private" else GROUP_SCOPE,
+            group_id,
+            user_id,
+            "用法：/sync",
+        )
+        return
+
+    target_scope = PRIVATE_SCOPE if event.get("message_type") == "private" else GROUP_SCOPE
+    source_scope = GROUP_SCOPE if target_scope == PRIVATE_SCOPE else PRIVATE_SCOPE
+    pid = get_private_current_pid(user_id) if target_scope == PRIVATE_SCOPE else current_group_pid(group_id)
+    group_pid = current_group_pid(group_id)
+
+    if not pid:
+        await _send_text(target_scope, group_id, user_id, "当前这边还没有题目，不能 sync。")
+        return
+    if not group_pid or pid != group_pid:
+        await _send_text(
+            target_scope,
+            group_id,
+            user_id,
+            "只有当前服务群题目可以 sync；其他 private 题会一直留在 private judge 里。",
+        )
+        return
+
+    if has_active_problem_request(scope=GROUP_SCOPE, group_id=group_id, user_id=user_id, pid=pid) \
+            or has_active_problem_request(scope=PRIVATE_SCOPE, group_id=group_id, user_id=user_id, pid=pid):
+        await _send_text(target_scope, group_id, user_id, "这题还有请求正在处理中，等它结束后再 /sync 吧。")
+        return
+
+    if source_scope == PRIVATE_SCOPE:
+        source_records = load_private_problem_history(user_id, pid)
+        source_label = "private judge"
+    else:
+        source_records = group_problem_history(group_id, user_id, pid)
+        source_label = "群聊"
+
+    starred_limited = _is_starred_limited(user_id)
+    if starred_limited:
+        source_records = _only_clarifies(source_records)
+
+    if not source_records:
+        if starred_limited:
+            await _send_text(
+                target_scope,
+                group_id,
+                user_id,
+                "对面没有可同步的 clarify 记录，本次 sync 已取消，没有覆盖任何历史。",
+            )
+        else:
+            await _send_text(
+                target_scope,
+                group_id,
+                user_id,
+                "对面没有这道题的历史记录，本次 sync 已取消，没有覆盖任何历史。",
+            )
+        return
+
+    records_to_copy = copy_records(source_records)
+    if target_scope == GROUP_SCOPE:
+        def _replace_group_records() -> None:
+            if starred_limited:
+                replace_group_problem_clarifies(group_id, user_id, pid, records_to_copy)
+            else:
+                replace_group_problem_history(group_id, user_id, pid, records_to_copy)
+
+        await run_group_state_update(group_id, _replace_group_records)
+    else:
+        if starred_limited:
+            replace_private_problem_clarifies(user_id, pid, records_to_copy)
+        else:
+            replace_private_problem_history(user_id, pid, records_to_copy)
+        if source_scope == GROUP_SCOPE and is_group_problem_solved(group_id, pid):
+            mark_private_solved(user_id, pid, source="group")
+
+    await send_history_card(
+        destination=target_scope,
+        user_id=user_id,
+        group_id=group_id,
+        records=source_records,
+        source_label=source_label,
+    )
+
+    extra = ""
+    if target_scope == GROUP_SCOPE and source_scope == PRIVATE_SCOPE and not starred_limited:
+        if private_record_has_correct(source_records, pid):
+            extra = await _score_synced_private_ac(group_id, user_id, sender, pid)
+    elif starred_limited:
+        extra = "打星模式下本次只同步 clarify，submit/review/通过记录已忽略。"
+
+    text = "已同步完成。"
+    if extra:
+        text += "\n" + extra
+    await _send_text(target_scope, group_id, user_id, text)
+
+
+def register() -> None:
+    registry.register(CommandDef(
+        name="sync",
+        aliases=[],
+        description="在群聊和 private judge 间同步当前群题记录（另一侧覆盖当前侧）",
+        usage="",
+        handler=handle,
+        cooldown=3,
+    ))

--- a/src/kouhai_bot/handlers/cmd/sync.py
+++ b/src/kouhai_bot/handlers/cmd/sync.py
@@ -52,6 +52,17 @@ def _only_clarifies(records: list[dict]) -> list[dict]:
     return [item for item in records if item.get("type") == "clarify"]
 
 
+async def _history_display_name(group_id: int, user_id: int, sender: dict) -> str:
+    try:
+        nickname_map = await fetch_group_member_nickname_map(group_id)
+        name = nickname_map.get(str(user_id))
+        if name:
+            return name
+    except Exception:
+        pass
+    return sender.get("card") or sender.get("nickname") or str(user_id)
+
+
 async def _send_text(scope: str, group_id: int, user_id: int, text: str) -> None:
     if scope == PRIVATE_SCOPE:
         await send_private_msg(user_id, build_plain_message(text))
@@ -145,10 +156,8 @@ async def handle(group_id: int, user_id: int, sender: dict,
 
     if source_scope == PRIVATE_SCOPE:
         source_records = load_private_problem_history(user_id, pid)
-        source_label = "private judge"
     else:
         source_records = group_problem_history(group_id, user_id, pid)
-        source_label = "群聊"
 
     starred_limited = _is_starred_limited(user_id)
     if starred_limited:
@@ -193,7 +202,7 @@ async def handle(group_id: int, user_id: int, sender: dict,
         user_id=user_id,
         group_id=group_id,
         records=source_records,
-        source_label=source_label,
+        user_display_name=await _history_display_name(group_id, user_id, sender),
     )
 
     extra = ""

--- a/src/kouhai_bot/handlers/cmd/sync.py
+++ b/src/kouhai_bot/handlers/cmd/sync.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import logging
 import re
+from collections import Counter
 
 from .. import registry
 from ..registry import CommandDef
-from ...napcat.client import build_at, build_plain_message, build_text, send_group_msg, send_private_msg
+from ...eventlog import EVENT_META_KEY, log_command_finished
+from ...napcat.client import build_at, build_plain_message, build_text, react_emoji, send_group_msg, send_private_msg
 from ...private_judge import (
     GROUP_SCOPE,
     PRIVATE_SCOPE,
@@ -35,6 +37,7 @@ from ..shared import (
     rating_to_points,
 )
 from .submit import (
+    _reveal_problem_source,
     _update_scoreboard_for_pid,
     has_active_problem_request,
     run_group_state_update,
@@ -42,6 +45,7 @@ from .submit import (
 from ...editorial_followup import schedule_post_solve_editorial_followup
 
 logger = logging.getLogger("kouhai-bot.cmd.sync")
+OK_REACTION_ID = "128076"
 
 
 def _is_starred_limited(user_id: int) -> bool:
@@ -70,12 +74,29 @@ async def _send_text(scope: str, group_id: int, user_id: int, text: str) -> None
         await send_group_msg(group_id, [build_at(user_id), build_text(f" {text}")])
 
 
-async def _score_synced_private_ac(group_id: int, user_id: int, sender: dict, pid: str) -> str:
+async def _react_group_success(message_id: str) -> None:
+    try:
+        await react_emoji(message_id, OK_REACTION_ID)
+    except Exception as e:
+        logger.warning("failed to react to successful sync %s: %s", message_id, e)
+
+
+def _synced_record_counts(records: list[dict], *, scored_correct: bool) -> dict[str, int]:
+    counter = Counter(str(item.get("type", "") or "") for item in records if isinstance(item, dict))
+    return {
+        "synced_submit_count": int(counter.get("submit", 0)),
+        "synced_clarify_count": int(counter.get("clarify", 0)),
+        "synced_review_count": int(counter.get("review", 0)),
+        "synced_correct_count": 1 if scored_correct else 0,
+    }
+
+
+async def _score_synced_private_ac(group_id: int, user_id: int, sender: dict, pid: str) -> tuple[str, bool]:
     problem = get_today_problem(group_id)
     if not problem or str(problem.get("today", "") or "") != pid:
-        return ""
+        return "", False
     if is_group_problem_solved(group_id, pid):
-        return "群里已经有人先通过这题了，本次只同步记录，不再加分。"
+        return "群里已经有人先通过这题了，本次只同步记录，不再加分。", False
 
     nickname = sender.get("card") or sender.get("nickname") or str(user_id)
 
@@ -87,7 +108,7 @@ async def _score_synced_private_ac(group_id: int, user_id: int, sender: dict, pi
 
     updated = await run_group_state_update(group_id, _update)
     if updated is None:
-        return "群里已经有人先通过这题了，本次只同步记录，不再加分。"
+        return "群里已经有人先通过这题了，本次只同步记录，不再加分。", False
     is_fb, solved, top5, sb = updated
     ranked = []
     try:
@@ -116,8 +137,11 @@ async def _score_synced_private_ac(group_id: int, user_id: int, sender: dict, pi
             lines.append(
                 f"{entry['rank']}. {name} ({entry['solved']} 题，{format_points(entry['score'])} 分)"
             )
+    reveal = await _reveal_problem_source(group_id)
+    if reveal:
+        lines.extend(["", reveal])
     schedule_post_solve_editorial_followup(group_id, pid)
-    return "\n".join(lines)
+    return "\n".join(lines), True
 
 
 async def handle(group_id: int, user_id: int, sender: dict,
@@ -206,16 +230,27 @@ async def handle(group_id: int, user_id: int, sender: dict,
     )
 
     extra = ""
+    scored_correct = False
     if target_scope == GROUP_SCOPE and source_scope == PRIVATE_SCOPE and not starred_limited:
         if private_record_has_correct(source_records, pid):
-            extra = await _score_synced_private_ac(group_id, user_id, sender, pid)
+            extra, scored_correct = await _score_synced_private_ac(group_id, user_id, sender, pid)
     elif starred_limited:
         extra = "打星模式下本次只同步 clarify，submit/review/通过记录已忽略。"
 
-    text = "已同步完成。"
-    if extra:
-        text += "\n" + extra
-    await _send_text(target_scope, group_id, user_id, text)
+    if target_scope == GROUP_SCOPE:
+        await _react_group_success(message_id)
+        log_command_finished(
+            event.get(EVENT_META_KEY),
+            status="correct" if scored_correct else "synced",
+            problem=pid,
+            extra={
+                **_synced_record_counts(source_records, scored_correct=scored_correct),
+                "source_scope": source_scope,
+                "target_scope": target_scope,
+            },
+        )
+        if extra:
+            await _send_text(target_scope, group_id, user_id, extra)
 
 
 def register() -> None:

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -20,6 +20,12 @@ from ..llm import ChatCompletionResult, chat_completion
 
 logger = logging.getLogger("kouhai-bot.shared")
 
+HIGH_DIFFICULTY_RATING_THRESHOLD = 2800
+HIGH_DIFFICULTY_NOTICE = (
+    "这道题的难度较高，bot 的推理能力可能受限。"
+    "如果你觉得 bot 说得不对，请查看题解～"
+)
+
 # ── LLM API ─────────────────────────────────────────────────────────────
 
 
@@ -402,6 +408,15 @@ def _coerce_int(value) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def high_difficulty_notice(problem: dict | None) -> str:
+    if not isinstance(problem, dict):
+        return ""
+    rating = _coerce_int(problem.get("rating"))
+    if rating is not None and rating > HIGH_DIFFICULTY_RATING_THRESHOLD:
+        return HIGH_DIFFICULTY_NOTICE
+    return ""
 
 
 def load_problem_ratings(group_id: int) -> dict[str, int]:

--- a/src/kouhai_bot/napcat/client.py
+++ b/src/kouhai_bot/napcat/client.py
@@ -86,6 +86,19 @@ async def send_private_msg(user_id: int, message: list[dict]) -> int | None:
         return None
 
 
+async def send_private_forward_msg(user_id: int, messages: list[dict]) -> int | None:
+    """Forward messages as a merged card to a private chat."""
+    try:
+        result = await _http_post("send_private_forward_msg", {
+            "user_id": user_id,
+            "messages": messages,
+        })
+        return _extract_message_id("send_private_forward_msg", result)
+    except Exception as e:
+        logger.error(f"send_private_forward_msg failed: {e}", exc_info=True)
+        return None
+
+
 async def react_emoji(message_id: str, emoji_id: str) -> None:
     """React with an emoji to a message."""
     try:
@@ -130,6 +143,10 @@ def build_text(text: str) -> dict:
 
 def build_at(qq: int) -> dict:
     return {"type": "at", "data": {"qq": str(qq)}}
+
+
+def build_face(emoji_id: str | int) -> dict:
+    return {"type": "face", "data": {"id": str(emoji_id)}}
 
 
 def build_plain_message(text: str) -> list[dict]:

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -662,7 +662,8 @@ def format_history_records(records: list[dict], *, user_display_name: str) -> st
         content = _one_line(item.get("content", ""))
         reply = _one_line(item.get("reply", ""))
         if content and reply:
-            lines.append(f"👤：{content}   🤖：{reply}")
+            lines.append(f"👤：{content}")
+            lines.append(f"🤖：{reply}")
         elif content:
             lines.append(f"👤：{content}")
         elif reply:

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -1,0 +1,729 @@
+"""Private judge state, problem resolution, and private-card helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import random
+import re
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import cloudscraper
+
+from .config import get_config
+from .handlers.shared import (
+    get_problem_summary,
+    get_today_problem,
+    load_scoreboard,
+    save_problem_summary,
+    summarize_problem,
+    translate_sample_notes,
+)
+from .napcat.client import (
+    build_plain_message,
+    send_group_forward_msg,
+    send_group_msg,
+    send_private_forward_msg,
+    send_private_msg,
+)
+from .problems.picker import _normalize_sample_block
+
+logger = logging.getLogger("kouhai-bot.private_judge")
+
+TZ = timezone(timedelta(hours=8))
+PRIVATE_SCOPE = "private"
+GROUP_SCOPE = "group"
+PRIVATE_FORWARD_THRESHOLD = 3000
+
+_CF_API = "https://codeforces.com/api/problemset.problems"
+_PROBLEM_RE = re.compile(r"^(?:CF)?(\d+)([A-Za-z][A-Za-z0-9]*)$", re.I)
+_PROBLEMSET_URL_RE = re.compile(
+    r"https?://(?:www\.)?codeforces\.com/problemset/problem/(\d+)/([A-Za-z0-9]+)",
+    re.I,
+)
+_CONTEST_URL_RE = re.compile(
+    r"https?://(?:www\.)?codeforces\.com/contest/(\d+)/problem/([A-Za-z0-9]+)",
+    re.I,
+)
+
+
+def _data_dir() -> Path:
+    return Path(get_config().data_dir)
+
+
+def _user_dir(user_id: int) -> Path:
+    path = _data_dir() / "private_judge" / "users"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _state_file(user_id: int) -> Path:
+    return _user_dir(user_id) / f"{int(user_id)}.json"
+
+
+def _default_state() -> dict[str, Any]:
+    return {
+        "current_problem": None,
+        "user_submissions": [],
+        "solved_problems": {},
+        "last_solved_problem": "",
+        "notified_group_problem_private": {},
+        "problem_cards": {},
+    }
+
+
+def load_private_state(user_id: int) -> dict[str, Any]:
+    path = _state_file(user_id)
+    if not path.exists():
+        return _default_state()
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return _default_state()
+    except Exception:
+        return _default_state()
+
+    state = _default_state()
+    state.update(data)
+    if not isinstance(state.get("user_submissions"), list):
+        state["user_submissions"] = []
+    if not isinstance(state.get("solved_problems"), dict):
+        state["solved_problems"] = {}
+    if not isinstance(state.get("notified_group_problem_private"), dict):
+        state["notified_group_problem_private"] = {}
+    if not isinstance(state.get("problem_cards"), dict):
+        state["problem_cards"] = {}
+    return state
+
+
+def save_private_state(user_id: int, state: dict[str, Any]) -> None:
+    path = _state_file(user_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(state, f, ensure_ascii=False, indent=2)
+
+
+def get_private_current_problem(user_id: int) -> dict | None:
+    problem = load_private_state(user_id).get("current_problem")
+    return problem if isinstance(problem, dict) else None
+
+
+def set_private_current_problem(user_id: int, problem: dict) -> None:
+    state = load_private_state(user_id)
+    state["current_problem"] = dict(problem)
+    save_private_state(user_id, state)
+
+
+def get_private_current_pid(user_id: int) -> str:
+    problem = get_private_current_problem(user_id)
+    return str(problem.get("today", "") or "") if problem else ""
+
+
+def load_private_submissions(user_id: int) -> list[dict]:
+    items = load_private_state(user_id).get("user_submissions", [])
+    return [item for item in items if isinstance(item, dict)]
+
+
+def load_private_problem_history(user_id: int, pid: str) -> list[dict]:
+    target = str(pid or "")
+    items = [
+        item for item in load_private_submissions(user_id)
+        if str(item.get("problem", "") or "") == target
+    ]
+    return sorted(items, key=lambda item: str(item.get("timestamp", "")))
+
+
+def save_private_submission(user_id: int, submission: dict) -> None:
+    state = load_private_state(user_id)
+    items = state.setdefault("user_submissions", [])
+    request_id = str(submission.get("request_id", "") or "")
+    if request_id:
+        for idx in range(len(items) - 1, -1, -1):
+            existing = items[idx]
+            if isinstance(existing, dict) and str(existing.get("request_id", "") or "") == request_id:
+                items[idx] = submission
+                break
+        else:
+            items.append(submission)
+    else:
+        items.append(submission)
+    save_private_state(user_id, state)
+
+
+def replace_private_problem_history(user_id: int, pid: str, records: list[dict]) -> None:
+    state = load_private_state(user_id)
+    target = str(pid or "")
+    kept = [
+        item for item in state.get("user_submissions", [])
+        if not isinstance(item, dict) or str(item.get("problem", "") or "") != target
+    ]
+    state["user_submissions"] = kept + [dict(item) for item in records]
+    save_private_state(user_id, state)
+
+
+def replace_private_problem_clarifies(user_id: int, pid: str, records: list[dict]) -> None:
+    state = load_private_state(user_id)
+    target = str(pid or "")
+    kept = []
+    for item in state.get("user_submissions", []):
+        if not isinstance(item, dict):
+            kept.append(item)
+            continue
+        if str(item.get("problem", "") or "") == target and item.get("type") == "clarify":
+            continue
+        kept.append(item)
+    state["user_submissions"] = kept + [dict(item) for item in records]
+    save_private_state(user_id, state)
+
+
+def clear_private_problem_history(user_id: int, pid: str) -> int:
+    state = load_private_state(user_id)
+    target = str(pid or "")
+    existing = state.get("user_submissions", [])
+    kept = [
+        item for item in existing
+        if not isinstance(item, dict) or str(item.get("problem", "") or "") != target
+    ]
+    removed = len(existing) - len(kept)
+    state["user_submissions"] = kept
+    save_private_state(user_id, state)
+    return removed
+
+
+def mark_private_solved(user_id: int, pid: str, *, source: str = "private") -> None:
+    target = str(pid or "")
+    if not target:
+        return
+    state = load_private_state(user_id)
+    solved = state.setdefault("solved_problems", {})
+    if not isinstance(solved.get(target), dict):
+        solved[target] = {}
+    solved[target].update({
+        "timestamp": int(time.time()),
+        "source": source,
+    })
+    state["last_solved_problem"] = target
+    save_private_state(user_id, state)
+
+
+def is_private_solved(user_id: int, pid: str) -> bool:
+    solved = load_private_state(user_id).get("solved_problems", {})
+    return isinstance(solved, dict) and str(pid or "") in solved
+
+
+def is_group_problem_solved(group_id: int, pid: str) -> bool:
+    target = str(pid or "")
+    if not target:
+        return False
+    sb = load_scoreboard(group_id)
+    return any(str(item.get("problem", "") or "") == target for item in sb.get("solves", []))
+
+
+def get_private_review_pid(user_id: int, group_id: int) -> str:
+    current_pid = get_private_current_pid(user_id)
+    if current_pid and (is_private_solved(user_id, current_pid) or is_group_problem_solved(group_id, current_pid)):
+        return current_pid
+    state = load_private_state(user_id)
+    last = str(state.get("last_solved_problem", "") or "")
+    if last:
+        return last
+    solved = state.get("solved_problems", {})
+    if isinstance(solved, dict) and solved:
+        return sorted(solved.keys())[-1]
+    return ""
+
+
+def mark_group_problem_private_notified(user_id: int, pid: str) -> bool:
+    """Mark first group-to-private redirect notice for pid.
+
+    Returns True when this is the first mark for this user/problem.
+    """
+    target = str(pid or "")
+    if not target:
+        return False
+    state = load_private_state(user_id)
+    notified = state.setdefault("notified_group_problem_private", {})
+    first = not bool(notified.get(target))
+    notified[target] = int(time.time())
+    save_private_state(user_id, state)
+    return first
+
+
+def has_group_problem_private_notified(user_id: int, pid: str) -> bool:
+    target = str(pid or "")
+    if not target:
+        return False
+    notified = load_private_state(user_id).get("notified_group_problem_private", {})
+    return isinstance(notified, dict) and bool(notified.get(target))
+
+
+def parse_problem_ref(text: str) -> tuple[int, str] | None:
+    value = (text or "").strip()
+    if not value:
+        return None
+    for pattern in (_PROBLEMSET_URL_RE, _CONTEST_URL_RE):
+        match = pattern.search(value)
+        if match:
+            return int(match.group(1)), match.group(2).upper()
+    match = _PROBLEM_RE.fullmatch(value)
+    if match:
+        return int(match.group(1)), match.group(2).upper()
+    return None
+
+
+def problem_id_from_ref(contest_id: int, index: str) -> str:
+    return f"{int(contest_id)}{str(index).upper()}"
+
+
+def _statement_path(pid: str) -> Path:
+    return _data_dir() / "statements" / f"{pid}.json"
+
+
+def load_statement_json(pid: str) -> dict:
+    path = _statement_path(pid)
+    if not path.exists():
+        return {}
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _problem_id(problem: dict) -> str:
+    contest_id = problem.get("contestId")
+    index = problem.get("index")
+    if contest_id in (None, "") or not index:
+        return ""
+    return f"{contest_id}{str(index).upper()}"
+
+
+def _cached_problem_by_pid(pid: str) -> dict | None:
+    for cache_path in sorted(_data_dir().glob("cf_all_*_*.json")):
+        try:
+            with cache_path.open(encoding="utf-8") as f:
+                items = json.load(f)
+        except Exception:
+            continue
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if isinstance(item, dict) and _problem_id(item) == pid:
+                return item
+    return None
+
+
+def _fetch_problemset() -> list[dict]:
+    scraper = cloudscraper.create_scraper()
+    resp = scraper.get(_CF_API, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    if data.get("status") != "OK":
+        raise RuntimeError(f"CF API error: {data}")
+    result = data.get("result", {})
+    problems = result.get("problems", [])
+    return problems if isinstance(problems, list) else []
+
+
+def _fetch_problem_by_pid(pid: str) -> dict | None:
+    for item in _fetch_problemset():
+        if isinstance(item, dict) and _problem_id(item) == pid:
+            return item
+    return None
+
+
+def _ensure_statement(problem: dict) -> dict:
+    from .problems import picker
+
+    cfg = get_config()
+    picker.STATE_DIR = cfg.data_dir
+    picker.CACHE_DIR = os.path.join(cfg.data_dir, "statements")
+    picker.GROUPS_DIR = os.path.join(cfg.data_dir, "groups")
+    os.makedirs(picker.CACHE_DIR, exist_ok=True)
+    os.makedirs(picker.GROUPS_DIR, exist_ok=True)
+    stmt = picker.fetch_statement(problem)
+    return stmt if isinstance(stmt, dict) else {}
+
+
+def resolve_problem_by_pid(pid: str) -> dict:
+    target = str(pid or "").strip().upper()
+    if not target:
+        raise ValueError("empty problem id")
+    parsed = parse_problem_ref(target)
+    if not parsed:
+        raise ValueError("bad problem id")
+    contest_id, index = parsed
+    normalized_pid = problem_id_from_ref(contest_id, index)
+    problem = _cached_problem_by_pid(normalized_pid)
+    if problem is None:
+        try:
+            problem = _fetch_problem_by_pid(normalized_pid)
+        except Exception as e:
+            logger.warning("failed to fetch CF metadata for %s: %s", normalized_pid, e)
+            problem = None
+    if problem is None:
+        problem = {
+            "contestId": contest_id,
+            "index": index,
+            "name": "",
+            "rating": "?",
+            "tags": [],
+        }
+
+    stmt = load_statement_json(normalized_pid)
+    if not stmt:
+        stmt = _ensure_statement(problem)
+    if not stmt:
+        raise RuntimeError("statement unavailable")
+
+    state = {
+        "today": normalized_pid,
+        "contestId": contest_id,
+        "index": index,
+        "name": problem.get("name") or stmt.get("name", ""),
+        "rating": problem.get("rating", "?"),
+        "tags": problem.get("tags", []),
+        "date": datetime.now(TZ).strftime("%Y-%m-%d"),
+    }
+    return state
+
+
+def resolve_random_problem(group_id: int) -> dict:
+    from .handlers.cmd.newproblem import _effective_rating_range
+
+    min_rating, max_rating = _effective_rating_range(group_id)
+    candidates: list[dict] = []
+    for item in _fetch_problemset():
+        if not isinstance(item, dict):
+            continue
+        rating = item.get("rating")
+        tags = item.get("tags", [])
+        if rating is None or not (min_rating <= int(rating) <= max_rating):
+            continue
+        if "*special" in tags:
+            continue
+        candidates.append(item)
+    if not candidates:
+        raise RuntimeError("no random candidates")
+
+    random.shuffle(candidates)
+    last_error: Exception | None = None
+    for problem in candidates[:20]:
+        pid = _problem_id(problem)
+        try:
+            stmt = load_statement_json(pid) or _ensure_statement(problem)
+            if stmt:
+                return {
+                    "today": pid,
+                    "contestId": problem["contestId"],
+                    "index": str(problem["index"]).upper(),
+                    "name": problem.get("name", ""),
+                    "rating": problem.get("rating", "?"),
+                    "tags": problem.get("tags", []),
+                    "date": datetime.now(TZ).strftime("%Y-%m-%d"),
+                }
+        except Exception as e:
+            last_error = e
+            logger.warning("random private problem %s unavailable: %s", pid, e)
+    raise RuntimeError(f"no statement-ready random candidate: {last_error}")
+
+
+def _build_sample_messages(stmt: dict) -> list[str]:
+    samples = stmt.get("samples")
+    if not isinstance(samples, list):
+        return []
+    messages: list[str] = []
+    for idx, sample in enumerate(samples, 1):
+        if not isinstance(sample, dict):
+            continue
+        sample_input = _normalize_sample_block(sample.get("input", "")).rstrip("\n")
+        sample_output = _normalize_sample_block(sample.get("output", "")).rstrip("\n")
+        if not sample_input and not sample_output:
+            continue
+        messages.append(
+            f"样例 {idx}\n"
+            f"Input:\n{sample_input}\n\n"
+            f"Output:\n{sample_output}"
+        )
+    return messages
+
+
+async def _build_notes_message(stmt: dict) -> str:
+    raw_notes = _normalize_sample_block(stmt.get("notes", ""))
+    if not raw_notes:
+        return ""
+    try:
+        translated, _tag = await translate_sample_notes(raw_notes)
+    except Exception:
+        translated = ""
+    text = (translated or raw_notes).strip()
+    return f"样例解释：\n{text}" if text else ""
+
+
+async def _problem_summary(group_id: int, pid: str, stmt: dict) -> str:
+    summary = get_problem_summary(group_id, pid)
+    if summary:
+        return summary
+    stmt_text = stmt.get("description", "") or ""
+    input_text = stmt.get("input", "") or ""
+    tl = stmt.get("time_limit", "?")
+    ml = stmt.get("memory_limit", "?")
+    result, model_tag = await summarize_problem(stmt_text, input_text, f"Time: {tl}, Memory: {ml}")
+    summary = (result or "").strip()
+    if summary:
+        if model_tag:
+            summary += model_tag
+        save_problem_summary(group_id, pid, summary)
+    return summary
+
+
+async def build_problem_card_payload(group_id: int, problem: dict, *, greeting: str = "private judge 题目") -> dict:
+    pid = str(problem.get("today", "") or "")
+    stmt = load_statement_json(pid)
+    if not stmt:
+        stmt = _ensure_statement(problem)
+    summary = await _problem_summary(group_id, pid, stmt) if stmt else ""
+    stmt_name = stmt.get("name", "") if stmt else ""
+    name = str(problem.get("name", "") or stmt_name)
+    rating = str(problem.get("rating", "") or "")
+    title_parts = [f"{greeting}：CF{pid}"]
+    if name:
+        title_parts.append(name)
+    if rating and rating != "?":
+        title_parts.append(f"rating {rating}")
+    post_msg = " ".join(title_parts)
+    if summary:
+        post_msg += "\n\n" + summary
+    return {
+        "pid": pid,
+        "post_msg": post_msg,
+        "sample_messages": _build_sample_messages(stmt),
+        "notes_message": await _build_notes_message(stmt),
+        "snake_enabled": False,
+    }
+
+
+def _daily_msg_path(group_id: int) -> Path:
+    return _data_dir() / "groups" / str(group_id) / "daily_msg.json"
+
+
+def load_current_group_card_payload(group_id: int, pid: str) -> dict | None:
+    path = _daily_msg_path(group_id)
+    if not path.exists():
+        return None
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return None
+    if not isinstance(data, dict) or str(data.get("pid", "") or "") != str(pid or ""):
+        return None
+    return data
+
+
+async def _send_forward_nodes_private(user_id: int, node_ids: list[str]) -> int | None:
+    if not node_ids:
+        return None
+    await asyncio.sleep(0.5)
+    return await send_private_forward_msg(
+        user_id,
+        [{"type": "node", "data": {"id": str(node_id)}} for node_id in node_ids],
+    )
+
+
+async def _send_forward_nodes_group(group_id: int, node_ids: list[str]) -> int | None:
+    if not node_ids:
+        return None
+    await asyncio.sleep(0.5)
+    return await send_group_forward_msg(
+        group_id,
+        [{"type": "node", "data": {"id": str(node_id)}} for node_id in node_ids],
+    )
+
+
+async def send_problem_card_private(user_id: int, group_id: int, problem: dict, *, prefer_group_card: bool = True) -> bool:
+    cfg = get_config()
+    pid = str(problem.get("today", "") or "")
+    payload = load_current_group_card_payload(group_id, pid) if prefer_group_card else None
+    if payload is None:
+        try:
+            payload = await build_problem_card_payload(group_id, problem)
+        except Exception as e:
+            logger.warning("failed to build private problem card for %s: %s", pid, e)
+            await send_private_msg(user_id, build_plain_message(
+                f"题目 CF{pid} 已设置，但题面暂时拉不到，稍后再试试 /problem。"
+            ))
+            return False
+
+    node_ids: list[str] = []
+    msg_id = payload.get("msg_id")
+    if msg_id:
+        node_ids.append(str(msg_id))
+        for sample_id in payload.get("sample_msg_ids", []) if isinstance(payload.get("sample_msg_ids"), list) else []:
+            if sample_id:
+                node_ids.append(str(sample_id))
+        for key in ("note_msg_id", "snake_msg_id"):
+            value = payload.get(key)
+            if value:
+                node_ids.append(str(value))
+        if await _send_forward_nodes_private(user_id, node_ids):
+            return True
+
+    post_msg = payload.get("post_msg")
+    sample_messages = payload.get("sample_messages")
+    notes_message = payload.get("notes_message")
+    if not isinstance(post_msg, str):
+        post_msg = f"当前题目：CF{pid}"
+    if not isinstance(sample_messages, list):
+        sample_messages = []
+    if not isinstance(notes_message, str):
+        notes_message = ""
+
+    node_ids = []
+    for text in [post_msg, *[str(item) for item in sample_messages], notes_message]:
+        if not text:
+            continue
+        resp = await send_private_msg(cfg.bot_qq, build_plain_message(text))
+        if resp:
+            node_ids.append(str(resp))
+    if await _send_forward_nodes_private(user_id, node_ids):
+        return True
+
+    await send_private_msg(user_id, build_plain_message(post_msg))
+    for sample in sample_messages:
+        await send_private_msg(user_id, build_plain_message(str(sample)))
+    if notes_message:
+        await send_private_msg(user_id, build_plain_message(notes_message))
+    return True
+
+
+def format_history_records(records: list[dict], *, source_label: str) -> str:
+    lines = [f"{source_label} 历史记录"]
+    for idx, item in enumerate(records, 1):
+        typ = str(item.get("type", "") or "unknown")
+        content = str(item.get("content", "") or "").strip()
+        result = str(item.get("result", "") or "")
+        reason = str(item.get("reason", "") or "")
+        reply = str(item.get("reply", "") or "")
+        lines.append("")
+        lines.append(f"#{idx} {typ}" + (f" / {result}" if result else ""))
+        if content:
+            lines.append(f"用户：{content}")
+        if reason:
+            lines.append(f"判定：{reason}")
+        if reply:
+            lines.append(f"Bot：{reply}")
+    return "\n".join(lines)
+
+
+async def send_history_card(
+    *,
+    destination: str,
+    user_id: int,
+    group_id: int,
+    records: list[dict],
+    source_label: str,
+) -> bool:
+    text = format_history_records(records, source_label=source_label)
+    chunks = [
+        text[i:i + PRIVATE_FORWARD_THRESHOLD]
+        for i in range(0, len(text), PRIVATE_FORWARD_THRESHOLD)
+    ] or [text]
+    cfg = get_config()
+    node_ids: list[str] = []
+    for chunk in chunks:
+        resp = await send_private_msg(cfg.bot_qq, build_plain_message(chunk))
+        if not resp:
+            node_ids = []
+            break
+        node_ids.append(str(resp))
+    if node_ids:
+        if destination == GROUP_SCOPE:
+            if await _send_forward_nodes_group(group_id, node_ids):
+                return True
+        else:
+            if await _send_forward_nodes_private(user_id, node_ids):
+                return True
+    if destination == GROUP_SCOPE:
+        await send_group_msg(group_id, build_plain_message(text[:3500]))
+    else:
+        await send_private_msg(user_id, build_plain_message(text[:3500]))
+    return True
+
+
+def group_problem_history(group_id: int, user_id: int, pid: str) -> list[dict]:
+    sb = load_scoreboard(group_id)
+    items = sb.get("user_submissions", {}).get(str(user_id), [])
+    if not isinstance(items, list):
+        return []
+    target = str(pid or "")
+    return sorted(
+        [item for item in items if isinstance(item, dict) and str(item.get("problem", "") or "") == target],
+        key=lambda item: str(item.get("timestamp", "")),
+    )
+
+
+def replace_group_problem_history(group_id: int, user_id: int, pid: str, records: list[dict]) -> None:
+    from .handlers.shared import save_scoreboard
+
+    sb = load_scoreboard(group_id)
+    submissions = sb.setdefault("user_submissions", {})
+    uid = str(user_id)
+    existing = submissions.get(uid, [])
+    if not isinstance(existing, list):
+        existing = []
+    target = str(pid or "")
+    kept = [
+        item for item in existing
+        if not isinstance(item, dict) or str(item.get("problem", "") or "") != target
+    ]
+    submissions[uid] = kept + [dict(item) for item in records]
+    save_scoreboard(group_id, sb)
+
+
+def replace_group_problem_clarifies(group_id: int, user_id: int, pid: str, records: list[dict]) -> None:
+    from .handlers.shared import save_scoreboard
+
+    sb = load_scoreboard(group_id)
+    submissions = sb.setdefault("user_submissions", {})
+    uid = str(user_id)
+    existing = submissions.get(uid, [])
+    if not isinstance(existing, list):
+        existing = []
+    target = str(pid or "")
+    kept = []
+    for item in existing:
+        if not isinstance(item, dict):
+            kept.append(item)
+            continue
+        if str(item.get("problem", "") or "") == target and item.get("type") == "clarify":
+            continue
+        kept.append(item)
+    submissions[uid] = kept + [dict(item) for item in records]
+    save_scoreboard(group_id, sb)
+
+
+def current_group_pid(group_id: int) -> str:
+    current = get_today_problem(group_id)
+    return str(current.get("today", "") or "") if current else ""
+
+
+def private_record_has_correct(records: list[dict], pid: str) -> bool:
+    target = str(pid or "")
+    return any(
+        str(item.get("problem", "") or "") == target
+        and item.get("type") == "submit"
+        and item.get("result") == "correct"
+        for item in records
+    )
+
+
+def copy_records(records: list[dict]) -> list[dict]:
+    return [json.loads(json.dumps(item, ensure_ascii=False)) for item in records]

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -455,9 +455,7 @@ def resolve_problem_by_pid(pid: str) -> dict:
             "tags": [],
         }
 
-    stmt = load_statement_json(normalized_pid)
-    if not stmt:
-        stmt = _ensure_statement(problem)
+    stmt = _ensure_statement(problem)
     if not stmt:
         raise RuntimeError("statement unavailable")
 
@@ -496,7 +494,7 @@ def resolve_random_problem(group_id: int) -> dict:
     for problem in candidates[:20]:
         pid = _problem_id(problem)
         try:
-            stmt = load_statement_json(pid) or _ensure_statement(problem)
+            stmt = _ensure_statement(problem)
             if stmt:
                 return {
                     "today": pid,
@@ -564,9 +562,7 @@ async def _problem_summary(group_id: int, pid: str, stmt: dict) -> str:
 
 async def build_problem_card_payload(group_id: int, problem: dict, *, greeting: str = "private judge 题目") -> dict:
     pid = str(problem.get("today", "") or "")
-    stmt = load_statement_json(pid)
-    if not stmt:
-        stmt = _ensure_statement(problem)
+    stmt = _ensure_statement(problem)
     summary = await _problem_summary(group_id, pid, stmt) if stmt else ""
     post_msg = greeting
     if summary:
@@ -667,14 +663,16 @@ async def send_problem_card_private(user_id: int, group_id: int, problem: dict, 
     if not isinstance(notes_message, str):
         notes_message = ""
 
-    node_ids = []
-    for text in [post_msg, *[str(item) for item in sample_messages], notes_message]:
-        if not text:
-            continue
-        resp = await send_private_msg(cfg.bot_qq, build_plain_message(text))
-        if resp:
-            node_ids.append(str(resp))
-    if await _send_forward_nodes_private(user_id, node_ids):
+    main_node_id = await send_private_msg(cfg.bot_qq, build_plain_message(post_msg))
+    node_ids = [str(main_node_id)] if main_node_id else []
+    if main_node_id:
+        for text in [*[str(item) for item in sample_messages], notes_message]:
+            if not text:
+                continue
+            resp = await send_private_msg(cfg.bot_qq, build_plain_message(text))
+            if resp:
+                node_ids.append(str(resp))
+    if main_node_id and await _send_forward_nodes_private(user_id, node_ids):
         await _send_high_difficulty_notice_private(user_id, problem)
         return True
 

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -645,22 +645,28 @@ async def send_problem_card_private(user_id: int, group_id: int, problem: dict, 
     return True
 
 
-def format_history_records(records: list[dict], *, source_label: str) -> str:
-    lines = [f"{source_label} 历史记录"]
-    for idx, item in enumerate(records, 1):
-        typ = str(item.get("type", "") or "unknown")
-        content = str(item.get("content", "") or "").strip()
-        result = str(item.get("result", "") or "")
-        reason = str(item.get("reason", "") or "")
-        reply = str(item.get("reply", "") or "")
-        lines.append("")
-        lines.append(f"#{idx} {typ}" + (f" / {result}" if result else ""))
-        if content:
-            lines.append(f"用户：{content}")
-        if reason:
-            lines.append(f"判定：{reason}")
-        if reply:
-            lines.append(f"Bot：{reply}")
+def _one_line(text: Any) -> str:
+    return " ".join(str(text or "").split())
+
+
+def _chunk_text(text: str, size: int = PRIVATE_FORWARD_THRESHOLD) -> list[str]:
+    if size <= 0:
+        return [text]
+    return [text[i:i + size] for i in range(0, len(text), size)] or [text]
+
+
+def format_history_records(records: list[dict], *, user_display_name: str) -> str:
+    name = _one_line(user_display_name) or "这位群友"
+    lines = [f"{name}在当前的历史记录如下："]
+    for item in records:
+        content = _one_line(item.get("content", ""))
+        reply = _one_line(item.get("reply", ""))
+        if content and reply:
+            lines.append(f"👤：{content}   🤖：{reply}")
+        elif content:
+            lines.append(f"👤：{content}")
+        elif reply:
+            lines.append(f"🤖：{reply}")
     return "\n".join(lines)
 
 
@@ -670,13 +676,10 @@ async def send_history_card(
     user_id: int,
     group_id: int,
     records: list[dict],
-    source_label: str,
+    user_display_name: str,
 ) -> bool:
-    text = format_history_records(records, source_label=source_label)
-    chunks = [
-        text[i:i + PRIVATE_FORWARD_THRESHOLD]
-        for i in range(0, len(text), PRIVATE_FORWARD_THRESHOLD)
-    ] or [text]
+    text = format_history_records(records, user_display_name=user_display_name)
+    chunks = _chunk_text(text)
     cfg = get_config()
     node_ids: list[str] = []
     for chunk in chunks:
@@ -692,10 +695,11 @@ async def send_history_card(
         else:
             if await _send_forward_nodes_private(user_id, node_ids):
                 return True
-    if destination == GROUP_SCOPE:
-        await send_group_msg(group_id, build_plain_message(text[:3500]))
-    else:
-        await send_private_msg(user_id, build_plain_message(text[:3500]))
+    for chunk in chunks:
+        if destination == GROUP_SCOPE:
+            await send_group_msg(group_id, build_plain_message(chunk))
+        else:
+            await send_private_msg(user_id, build_plain_message(chunk))
     return True
 
 

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -8,6 +8,7 @@ import logging
 import os
 import random
 import re
+import tempfile
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -39,6 +40,7 @@ TZ = timezone(timedelta(hours=8))
 PRIVATE_SCOPE = "private"
 GROUP_SCOPE = "group"
 PRIVATE_FORWARD_THRESHOLD = 3000
+_PRIVATE_STATE_LOAD_WARNED: set[str] = set()
 
 _CF_API = "https://codeforces.com/api/problemset.problems"
 _PROBLEM_RE = re.compile(r"^(?:CF)?(\d+)([A-Za-z][A-Za-z0-9]*)$", re.I)
@@ -77,6 +79,22 @@ def _default_state() -> dict[str, Any]:
     }
 
 
+def _warn_private_state_load_failure(path: Path, reason: str, exc: Exception | None = None) -> None:
+    key = str(path)
+    if key in _PRIVATE_STATE_LOAD_WARNED:
+        return
+    _PRIVATE_STATE_LOAD_WARNED.add(key)
+    if exc is None:
+        logger.warning("invalid private judge state at %s; using defaults: %s", path, reason)
+    else:
+        logger.warning(
+            "failed to load private judge state at %s; using defaults: %s",
+            path,
+            reason,
+            exc_info=True,
+        )
+
+
 def load_private_state(user_id: int) -> dict[str, Any]:
     path = _state_file(user_id)
     if not path.exists():
@@ -85,8 +103,10 @@ def load_private_state(user_id: int) -> dict[str, Any]:
         with path.open(encoding="utf-8") as f:
             data = json.load(f)
         if not isinstance(data, dict):
+            _warn_private_state_load_failure(path, f"expected object, got {type(data).__name__}")
             return _default_state()
-    except Exception:
+    except Exception as e:
+        _warn_private_state_load_failure(path, str(e), e)
         return _default_state()
 
     state = _default_state()
@@ -105,8 +125,37 @@ def load_private_state(user_id: int) -> dict[str, Any]:
 def save_private_state(user_id: int, state: dict[str, Any]) -> None:
     path = _state_file(user_id)
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as f:
-        json.dump(state, f, ensure_ascii=False, indent=2)
+    tmp_name = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as f:
+            tmp_name = f.name
+            json.dump(state, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_name, path)
+        try:
+            dir_fd = os.open(path.parent, os.O_RDONLY)
+        except OSError:
+            return
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except Exception:
+        if tmp_name:
+            try:
+                os.unlink(tmp_name)
+            except FileNotFoundError:
+                pass
+        raise
 
 
 def get_private_current_problem(user_id: int) -> dict | None:

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -54,6 +54,10 @@ _CONTEST_URL_RE = re.compile(
 )
 
 
+class NonFormulaImageProblem(RuntimeError):
+    """Raised when a statement is unavailable because it depends on diagrams/images."""
+
+
 def _data_dir() -> Path:
     return Path(get_config().data_dir)
 
@@ -398,7 +402,31 @@ def _ensure_statement(problem: dict) -> dict:
     os.makedirs(picker.CACHE_DIR, exist_ok=True)
     os.makedirs(picker.GROUPS_DIR, exist_ok=True)
     stmt = picker.fetch_statement(problem)
-    return stmt if isinstance(stmt, dict) else {}
+    if isinstance(stmt, dict):
+        return stmt
+    if _has_non_formula_images(problem):
+        raise NonFormulaImageProblem(_problem_id(problem) or "unknown")
+    return {}
+
+
+def _has_non_formula_images(problem: dict) -> bool:
+    from .problems import picker
+
+    contest_id = problem.get("contestId")
+    index = problem.get("index")
+    if contest_id in (None, "") or not index:
+        return False
+    try:
+        result = picker.cf_statement.process_problem(contest_id, index, vl_backend="none")
+    except Exception as e:
+        logger.warning(
+            "failed to inspect non-formula images for %s%s: %s",
+            contest_id,
+            index,
+            e,
+        )
+        return False
+    return bool(result.get("has_non_formula_images"))
 
 
 def resolve_problem_by_pid(pid: str) -> dict:

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -490,15 +490,7 @@ async def build_problem_card_payload(group_id: int, problem: dict, *, greeting: 
     if not stmt:
         stmt = _ensure_statement(problem)
     summary = await _problem_summary(group_id, pid, stmt) if stmt else ""
-    stmt_name = stmt.get("name", "") if stmt else ""
-    name = str(problem.get("name", "") or stmt_name)
-    rating = str(problem.get("rating", "") or "")
-    title_parts = [f"{greeting}：CF{pid}"]
-    if name:
-        title_parts.append(name)
-    if rating and rating != "?":
-        title_parts.append(f"rating {rating}")
-    post_msg = " ".join(title_parts)
+    post_msg = greeting
     if summary:
         post_msg += "\n\n" + summary
     return {
@@ -558,7 +550,7 @@ async def send_problem_card_private(user_id: int, group_id: int, problem: dict, 
         except Exception as e:
             logger.warning("failed to build private problem card for %s: %s", pid, e)
             await send_private_msg(user_id, build_plain_message(
-                f"题目 CF{pid} 已设置，但题面暂时拉不到，稍后再试试 /problem。"
+                "题目已设置，但题面暂时拉不到，稍后再试试 /problem。"
             ))
             return False
 
@@ -580,7 +572,7 @@ async def send_problem_card_private(user_id: int, group_id: int, problem: dict, 
     sample_messages = payload.get("sample_messages")
     notes_message = payload.get("notes_message")
     if not isinstance(post_msg, str):
-        post_msg = f"当前题目：CF{pid}"
+        post_msg = "当前题目"
     if not isinstance(sample_messages, list):
         sample_messages = []
     if not isinstance(notes_message, str):

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -45,12 +45,12 @@ _PRIVATE_STATE_LOAD_WARNED: set[str] = set()
 
 _CF_API = "https://codeforces.com/api/problemset.problems"
 _PROBLEM_RE = re.compile(r"^(?:CF)?(\d+)([A-Za-z][A-Za-z0-9]*)$", re.I)
-_PROBLEMSET_URL_RE = re.compile(
-    r"https?://(?:www\.)?codeforces\.com/problemset/problem/(\d+)/([A-Za-z0-9]+)",
+_PROBLEM_PATH_RE = re.compile(
+    r"(?:^|/)(?:problemset/)?problem/(\d+)/([A-Za-z0-9]+)(?:[/?#]|$)",
     re.I,
 )
-_CONTEST_URL_RE = re.compile(
-    r"https?://(?:www\.)?codeforces\.com/contest/(\d+)/problem/([A-Za-z0-9]+)",
+_CONTEST_PATH_RE = re.compile(
+    r"(?:^|/)contest/(\d+)/problem/([A-Za-z0-9]+)(?:[/?#]|$)",
     re.I,
 )
 
@@ -321,7 +321,7 @@ def parse_problem_ref(text: str) -> tuple[int, str] | None:
     value = (text or "").strip()
     if not value:
         return None
-    for pattern in (_PROBLEMSET_URL_RE, _CONTEST_URL_RE):
+    for pattern in (_CONTEST_PATH_RE, _PROBLEM_PATH_RE):
         match = pattern.search(value)
         if match:
             return int(match.group(1)), match.group(2).upper()

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -20,6 +20,7 @@ from .config import get_config
 from .handlers.shared import (
     get_problem_summary,
     get_today_problem,
+    high_difficulty_notice,
     load_scoreboard,
     save_problem_summary,
     summarize_problem,
@@ -617,6 +618,16 @@ async def _send_forward_nodes_group(group_id: int, node_ids: list[str]) -> int |
     )
 
 
+async def _send_high_difficulty_notice_private(user_id: int, problem: dict) -> None:
+    notice = high_difficulty_notice(problem)
+    if not notice:
+        return
+    try:
+        await send_private_msg(user_id, build_plain_message(notice))
+    except Exception as e:
+        logger.warning("failed to send private high-difficulty notice: %s", e)
+
+
 async def send_problem_card_private(user_id: int, group_id: int, problem: dict, *, prefer_group_card: bool = True) -> bool:
     cfg = get_config()
     pid = str(problem.get("today", "") or "")
@@ -643,6 +654,7 @@ async def send_problem_card_private(user_id: int, group_id: int, problem: dict, 
             if value:
                 node_ids.append(str(value))
         if await _send_forward_nodes_private(user_id, node_ids):
+            await _send_high_difficulty_notice_private(user_id, problem)
             return True
 
     post_msg = payload.get("post_msg")
@@ -663,6 +675,7 @@ async def send_problem_card_private(user_id: int, group_id: int, problem: dict, 
         if resp:
             node_ids.append(str(resp))
     if await _send_forward_nodes_private(user_id, node_ids):
+        await _send_high_difficulty_notice_private(user_id, problem)
         return True
 
     await send_private_msg(user_id, build_plain_message(post_msg))
@@ -670,6 +683,7 @@ async def send_problem_card_private(user_id: int, group_id: int, problem: dict, 
         await send_private_msg(user_id, build_plain_message(str(sample)))
     if notes_message:
         await send_private_msg(user_id, build_plain_message(notes_message))
+    await _send_high_difficulty_notice_private(user_id, problem)
     return True
 
 

--- a/tests/test_achievements.py
+++ b/tests/test_achievements.py
@@ -40,6 +40,7 @@ def _log_command(
     command: str,
     at: datetime,
     status: str = "ok",
+    extra: dict | None = None,
 ) -> None:
     with patch("kouhai_bot.eventlog.now_tz", return_value=at):
         meta = log_command_received(
@@ -51,7 +52,7 @@ def _log_command(
             raw_text=f"/{command} payload",
         )
     with patch("kouhai_bot.eventlog.now_tz", return_value=at + timedelta(seconds=2)):
-        log_command_finished(meta, status=status, problem="542D")
+        log_command_finished(meta, status=status, problem="542D", extra=extra)
 
 
 def test_achievement_window_uses_4am_cutoff():
@@ -130,6 +131,19 @@ def test_build_achievement_report_counts_window_and_statuses():
                 at=datetime(2026, 5, 15, 4, 1, tzinfo=TZ),
                 status="correct",
             )
+            _log_command(
+                user_id=4,
+                nickname="Carol",
+                command="sync",
+                at=datetime(2026, 5, 14, 7, 30, tzinfo=TZ),
+                status="correct",
+                extra={
+                    "synced_submit_count": 2,
+                    "synced_correct_count": 1,
+                    "synced_clarify_count": 2,
+                    "synced_review_count": 3,
+                },
+            )
 
             report = build_achievement_report(
                 GID,
@@ -139,10 +153,10 @@ def test_build_achievement_report_counts_window_and_statuses():
         assert "统计窗口：05-14 04:00 ~ 05-15 04:00" in report
         assert "最早 submit：Alice（04:01）" in report
         assert "最晚 submit：Bob（03:50）" in report
-        assert "通过题目最多：Alice、Bob（1 次）" in report
+        assert "通过题目最多：Alice、Bob、Carol（1 次）" in report
         assert "submit 尝试最多：Alice（3 次）" in report
-        assert "review 最多：Alice（2 次）" in report
-        assert "clarify 最多：Bob（1 次）" in report
+        assert "review 最多：Carol（3 次）" in report
+        assert "clarify 最多：Carol（2 次）" in report
         assert "TooEarly" not in report
         assert "TooLate" not in report
     finally:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1622,6 +1622,38 @@ def test_submit_operation_not_blocked():
     print("✅ submit: 操作 not blocked")
 
 
+def test_private_submit_sends_ack_face_instead_of_reaction():
+    _reset_state()
+    _setup_problem()
+    global _deepseek_response
+    _deepseek_response = {
+        "correct": False,
+        "reason": "做法还不够完整",
+        "reply": "再补一下关键证明～",
+        "reaction": "",
+    }
+
+    with _all_patches():
+        from kouhai_bot.handlers.cmd.submit import handle
+        from kouhai_bot.handlers.shared import get_today_problem
+        from kouhai_bot.private_judge import set_private_current_problem
+
+        set_private_current_problem(UID, get_today_problem(GID))
+        asyncio.run(handle(**_kwargs(_make_private_event("/submit try dp"))))
+
+    faces = [
+        seg.get("data", {}).get("id")
+        for item in _private_sent if item["user_id"] == UID
+        for seg in item["message"] if isinstance(seg, dict) and seg.get("type") == "face"
+    ]
+    assert any(face in {"128064", "289"} for face in faces), f"Expected private ack face, got: {_private_sent}"
+    assert not _reacted, f"Private submit should not use group reactions: {_reacted}"
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
+    assert "关键证明" in private_text, private_text
+    _cleanup()
+    print("✅ private submit: ack uses face message")
+
+
 def test_submit_no_problem():
     """No problem → appropriate message."""
     _reset_state()
@@ -2150,8 +2182,11 @@ def test_private_help_only_shows_private_judge_commands():
         discover_commands()
         asyncio.run(handle(**_kwargs(_make_private_event("/help"))))
 
-    assert _private_sent, "Expected private help to send directly"
-    msg = _private_sent[-1]["message"]
+    assert _private_forwarded, "Expected private help to be sent as a forward card"
+    assert _private_forwarded[-1]["user_id"] == UID, _private_forwarded
+    self_sends = [item for item in _private_sent if item["user_id"] == 1]
+    assert self_sends, "Expected private help to self-send before forward"
+    msg = self_sends[-1]["message"]
     text = " ".join(
         seg.get("data", {}).get("text", "")
         for seg in msg if isinstance(seg, dict) and seg.get("type") == "text"
@@ -3388,6 +3423,31 @@ def test_submit_user_group_blocked_uses_dynamic_wait():
     print("✅ submit: dynamic wait redirects to private")
 
 
+def test_parse_problem_ref_accepts_loose_codeforces_links():
+    from kouhai_bot.private_judge import parse_problem_ref, problem_id_from_ref
+
+    cases = {
+        "CF2234B": "2234B",
+        "2234B": "2234B",
+        "https://codeforces.com/contest/2233/problem/F": "2233F",
+        "codeforces.com/contest/2233/problem/F": "2233F",
+        "/contest/2233/problem/F": "2233F",
+        "contest/2233/problem/F": "2233F",
+        "https://codeforces.com/problemset/problem/2234/B": "2234B",
+        "codeforces.com/problemset/problem/2234/B": "2234B",
+        "/problemset/problem/2234/B": "2234B",
+        "problem/2230/F": "2230F",
+        "problem/2230/F?locale=en": "2230F",
+    }
+    for raw, expected in cases.items():
+        parsed = parse_problem_ref(raw)
+        assert parsed is not None, raw
+        assert problem_id_from_ref(*parsed) == expected, (raw, parsed)
+
+    assert parse_problem_ref("contest/abc/problem/F") is None
+    print("✅ private setproblem: accepts loose Codeforces links")
+
+
 def test_private_setproblem_current_copies_empty_private_history():
     _reset_state()
     _setup_problem_for(GID, PID)
@@ -3830,6 +3890,7 @@ if __name__ == "__main__":
     test_review_after_pending_submit_uses_snapshotted_solved_problem()
     test_submit_off_topic()
     test_submit_operation_not_blocked()
+    test_private_submit_sends_ack_face_instead_of_reaction()
     test_submit_no_problem()
     test_clarify_with_problem()
     test_clarify_no_problem()
@@ -3845,6 +3906,7 @@ if __name__ == "__main__":
     test_scoreboard_with_data()
     test_scoreboard_splits_default_and_starred_groups()
     test_help_shows_short_aliases_and_configured_newproblem_cooldown()
+    test_private_help_only_shows_private_judge_commands()
     test_newproblem_cooldown()
     test_newproblem_busy_rejects_concurrent_force()
     test_newproblem_unsolved_rejects()
@@ -3872,4 +3934,5 @@ if __name__ == "__main__":
     test_submit_starred_user_shows_own_group_top5()
     test_submit_alias_dispatches_to_submit_handler()
     test_submit_user_group_blocked_within_window()
+    test_parse_problem_ref_accepts_loose_codeforces_links()
     print(f"\n🎉 E2E tests passed")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -430,6 +430,7 @@ def _all_patches():
     stack.enter_context(patch("kouhai_bot.handlers.cmd.setproblem.send_private_msg", _mock_send_private))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.sync.send_group_msg", _mock_send_group))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.sync.send_private_msg", _mock_send_private))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.sync.react_emoji", _mock_react))
     stack.enter_context(patch("kouhai_bot.editorial_followup.send_private_msg", _mock_send_private))
     stack.enter_context(patch("kouhai_bot.editorial_followup.send_group_forward_msg", _mock_send_group_forward))
     stack.enter_context(patch("kouhai_bot.private_judge.send_group_msg", _mock_send_group))
@@ -3634,18 +3635,40 @@ def test_sync_private_correct_current_problem_scores_for_normal_user():
         "problem": PID,
     }
 
-    with _all_patches():
+    with _all_patches(), patch(
+        "kouhai_bot.handlers.cmd.sync._reveal_problem_source",
+        AsyncMock(return_value="本题来自 CF542D✨"),
+    ):
         from kouhai_bot.private_judge import save_private_submission
         from kouhai_bot.handlers.cmd.sync import handle
+        from kouhai_bot.eventlog import EVENT_META_KEY, load_events, log_command_received
 
         save_private_submission(UID, private_record)
-        asyncio.run(handle(**_kwargs(_make_event("/sync"))))
+        event = _make_event("/sync")
+        event[EVENT_META_KEY] = log_command_received(
+            group_id=GID,
+            user_id=UID,
+            sender=event["sender"],
+            command="sync",
+            message_id=event["message_id"],
+            raw_text=event["raw_message"],
+        )
+        asyncio.run(handle(**_kwargs(event)))
+        logged_events = load_events(GID, event[EVENT_META_KEY]["date"])
 
     with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
         saved = json.load(f)
     assert saved["solves"] and str(saved["solves"][0]["user_id"]) == str(UID), saved
     assert saved["user_submissions"][str(UID)][0]["content"] == "private ac"
-    assert any("本题 +" in _last_text_item(item) for item in _sent), _sent
+    text = "\n".join(_last_text_item(item) for item in _sent)
+    assert "本题 +" in text, _sent
+    assert "本题来自 CF542D" in text, text
+    assert "已同步完成" not in text, text
+    assert ("msg_001", "128076") in _reacted, _reacted
+    finished = [item for item in logged_events if item.get("type") == "finished"]
+    assert finished and finished[-1]["status"] == "correct", finished
+    assert finished[-1]["synced_submit_count"] == 1, finished[-1]
+    assert finished[-1]["synced_correct_count"] == 1, finished[-1]
     _cleanup()
     print("✅ sync: private AC scores current group problem for normal user")
 
@@ -3694,6 +3717,8 @@ def test_sync_history_card_uses_friendly_visible_format():
     assert "secret reason" not in history_text and "hidden clarify reason" not in history_text
     assert "submit" not in history_text and "incorrect" not in history_text
     assert _forwarded, "Expected history to be forwarded to group"
+    assert not any("已同步完成" in _last_text_item(item) for item in _sent), _sent
+    assert ("msg_001", "128076") in _reacted, _reacted
     _cleanup()
     print("✅ sync: history card uses friendly visible format")
 
@@ -3770,6 +3795,8 @@ def test_private_sync_from_solved_group_marks_private_review_state():
         review_pid = get_private_review_pid(UID, GID)
 
     assert review_pid == PID
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent)
+    assert "已同步完成" not in private_text, private_text
     _cleanup()
     print("✅ sync: solved group state is persisted for private review")
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -87,8 +87,10 @@ def _write_state(group_id: int, data: dict):
 def _write_statement(pid: str, data: dict):
     d = os.path.join(_data_dir(), "statements")
     os.makedirs(d, exist_ok=True)
+    payload = dict(data)
+    payload.setdefault("_vl_processed", True)
     with open(os.path.join(d, f"{pid}.json"), "w") as f:
-        json.dump(data, f)
+        json.dump(payload, f)
 
 
 def _write_scoreboard(group_id: int, data: dict):
@@ -3364,6 +3366,60 @@ def test_starred_redirect_does_not_mark_first_notice_when_private_intro_fails():
     print("✅ submit: failed private redirect does not consume first notice")
 
 
+def test_starred_redirect_does_not_mark_first_notice_when_private_repeat_fails():
+    """If repeat DM fails after intro/card, retry should still send intro/card later."""
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _write_state(GID, {
+        "today": PID,
+        "contestId": 542,
+        "index": "D",
+        "name": "Superhero's Job",
+        "rating": 2600,
+        "tags": ["number theory", "dp"],
+        "date": "2026-05-14",
+        "posted_at": int(time.time()),
+    })
+
+    lazy = _LazyConfig()
+    lazy._config = {
+        **_config_dict(),
+        "user_groups": [
+            UserGroupConfig(
+                name="starred",
+                display_name="打星",
+                user_ids=[UID],
+                submit_delay_sec=300,
+                submit_delay_message="将机会多留给年轻人吧～{wait}",
+            )
+        ],
+    }
+
+    async def _fail_repeat_send(user_id, message):
+        text = _last_text_item({"message": message})
+        if "刚才被撤回的提交内容" in text:
+            return None
+        return await _mock_send_private(user_id, message)
+
+    with _all_patches(), patch("kouhai_bot.config._config", lazy):
+        from kouhai_bot.handlers.cmd.submit import handle
+        from kouhai_bot.private_judge import has_group_problem_private_notified
+
+        with patch("kouhai_bot.handlers.cmd.submit.send_private_msg", _fail_repeat_send):
+            asyncio.run(handle(**_kwargs(_make_event("/submit my solution text here"))))
+
+        notified = has_group_problem_private_notified(UID, PID)
+
+    assert not notified
+    assert _deleted == [], f"Submit should not be recalled when private repeat failed: {_deleted}"
+    assert not any(call.get("task") == "judge" for call in _deepseek_calls), (
+        f"Judge should not run when private repeat failed: {_deepseek_calls}"
+    )
+    assert any("私聊复述提交失败" in _last_text_item(item) for item in _sent), _sent
+    _cleanup()
+    print("✅ submit: failed private repeat does not consume first notice")
+
+
 def test_submit_user_group_blocked_uses_dynamic_wait():
     """Dynamic wait still redirects starred submits to private judge."""
     _reset_state()
@@ -3480,6 +3536,62 @@ def test_private_setproblem_current_copies_empty_private_history():
     print("✅ private setproblem: copies empty private history")
 
 
+def test_resolve_problem_by_pid_revalidates_cached_statement():
+    _reset_state()
+    _write_statement(PID, {
+        "name": "stale cache",
+        "description": "old statement without VL marker",
+    })
+    problem = {
+        "contestId": 542,
+        "index": "D",
+        "name": "Superhero's Job",
+        "rating": 2600,
+        "tags": ["number theory", "dp"],
+    }
+
+    with _all_patches(), \
+        patch("kouhai_bot.private_judge._cached_problem_by_pid", return_value=problem), \
+        patch("kouhai_bot.private_judge._ensure_statement", return_value={"name": "validated"}) as ensure:
+        from kouhai_bot.private_judge import resolve_problem_by_pid
+
+        state = resolve_problem_by_pid(PID)
+
+    ensure.assert_called_once_with(problem)
+    assert state["today"] == PID, state
+    assert state["name"] == "Superhero's Job", state
+    _cleanup()
+    print("✅ private setproblem: revalidates cached statements")
+
+
+def test_resolve_random_problem_revalidates_cached_statement():
+    _reset_state()
+    _write_statement(PID, {
+        "name": "stale cache",
+        "description": "old statement without VL marker",
+    })
+    problem = {
+        "contestId": 542,
+        "index": "D",
+        "name": "Superhero's Job",
+        "rating": 2600,
+        "tags": ["number theory", "dp"],
+    }
+
+    with _all_patches(), \
+        patch("kouhai_bot.private_judge._fetch_problemset", return_value=[problem]), \
+        patch("kouhai_bot.private_judge.random.shuffle", lambda items: None), \
+        patch("kouhai_bot.private_judge._ensure_statement", return_value={"name": "validated"}) as ensure:
+        from kouhai_bot.private_judge import resolve_random_problem
+
+        state = resolve_random_problem(GID)
+
+    ensure.assert_called_once_with(problem)
+    assert state["today"] == PID, state
+    _cleanup()
+    print("✅ private setproblem random: revalidates cached statements")
+
+
 def test_private_setproblem_non_formula_image_hint():
     _reset_state()
 
@@ -3502,6 +3614,41 @@ def test_private_setproblem_non_formula_image_hint():
     assert "换一道题" in private_text, private_text
     _cleanup()
     print("✅ private setproblem: explains non-formula image limitation")
+
+
+def test_build_problem_card_payload_revalidates_cached_statement():
+    _reset_state()
+    _write_statement(PID, {
+        "name": "stale cache",
+        "description": "old statement without VL marker",
+    })
+    statement = {
+        "name": "validated",
+        "time_limit": "2s",
+        "memory_limit": "256MB",
+        "description": "validated statement",
+        "input": "n",
+        "samples": [],
+        "notes": "",
+    }
+
+    with _all_patches(), \
+        patch("kouhai_bot.private_judge._ensure_statement", return_value=statement) as ensure:
+        from kouhai_bot.private_judge import build_problem_card_payload
+
+        payload = asyncio.run(build_problem_card_payload(GID, {
+            "today": PID,
+            "contestId": 542,
+            "index": "D",
+            "name": "Superhero's Job",
+            "rating": 2600,
+            "tags": [],
+        }))
+
+    ensure.assert_called_once()
+    assert payload["post_msg"].startswith("private judge 题目"), payload
+    _cleanup()
+    print("✅ private problem card: revalidates cached statements")
 
 
 def test_private_problem_card_hides_original_problem_identity():
@@ -3572,6 +3719,46 @@ def test_private_problem_card_high_difficulty_warns_after_card():
     assert "题解" in private_text, private_text
     _cleanup()
     print("✅ private problem card: high difficulty warns after card")
+
+
+def test_private_problem_card_falls_back_when_main_self_send_fails():
+    _reset_state()
+    problem = {
+        "today": PID,
+        "contestId": 542,
+        "index": "D",
+        "name": "Superhero's Job",
+        "rating": 2600,
+        "tags": [],
+    }
+    payload = {
+        "post_msg": "MAIN CARD",
+        "sample_messages": ["SAMPLE CARD"],
+        "notes_message": "NOTE CARD",
+    }
+
+    async def _send_private_with_main_self_send_failure(user_id, message):
+        text = _last_text_item({"message": message})
+        if user_id == 1 and text == "MAIN CARD":
+            return None
+        return await _mock_send_private(user_id, message)
+
+    with _all_patches(), \
+        patch("kouhai_bot.private_judge.asyncio.sleep", AsyncMock()), \
+        patch("kouhai_bot.private_judge.build_problem_card_payload", AsyncMock(return_value=payload)), \
+        patch("kouhai_bot.private_judge.send_private_msg", _send_private_with_main_self_send_failure):
+        from kouhai_bot.private_judge import send_problem_card_private
+
+        ok = asyncio.run(send_problem_card_private(UID, GID, problem, prefer_group_card=False))
+
+    assert ok
+    assert _private_forwarded == [], f"Should not forward without main card node: {_private_forwarded}"
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent)
+    assert "MAIN CARD" in private_text, private_text
+    assert "SAMPLE CARD" in private_text, private_text
+    assert "NOTE CARD" in private_text, private_text
+    _cleanup()
+    print("✅ private problem card: falls back when main node self-send fails")
 
 
 def test_private_state_load_logs_corrupt_json_once(caplog):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3427,6 +3427,53 @@ def test_private_problem_card_hides_original_problem_identity():
     print("✅ private problem card: hides original identity")
 
 
+def test_private_state_load_logs_corrupt_json_once(caplog):
+    _reset_state()
+    state_dir = os.path.join(_data_dir(), "private_judge", "users")
+    os.makedirs(state_dir, exist_ok=True)
+    with open(os.path.join(state_dir, f"{UID}.json"), "w") as f:
+        f.write("{bad json")
+
+    with _all_patches():
+        from kouhai_bot.private_judge import _PRIVATE_STATE_LOAD_WARNED, load_private_state
+
+        _PRIVATE_STATE_LOAD_WARNED.clear()
+        caplog.set_level("WARNING", logger="kouhai-bot.private_judge")
+        state = load_private_state(UID)
+        state_again = load_private_state(UID)
+
+    assert state["user_submissions"] == []
+    assert state_again["user_submissions"] == []
+    messages = [record.getMessage() for record in caplog.records]
+    assert sum("failed to load private judge state" in message for message in messages) == 1
+    _cleanup()
+    print("✅ private state: corrupt JSON logs once")
+
+
+def test_private_state_save_writes_complete_json_without_temp_leftovers():
+    _reset_state()
+    with _all_patches():
+        from kouhai_bot.private_judge import load_private_state, save_private_state
+
+        save_private_state(UID, {
+            "current_problem": {"today": PID},
+            "user_submissions": [{"problem": PID, "content": "x"}],
+            "solved_problems": {},
+            "last_solved_problem": "",
+            "notified_group_problem_private": {},
+            "problem_cards": {},
+        })
+        loaded = load_private_state(UID)
+
+    assert loaded["current_problem"]["today"] == PID
+    assert loaded["user_submissions"][0]["content"] == "x"
+    state_dir = os.path.join(_data_dir(), "private_judge", "users")
+    leftovers = [name for name in os.listdir(state_dir) if name.endswith(".tmp")]
+    assert leftovers == []
+    _cleanup()
+    print("✅ private state: atomic save writes complete JSON")
+
+
 def test_private_review_allowed_after_group_solves_current_problem():
     _reset_state()
     global _deepseek_response

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3389,6 +3389,30 @@ def test_private_setproblem_current_copies_empty_private_history():
     print("✅ private setproblem: copies empty private history")
 
 
+def test_private_setproblem_non_formula_image_hint():
+    _reset_state()
+
+    with _all_patches():
+        from kouhai_bot.handlers.cmd.setproblem import handle
+        from kouhai_bot.private_judge import NonFormulaImageProblem
+
+        with patch(
+            "kouhai_bot.handlers.cmd.setproblem.resolve_problem_by_pid",
+            side_effect=NonFormulaImageProblem("1065C"),
+        ):
+            asyncio.run(handle(**_kwargs(_make_private_event("/setproblem 1065C"))))
+
+    private_text = "\n".join(
+        " ".join(seg.get("data", {}).get("text", "") for seg in item["message"] if seg.get("type") == "text")
+        for item in _private_sent
+    )
+    assert "非公式图片" in private_text, private_text
+    assert "处理能力有限" in private_text, private_text
+    assert "换一道题" in private_text, private_text
+    _cleanup()
+    print("✅ private setproblem: explains non-formula image limitation")
+
+
 def test_private_problem_card_hides_original_problem_identity():
     _reset_state()
     _write_statement(PID, {

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3564,6 +3564,86 @@ def test_sync_private_correct_current_problem_scores_for_normal_user():
     print("✅ sync: private AC scores current group problem for normal user")
 
 
+def test_sync_history_card_uses_friendly_visible_format():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _group_members[GID][0]["card"] = "AliceCard"
+    private_records = [
+        {
+            "timestamp": "2026-05-14T12:00:00+08:00",
+            "type": "submit",
+            "content": "first line\nsecond line",
+            "result": "incorrect",
+            "reason": "secret reason",
+            "reply": "bot reply\nvisible",
+            "problem": PID,
+        },
+        {
+            "timestamp": "2026-05-14T12:01:00+08:00",
+            "type": "clarify",
+            "content": "what is n?",
+            "result": "clarify",
+            "reason": "hidden clarify reason",
+            "reply": "n is input",
+            "problem": PID,
+        },
+    ]
+
+    with _all_patches():
+        from kouhai_bot.private_judge import save_private_submission
+        from kouhai_bot.handlers.cmd.sync import handle
+
+        for record in private_records:
+            save_private_submission(UID, record)
+        asyncio.run(handle(**_kwargs(_make_event("/sync"))))
+
+    history_text = "\n".join(
+        _last_text_item(item)
+        for item in _private_sent
+        if item["user_id"] == 1
+    )
+    assert "AliceCard在当前的历史记录如下：" in history_text, history_text
+    assert "👤：first line second line   🤖：bot reply visible" in history_text, history_text
+    assert "👤：what is n?   🤖：n is input" in history_text, history_text
+    assert "secret reason" not in history_text and "hidden clarify reason" not in history_text
+    assert "submit" not in history_text and "incorrect" not in history_text
+    assert _forwarded, "Expected history to be forwarded to group"
+    _cleanup()
+    print("✅ sync: history card uses friendly visible format")
+
+
+def test_sync_history_card_chunks_long_history():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    long_text = "x" * 6500
+
+    with _all_patches():
+        from kouhai_bot.private_judge import save_private_submission
+        from kouhai_bot.handlers.cmd.sync import handle
+
+        save_private_submission(UID, {
+            "timestamp": "2026-05-14T12:00:00+08:00",
+            "type": "submit",
+            "content": long_text,
+            "result": "incorrect",
+            "reason": "hidden",
+            "reply": "try again",
+            "problem": PID,
+        })
+        asyncio.run(handle(**_kwargs(_make_event("/sync"))))
+
+    assert _forwarded, "Expected history forward card"
+    assert len(_forwarded[0]["messages"]) >= 3, _forwarded
+    chunk_text = "".join(
+        _last_text_item(item)
+        for item in _private_sent
+        if item["user_id"] == 1
+    )
+    assert long_text in chunk_text, "Long history should not be truncated"
+    _cleanup()
+    print("✅ sync: long history card is chunked")
+
+
 def test_private_sync_from_solved_group_marks_private_review_state():
     _reset_state()
     _setup_problem_for(GID, PID)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -30,6 +30,8 @@ _sent: list[dict] = []
 _reacted: list[tuple] = []
 _private_sent: list[dict] = []
 _forwarded: list[dict] = []
+_private_forwarded: list[dict] = []
+_deleted: list[str] = []
 _deepseek_response: dict | None = None
 _group_members: dict[int, list[dict]] = {}
 _deepseek_calls: list[dict] = []
@@ -37,11 +39,13 @@ _temp_dir = None
 
 
 def _reset_state():
-    global _sent, _reacted, _private_sent, _forwarded, _deepseek_response, _group_members, _deepseek_calls, _temp_dir
+    global _sent, _reacted, _private_sent, _forwarded, _private_forwarded, _deleted, _deepseek_response, _group_members, _deepseek_calls, _temp_dir
     _sent.clear()
     _reacted.clear()
     _private_sent.clear()
     _forwarded.clear()
+    _private_forwarded.clear()
+    _deleted.clear()
     _deepseek_response = None
     _group_members = {
         GID: [
@@ -158,6 +162,15 @@ async def _mock_send_group_forward(group_id, messages):
     return 2000 + len(_forwarded)
 
 
+async def _mock_send_private_forward(user_id, messages):
+    _private_forwarded.append({"user_id": user_id, "messages": messages})
+    return 3000 + len(_private_forwarded)
+
+
+async def _mock_delete_msg(message_id):
+    _deleted.append(str(message_id))
+
+
 async def _mock_http_post(action, data):
     if action == "get_group_member_list":
         return {"status": "ok", "data": list(_group_members.get(int(data["group_id"]), []))}
@@ -244,6 +257,21 @@ def _make_event(text="", group_id=GID, user_id=UID, message_id="msg_001", messag
         "type": "message",
         "message_type": "group",
         "group_id": group_id,
+        "user_id": user_id,
+        "sender": {"nickname": "Alice", "card": "", "user_id": user_id},
+        "message_id": message_id,
+        "raw_message": text,
+        "message": message,
+    }
+
+
+def _make_private_event(text="", user_id=UID, message_id="priv_001", message=None):
+    if message is None:
+        message = [{"type": "text", "data": {"text": text}}]
+    return {
+        "type": "message",
+        "message_type": "private",
+        "group_id": GID,
         "user_id": user_id,
         "sender": {"nickname": "Alice", "card": "", "user_id": user_id},
         "message_id": message_id,
@@ -381,11 +409,15 @@ def _all_patches():
     stack.enter_context(patch("kouhai_bot.napcat.client.react_emoji", _mock_react))
     stack.enter_context(patch("kouhai_bot.napcat.client.send_private_msg", _mock_send_private))
     stack.enter_context(patch("kouhai_bot.napcat.client.send_group_forward_msg", _mock_send_group_forward))
+    stack.enter_context(patch("kouhai_bot.napcat.client.send_private_forward_msg", _mock_send_private_forward))
+    stack.enter_context(patch("kouhai_bot.napcat.client.delete_msg", _mock_delete_msg))
     stack.enter_context(patch("kouhai_bot.napcat.client._http_post", _mock_http_post))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.submit.send_group_msg", _mock_send_group))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.submit.react_emoji", _mock_react))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.submit.send_private_msg", _mock_send_private))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.submit.send_group_forward_msg", _mock_send_group_forward))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.submit.send_private_forward_msg", _mock_send_private_forward))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.submit.delete_msg", _mock_delete_msg))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.clarify.send_group_msg", _mock_send_group))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.review.send_group_msg", _mock_send_group))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.clear.react_emoji", _mock_react))
@@ -393,8 +425,17 @@ def _all_patches():
     stack.enter_context(patch("kouhai_bot.handlers.cmd.newproblem.send_private_msg", _mock_send_private))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.newproblem.react_emoji", _mock_react))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.stubs.send_group_msg", _mock_send_group))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.stubs.send_private_msg", _mock_send_private))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.setproblem.send_group_msg", _mock_send_group))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.setproblem.send_private_msg", _mock_send_private))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.sync.send_group_msg", _mock_send_group))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.sync.send_private_msg", _mock_send_private))
     stack.enter_context(patch("kouhai_bot.editorial_followup.send_private_msg", _mock_send_private))
     stack.enter_context(patch("kouhai_bot.editorial_followup.send_group_forward_msg", _mock_send_group_forward))
+    stack.enter_context(patch("kouhai_bot.private_judge.send_group_msg", _mock_send_group))
+    stack.enter_context(patch("kouhai_bot.private_judge.send_private_msg", _mock_send_private))
+    stack.enter_context(patch("kouhai_bot.private_judge.send_group_forward_msg", _mock_send_group_forward))
+    stack.enter_context(patch("kouhai_bot.private_judge.send_private_forward_msg", _mock_send_private_forward))
     stack.enter_context(patch("kouhai_bot.handlers.shared.call_chat_completion_result", _mock_chat_completion_result))
     stack.enter_context(patch("kouhai_bot.handlers.shared.judge_submission_result", _mock_judge_result))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.submit.call_chat_completion_result", _mock_chat_completion_result))
@@ -1619,6 +1660,50 @@ def test_clarify_with_problem():
     print("✅ clarify: with problem")
 
 
+def test_private_clarify_uses_private_problem_summary():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _write_statement(PID2, {
+        "name": "A. Private Problem",
+        "time_limit": "1s",
+        "memory_limit": "256MB",
+        "description": "Private statement asks for a path count.",
+        "input": "n",
+        "output": "answer",
+        "samples": [{"input": "1", "output": "1"}],
+    })
+    _write_group_file(GID, "problem_summaries.json", {
+        PID2: {"summary_zh": "PRIVATE_PID_SUMMARY"},
+    })
+    ctx_file = os.path.join(_data_dir(), "groups", f"groupctx_{GID}.json")
+    with open(ctx_file, "w") as f:
+        json.dump([{"role": "assistant", "content": "GROUP_CURRENT_SUMMARY"}], f)
+    global _deepseek_response
+    _deepseek_response = '{"reply": "按 private 题面解释。", "reaction": ""}'
+
+    with _all_patches():
+        from kouhai_bot.private_judge import set_private_current_problem
+        from kouhai_bot.handlers.cmd.clarify import handle
+
+        set_private_current_problem(UID, {
+            "today": PID2,
+            "contestId": 100,
+            "index": "A",
+            "name": "Private Problem",
+            "rating": 2000,
+            "tags": [],
+        })
+        asyncio.run(handle(**_kwargs(_make_private_event("/clarify 输入是什么？"))))
+
+    clarify_calls = [call for call in _deepseek_calls if call.get("task") == "clarify"]
+    assert clarify_calls, _deepseek_calls
+    user_content = clarify_calls[-1]["messages"][-1]["content"]
+    assert "PRIVATE_PID_SUMMARY" in user_content, user_content
+    assert "GROUP_CURRENT_SUMMARY" not in user_content, user_content
+    _cleanup()
+    print("✅ private clarify: uses pid-specific summary")
+
+
 def test_clarify_llm_failure_shows_admin_message():
     _reset_state()
     _setup_problem()
@@ -2019,8 +2104,34 @@ def test_help_shows_short_aliases_and_configured_newproblem_cooldown():
     assert "/tag — 查看当前题目的算法标签" in text, text
     assert "/review(/rv) 你的问题 — 默认复盘上一道已通过题；引用题目卡片可复盘旧题；@群友可带入其上下文" in text, text
     assert "/clarify(/clrf) 你的问题 — 向AI澄清题目细节，只回答题目本身不剧透做法" in text, text
+    assert "/setproblem(/sp)" not in text, text
+    assert "/sync —" not in text, text
+    assert "private judge" in text and "详细用法请私聊发 /help" in text, text
     _cleanup()
     print("✅ help: aliases and dynamic cooldown")
+
+
+def test_private_help_only_shows_private_judge_commands():
+    _reset_state()
+    with _all_patches():
+        from kouhai_bot.handlers.cmd.help import handle
+        from kouhai_bot.handlers.registry import discover_commands
+        discover_commands()
+        asyncio.run(handle(**_kwargs(_make_private_event("/help"))))
+
+    assert _private_sent, "Expected private help to send directly"
+    msg = _private_sent[-1]["message"]
+    text = " ".join(
+        seg.get("data", {}).get("text", "")
+        for seg in msg if isinstance(seg, dict) and seg.get("type") == "text"
+    )
+    assert "/setproblem(/sp) [题号|链接|random] — 设置 private judge 当前题" in text, text
+    assert "/sync — 在群聊和 private judge 间同步当前群题记录" in text, text
+    assert "/newproblem(/np)" not in text, text
+    assert "/scoreboard" not in text, text
+    assert "可能丢掉当前侧这题交流历史" in text, text
+    _cleanup()
+    print("✅ private help: filters group-only commands")
 
 
 def test_newproblem_cooldown():
@@ -3091,7 +3202,55 @@ def test_submit_parallel_different_groups_do_not_block():
 
 
 def test_submit_user_group_blocked_within_window():
-    """Configured user groups can delay /submit shortly after a new problem is posted."""
+    """Delayed starred group /submit is recalled and judged in private."""
+    _reset_state()
+    global _deepseek_response
+    _deepseek_response = {"correct": False, "reason": "private no", "reply": "还不对"}
+    _setup_problem_for(GID, PID)
+    _write_state(GID, {
+        "today": PID,
+        "contestId": 542,
+        "index": "D",
+        "name": "Superhero's Job",
+        "rating": 2600,
+        "tags": ["number theory", "dp"],
+        "date": "2026-05-14",
+        "posted_at": int(time.time()),
+    })
+
+    lazy = _LazyConfig()
+    lazy._config = {
+        **_config_dict(),
+        "user_groups": [
+            UserGroupConfig(
+                name="starred",
+                display_name="打星",
+                user_ids=[UID],
+                submit_delay_sec=300,
+                submit_delay_message="将机会多留给年轻人吧～{wait}",
+            )
+        ],
+    }
+
+    with _all_patches(), patch("kouhai_bot.config._config", lazy):
+        from kouhai_bot.handlers.cmd.submit import handle
+        asyncio.run(handle(**_kwargs(_make_event("/submit my solution text here"))))
+
+    assert _deleted == ["msg_001"], f"Expected original group submit to be recalled: {_deleted}"
+    private_text = "\n".join(
+        " ".join(seg.get("data", {}).get("text", "") for seg in item["message"] if seg.get("type") == "text")
+        for item in _private_sent
+    )
+    assert "已转到 private judge" in private_text, private_text
+    assert "刚才被撤回的提交内容" in private_text, private_text
+    assert "my solution text here" in private_text, private_text
+    assert _deepseek_calls, "Private judge should run for redirected submit"
+    _cleanup()
+    print("✅ submit: delayed user group submit redirects to private")
+
+
+def test_starred_redirect_does_not_mark_first_notice_when_private_intro_fails():
+    """If the first private notice cannot be sent, retry should still send intro/card later."""
     _reset_state()
     _setup_problem_for(GID, PID)
     _write_state(GID, {
@@ -3119,25 +3278,31 @@ def test_submit_user_group_blocked_within_window():
         ],
     }
 
-    with ExitStack() as stack:
-        stack.enter_context(patch("kouhai_bot.config._config", lazy))
-        stack.enter_context(patch("kouhai_bot.napcat.client.send_group_msg", _mock_send_group))
-        stack.enter_context(patch("kouhai_bot.handlers.cmd.submit.send_group_msg", _mock_send_group))
-        stack.enter_context(patch("kouhai_bot.handlers.shared.judge_submission_result", _mock_judge_result))
-        from kouhai_bot.handlers.cmd.submit import handle
-        asyncio.run(handle(**_kwargs(_make_event("/submit my solution text here"))))
+    async def _fail_private_send(user_id, message):
+        return None
 
-    text = _last_text()
-    assert "将机会多留给年轻人吧～" in text, f"Expected user-group reminder, got: {text}"
-    assert "请等待" in text and "后再提交" in text, f"Expected wait hint, got: {text}"
-    assert not _deepseek_calls, f"Judge should not run for blocked submit: {_deepseek_calls}"
+    with _all_patches(), patch("kouhai_bot.config._config", lazy):
+        from kouhai_bot.handlers.cmd.submit import handle
+        from kouhai_bot.private_judge import has_group_problem_private_notified
+
+        with patch("kouhai_bot.handlers.cmd.submit.send_private_msg", _fail_private_send):
+            asyncio.run(handle(**_kwargs(_make_event("/submit my solution text here"))))
+
+        notified = has_group_problem_private_notified(UID, PID)
+
+    assert not notified
+    assert _deleted == [], f"Submit should not be recalled when private repeat failed: {_deleted}"
+    assert not _deepseek_calls, f"Judge should not run when private repeat failed: {_deepseek_calls}"
+    assert any("私聊发送失败" in _last_text_item(item) for item in _sent), _sent
     _cleanup()
-    print("✅ submit: user group blocked within window")
+    print("✅ submit: failed private redirect does not consume first notice")
 
 
 def test_submit_user_group_blocked_uses_dynamic_wait():
-    """Dynamic wait stored in scoreboard extends the configured floor."""
+    """Dynamic wait still redirects starred submits to private judge."""
     _reset_state()
+    global _deepseek_response
+    _deepseek_response = {"correct": False, "reason": "private no", "reply": "还不对"}
     _setup_problem_for(GID, PID)
     _write_state(GID, {
         "today": PID,
@@ -3177,20 +3342,195 @@ def test_submit_user_group_blocked_uses_dynamic_wait():
         ],
     }
 
-    with ExitStack() as stack:
-        stack.enter_context(patch("kouhai_bot.config._config", lazy))
-        stack.enter_context(patch("kouhai_bot.napcat.client.send_group_msg", _mock_send_group))
-        stack.enter_context(patch("kouhai_bot.handlers.cmd.submit.send_group_msg", _mock_send_group))
-        stack.enter_context(patch("kouhai_bot.handlers.shared.judge_submission_result", _mock_judge_result))
+    with _all_patches(), patch("kouhai_bot.config._config", lazy):
         from kouhai_bot.handlers.cmd.submit import handle
         asyncio.run(handle(**_kwargs(_make_event("/submit my solution text here"))))
 
-    text = _last_text()
-    assert "将机会多留给年轻人吧～" in text, f"Expected dynamic wait reminder, got: {text}"
-    assert "请等待 9 分钟后再提交" in text, f"Expected extended dynamic wait, got: {text}"
-    assert not _deepseek_calls, f"Judge should not run for blocked submit: {_deepseek_calls}"
+    assert _deleted == ["msg_001"], f"Expected original group submit to be recalled: {_deleted}"
+    private_text = "\n".join(
+        " ".join(seg.get("data", {}).get("text", "") for seg in item["message"] if seg.get("type") == "text")
+        for item in _private_sent
+    )
+    assert "刚才被撤回的提交内容" in private_text, private_text
+    assert _deepseek_calls, "Private judge should run for redirected submit"
     _cleanup()
-    print("✅ submit: user group blocked by dynamic wait")
+    print("✅ submit: dynamic wait redirects to private")
+
+
+def test_private_setproblem_current_copies_empty_private_history():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    group_record = {
+        "timestamp": "2026-05-14T12:00:00+08:00",
+        "type": "clarify",
+        "content": "n 是多少？",
+        "result": "clarify",
+        "reply": "n ≤ 1e5",
+        "problem": PID,
+    }
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {str(UID): [group_record]}})
+
+    with _all_patches():
+        from kouhai_bot.handlers.cmd.setproblem import handle
+        from kouhai_bot.private_judge import get_private_current_problem, load_private_problem_history
+
+        asyncio.run(handle(**_kwargs(_make_private_event("/setproblem"))))
+        current = get_private_current_problem(UID)
+        history = load_private_problem_history(UID, PID)
+
+    assert current and current["today"] == PID, current
+    assert history and history[0]["content"] == "n 是多少？", history
+    private_text = "\n".join(
+        " ".join(seg.get("data", {}).get("text", "") for seg in item["message"] if seg.get("type") == "text")
+        for item in _private_sent
+    )
+    assert "来自群聊的历史记录" in private_text, private_text
+    _cleanup()
+    print("✅ private setproblem: copies empty private history")
+
+
+def test_private_review_allowed_after_group_solves_current_problem():
+    _reset_state()
+    global _deepseek_response
+    _deepseek_response = "可以复盘这题。"
+    _setup_problem_for(GID, PID)
+    _write_scoreboard(GID, {
+        "solves": [{"user_id": OTHER_UID, "nickname": "Bob", "problem": PID, "timestamp": time.time()}],
+        "user_submissions": {},
+    })
+
+    with _all_patches():
+        from kouhai_bot.private_judge import set_private_current_problem
+        from kouhai_bot.handlers.cmd.review import handle
+
+        set_private_current_problem(UID, {
+            "today": PID,
+            "contestId": 542,
+            "index": "D",
+            "name": "Superhero's Job",
+            "rating": 2600,
+            "tags": [],
+        })
+        asyncio.run(handle(**_kwargs(_make_private_event("/review 为什么这样做？"))))
+
+    review_calls = [call for call in _deepseek_calls if call.get("task") == "review"]
+    assert review_calls, _deepseek_calls
+    private_text = "\n".join(
+        " ".join(seg.get("data", {}).get("text", "") for seg in item["message"] if seg.get("type") == "text")
+        for item in _private_sent
+    )
+    assert "可以复盘" in private_text, private_text
+    _cleanup()
+    print("✅ private review: group solve unlocks current problem")
+
+
+def test_sync_aborts_when_source_has_no_history_without_clearing_target():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    target_record = {
+        "timestamp": "2026-05-14T12:00:00+08:00",
+        "type": "clarify",
+        "content": "group keep",
+        "result": "clarify",
+        "reply": "keep",
+        "problem": PID,
+    }
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {str(UID): [target_record]}})
+
+    with _all_patches():
+        from kouhai_bot.handlers.cmd.sync import handle
+        asyncio.run(handle(**_kwargs(_make_event("/sync"))))
+
+    with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
+        saved = json.load(f)
+    assert saved["user_submissions"][str(UID)][0]["content"] == "group keep"
+    assert "已取消" in _last_text(), _last_text()
+    _cleanup()
+    print("✅ sync: empty source aborts without clearing target")
+
+
+def test_sync_private_correct_current_problem_scores_for_normal_user():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
+    private_record = {
+        "timestamp": "2026-05-14T12:00:00+08:00",
+        "type": "submit",
+        "content": "private ac",
+        "result": "correct",
+        "reason": "ok",
+        "reply": "",
+        "problem": PID,
+    }
+
+    with _all_patches():
+        from kouhai_bot.private_judge import save_private_submission
+        from kouhai_bot.handlers.cmd.sync import handle
+
+        save_private_submission(UID, private_record)
+        asyncio.run(handle(**_kwargs(_make_event("/sync"))))
+
+    with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
+        saved = json.load(f)
+    assert saved["solves"] and str(saved["solves"][0]["user_id"]) == str(UID), saved
+    assert saved["user_submissions"][str(UID)][0]["content"] == "private ac"
+    assert any("本题 +" in _last_text_item(item) for item in _sent), _sent
+    _cleanup()
+    print("✅ sync: private AC scores current group problem for normal user")
+
+
+def test_private_sync_from_solved_group_marks_private_review_state():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    group_record = {
+        "timestamp": "2026-05-14T12:00:00+08:00",
+        "type": "clarify",
+        "content": "group clarify",
+        "result": "clarify",
+        "reply": "group reply",
+        "problem": PID,
+    }
+    _write_scoreboard(GID, {
+        "solves": [{"user_id": OTHER_UID, "nickname": "Bob", "problem": PID, "timestamp": time.time()}],
+        "user_submissions": {str(UID): [group_record]},
+    })
+
+    with _all_patches():
+        from kouhai_bot.private_judge import get_private_review_pid, set_private_current_problem
+        from kouhai_bot.handlers.cmd.sync import handle
+
+        set_private_current_problem(UID, {
+            "today": PID,
+            "contestId": 542,
+            "index": "D",
+            "name": "Superhero's Job",
+            "rating": 2600,
+            "tags": [],
+        })
+        asyncio.run(handle(**_kwargs(_make_private_event("/sync"))))
+        set_private_current_problem(UID, {
+            "today": PID2,
+            "contestId": 100,
+            "index": "A",
+            "name": "Other Problem",
+            "rating": 2000,
+            "tags": [],
+        })
+        review_pid = get_private_review_pid(UID, GID)
+
+    assert review_pid == PID
+    _cleanup()
+    print("✅ sync: solved group state is persisted for private review")
+
+
+def _last_text_item(item: dict) -> str:
+    msg = item.get("message", [])
+    if isinstance(msg, list):
+        return " ".join(
+            seg.get("data", {}).get("text", "")
+            for seg in msg if isinstance(seg, dict) and seg.get("type") == "text"
+        )
+    return str(msg)
 
 
 if __name__ == "__main__":

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3603,8 +3603,8 @@ def test_sync_history_card_uses_friendly_visible_format():
         if item["user_id"] == 1
     )
     assert "AliceCard在当前的历史记录如下：" in history_text, history_text
-    assert "👤：first line second line   🤖：bot reply visible" in history_text, history_text
-    assert "👤：what is n?   🤖：n is input" in history_text, history_text
+    assert "👤：first line second line\n🤖：bot reply visible" in history_text, history_text
+    assert "👤：what is n?\n🤖：n is input" in history_text, history_text
     assert "secret reason" not in history_text and "hidden clarify reason" not in history_text
     assert "submit" not in history_text and "incorrect" not in history_text
     assert _forwarded, "Expected history to be forwarded to group"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1934,6 +1934,36 @@ def test_problem_unsolved_resend_does_not_show_next_problem_hint():
     print("✅ problem: unsolved resend has no next-problem hint")
 
 
+def test_problem_high_difficulty_resend_warns_after_card():
+    _reset_state()
+    _setup_problem()
+    _write_state(GID, {
+        "today": PID,
+        "contestId": 542,
+        "index": "D",
+        "name": "Superhero's Job",
+        "rating": 2901,
+        "tags": ["number theory", "dp"],
+        "date": "2026-05-14",
+    })
+    _write_group_file(GID, "daily_msg.json", {
+        "msg_id": 1111,
+        "pid": PID,
+    })
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
+
+    with _all_patches():
+        from kouhai_bot.handlers.cmd.stubs import handle_problem
+        asyncio.run(handle_problem(**_kwargs(_make_event("/problem"))))
+
+    assert len(_forwarded) == 1, f"Expected problem card resend, got: {_forwarded}"
+    text = _last_text()
+    assert "难度较高" in text, text
+    assert "题解" in text, text
+    _cleanup()
+    print("✅ problem: high difficulty resend warns after card")
+
+
 def test_problem_no_current_problem():
     """No current problem → friendly /newproblem hint."""
     _reset_state()
@@ -3451,6 +3481,38 @@ def test_private_problem_card_hides_original_problem_identity():
     print("✅ private problem card: hides original identity")
 
 
+def test_private_problem_card_high_difficulty_warns_after_card():
+    _reset_state()
+    _write_group_file(GID, "daily_msg.json", {
+        "msg_id": 1111,
+        "pid": PID,
+    })
+    problem = {
+        "today": PID,
+        "contestId": 542,
+        "index": "D",
+        "name": "Superhero's Job",
+        "rating": 2901,
+        "tags": [],
+    }
+
+    with _all_patches(), patch("kouhai_bot.private_judge.asyncio.sleep", AsyncMock()):
+        from kouhai_bot.private_judge import send_problem_card_private
+
+        ok = asyncio.run(send_problem_card_private(UID, GID, problem, prefer_group_card=True))
+
+    assert ok
+    assert len(_private_forwarded) == 1, f"Expected private problem card, got: {_private_forwarded}"
+    private_text = "\n".join(
+        " ".join(seg.get("data", {}).get("text", "") for seg in item["message"] if seg.get("type") == "text")
+        for item in _private_sent
+    )
+    assert "难度较高" in private_text, private_text
+    assert "题解" in private_text, private_text
+    _cleanup()
+    print("✅ private problem card: high difficulty warns after card")
+
+
 def test_private_state_load_logs_corrupt_json_once(caplog):
     _reset_state()
     state_dir = os.path.join(_data_dir(), "private_judge", "users")
@@ -3750,6 +3812,7 @@ if __name__ == "__main__":
     test_problem_ignores_stale_daily_msg_pid()
     test_problem_solved_resend_shows_next_problem_hint()
     test_problem_unsolved_resend_does_not_show_next_problem_hint()
+    test_problem_high_difficulty_resend_warns_after_card()
     test_problem_alias_dispatches_to_problem_handler()
     test_tag_with_tags()
     test_scoreboard_with_data()
@@ -3776,6 +3839,7 @@ if __name__ == "__main__":
     test_review_history_formats_types_and_submit_numbers()
     test_user_submission_history_is_unbounded_and_upserts_by_request_id()
     test_clarify_prompt_hides_original_problem_identity()
+    test_private_problem_card_high_difficulty_warns_after_card()
     test_submit_same_user_includes_previous_clarify_history()
     test_submit_parallel_different_groups_do_not_block()
     test_submit_starred_user_shows_own_group_top5()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3389,6 +3389,44 @@ def test_private_setproblem_current_copies_empty_private_history():
     print("✅ private setproblem: copies empty private history")
 
 
+def test_private_problem_card_hides_original_problem_identity():
+    _reset_state()
+    _write_statement(PID, {
+        "name": "D. Superhero's Job",
+        "time_limit": "2s",
+        "memory_limit": "256MB",
+        "description": "Statement text",
+        "input": "n",
+        "output": "answer",
+        "samples": [{"input": "1", "output": "1"}],
+    })
+    _write_group_file(GID, "problem_summaries.json", {
+        PID: {"summary_zh": "SUMMARY_ONLY"},
+    })
+
+    with _all_patches():
+        from kouhai_bot.private_judge import build_problem_card_payload
+
+        payload = asyncio.run(build_problem_card_payload(GID, {
+            "today": PID,
+            "contestId": 542,
+            "index": "D",
+            "name": "Superhero's Job",
+            "rating": 2600,
+            "tags": [],
+        }))
+
+    post_msg = payload["post_msg"]
+    assert post_msg.startswith("private judge 题目"), post_msg
+    assert "SUMMARY_ONLY" in post_msg, post_msg
+    assert PID not in post_msg, post_msg
+    assert "CF" not in post_msg, post_msg
+    assert "Superhero" not in post_msg, post_msg
+    assert "2600" not in post_msg and "rating" not in post_msg, post_msg
+    _cleanup()
+    print("✅ private problem card: hides original identity")
+
+
 def test_private_review_allowed_after_group_solves_current_problem():
     _reset_state()
     global _deepseek_response

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -15,7 +15,7 @@ def test_discover_commands():
     cmds = all_commands()
     names = {c.name for c in cmds}
     expected = {"help", "newproblem", "submit", "problem",
-                "tag", "clarify", "scoreboard"}
+                "tag", "clarify", "scoreboard", "setproblem", "sync"}
     missing = expected - names
     assert not missing, f"Missing commands: {missing}"
     assert len(cmds) >= 7
@@ -49,6 +49,7 @@ def test_alias_lookup():
         "rv": "review",
         "pb": "problem",
         "np": "newproblem",
+        "sp": "setproblem",
     }
     for alias, canonical in expected.items():
         cmd = get(alias)


### PR DESCRIPTION
## Summary

Add private judge support for one-on-one judging over QQ private messages while keeping group context and private context separate but syncable.

Key changes:
- Add private-judge state storage, private problem cards, CF problem/link parsing, random private problem selection, and history-card forwarding helpers.
- Add `/setproblem` (`/sp`) and `/sync`; keep group help concise while private help lists the private-judge commands in detail.
- Extend `/submit`, `/clarify`, `/review`, `/clear`, `/problem`, `/tag`, and `/status` to work in private mode without group mentions/reactions.
- Redirect delayed starred-user group submissions into private judge, preserving the submitted text before recalling the group message.
- Allow group-solved current private problems to enter review, and allow normal users to sync a private AC for the current group problem back into the group scoreboard.

## Semantics / Safety

- `/sync` aborts without overwriting if the source side has no relevant history.
- Group-side `/sync` scoreboard writes now run under the group state lock.
- Private clarification uses the selected problem's summary instead of the latest group summary.
- If the first starred-user private redirect message cannot be sent, the original group message is not recalled and the first-notice state is not consumed.
- `/sp` is intentionally retained per product decision.

## Validation

- `uv run python -m pytest tests/test_commands.py -q` -> 88 passed
- `uv run python -m pytest` -> 169 passed
- `git diff --cached --check`