### PR TITLE
[codex] Fix private reaction ack messages

### DIFF
--- a/src/kouhai_bot/handlers/cmd/clear.py
+++ b/src/kouhai_bot/handlers/cmd/clear.py
@@ -9,7 +9,7 @@ from .. import registry
 from ..registry import CommandDef
 from ...eventlog import EVENT_META_KEY
 from ...napcat.client import (
-    build_face,
+    build_private_reaction_message,
     send_private_msg,
     react_emoji,
 )
@@ -26,7 +26,7 @@ async def handle(group_id: int, user_id: int, sender: dict,
     stripped = raw_text.strip()
     if not re.fullmatch(r"/clear(?:\s+)?", stripped):
         if scope == PRIVATE_SCOPE:
-            await send_private_msg(user_id, [build_face("10060")])
+            await send_private_msg(user_id, build_private_reaction_message("10060"))
         else:
             await react_emoji(message_id, "10060")
         return

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -74,7 +74,7 @@ from ...private_judge import (
 from ...tutorials import format_editorial_for_review, get_official_editorial
 from ...napcat.client import (
     build_at,
-    build_face,
+    build_private_reaction_message,
     build_plain_message,
     build_text,
     delete_msg,
@@ -297,7 +297,7 @@ async def _send_req_segments(req: PendingRequest, segments: list[dict]) -> int |
 
 async def _react_req(req: PendingRequest, emoji_id: str) -> None:
     if req.is_private:
-        await send_private_msg(req.user_id, [build_face(emoji_id)])
+        await send_private_msg(req.user_id, build_private_reaction_message(emoji_id))
         return
     await react_emoji(req.message_id, emoji_id)
 

--- a/src/kouhai_bot/napcat/client.py
+++ b/src/kouhai_bot/napcat/client.py
@@ -149,6 +149,16 @@ def build_face(emoji_id: str | int) -> dict:
     return {"type": "face", "data": {"id": str(emoji_id)}}
 
 
+def build_private_reaction_message(emoji_id: str | int) -> list[dict]:
+    text = {
+        "128064": "👀",
+        "289": "[睁眼]",
+        "10060": "👌",
+        "123": "😵",
+    }.get(str(emoji_id), "收到～")
+    return build_plain_message(text)
+
+
 def build_plain_message(text: str) -> list[dict]:
     return [build_text(text)]
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1624,7 +1624,7 @@ def test_submit_operation_not_blocked():
     print("✅ submit: 操作 not blocked")
 
 
-def test_private_submit_sends_ack_face_instead_of_reaction():
+def test_private_submit_sends_text_ack_instead_of_face_or_reaction():
     _reset_state()
     _setup_problem()
     global _deepseek_response
@@ -1643,17 +1643,38 @@ def test_private_submit_sends_ack_face_instead_of_reaction():
         set_private_current_problem(UID, get_today_problem(GID))
         asyncio.run(handle(**_kwargs(_make_private_event("/submit try dp"))))
 
-    faces = [
-        seg.get("data", {}).get("id")
+    face_segments = [
+        seg
         for item in _private_sent if item["user_id"] == UID
         for seg in item["message"] if isinstance(seg, dict) and seg.get("type") == "face"
     ]
-    assert any(face in {"128064", "289"} for face in faces), f"Expected private ack face, got: {_private_sent}"
+    assert not face_segments, f"Private ack should avoid face segments NapCat may reject: {_private_sent}"
     assert not _reacted, f"Private submit should not use group reactions: {_reacted}"
     private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
+    assert any(token in private_text for token in ("👀", "[睁眼]")), private_text
     assert "关键证明" in private_text, private_text
     _cleanup()
-    print("✅ private submit: ack uses face message")
+    print("✅ private submit: ack uses safe text message")
+
+
+def test_private_clear_invalid_usage_sends_text_ack_instead_of_face():
+    _reset_state()
+
+    with _all_patches():
+        from kouhai_bot.handlers.cmd.clear import handle
+        asyncio.run(handle(**_kwargs(_make_private_event("/clear now"))))
+
+    face_segments = [
+        seg
+        for item in _private_sent if item["user_id"] == UID
+        for seg in item["message"] if isinstance(seg, dict) and seg.get("type") == "face"
+    ]
+    assert not face_segments, f"Private clear ack should avoid face segments: {_private_sent}"
+    assert not _reacted, f"Private clear should not use group reactions: {_reacted}"
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
+    assert "👌" in private_text, private_text
+    _cleanup()
+    print("✅ private clear invalid usage: ack uses safe text message")
 
 
 def test_submit_no_problem():
@@ -4077,7 +4098,8 @@ if __name__ == "__main__":
     test_review_after_pending_submit_uses_snapshotted_solved_problem()
     test_submit_off_topic()
     test_submit_operation_not_blocked()
-    test_private_submit_sends_ack_face_instead_of_reaction()
+    test_private_submit_sends_text_ack_instead_of_face_or_reaction()
+    test_private_clear_invalid_usage_sends_text_ack_instead_of_face()
     test_submit_no_problem()
     test_clarify_with_problem()
     test_clarify_no_problem()


### PR DESCRIPTION
## What changed

- Added a private-message-safe reaction acknowledgement builder.
- Switched private `/submit` and private `/clear` acknowledgements away from OneBot `face` segments.
- Kept group acknowledgements using `set_msg_emoji_like` reactions.
- Updated command tests to assert private acknowledgements are text messages, not `face` segments.

## Why

NapCat rejected private messages like `[{"type":"face","data":{"id":"128064"}}]` with `消息体无法解析`. Those IDs are reaction emoji IDs, not reliable QQ private-message `face` IDs, so sending them as `face` segments can fail before the judge result is delivered.

## Validation

- `python3 -m py_compile src/kouhai_bot/napcat/client.py src/kouhai_bot/handlers/cmd/submit.py src/kouhai_bot/handlers/cmd/clear.py tests/test_commands.py`
- `.venv/bin/python tests/test_commands.py`