### PR TITLE
[codex] Auto approve service group friend requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ NapCat (QQ) ──WS──> worker.py
 - **Stale cache detection**: `picker.py:fetch_statement()` detects caches created before VL pipeline via `_vl_processed` flag. Stale caches with images are re-fetched with Qwen-VL. Problems with non-formula images (tex-graphics / diagrams) are skipped.
 - **No hermes cron involvement**: The bot runs its own scheduler loop (`scheduler/engine.py`), not hermes cron jobs.
 - **Single worker runtime**: `worker.py` keeps the NapCat reverse-WS connection, dispatches commands, and owns the scheduler in one process. There is no SQLite event queue, ingress supervisor, worker hot-swap, or auto-update loop.
+- **Friend request auto-approval**: OneBot `post_type="request"` events are parsed by `napcat/client.py` and handled in `handlers.process_event()`. Only `request_type="friend"` is considered. The bot calls `set_friend_add_request` only when the requester is confirmed to be a member of `CURRENT_GROUP` via NapCat member lookup; lookup failure, malformed events, non-friend requests, and non-members are ignored without approving.
 - **User groups**: `user_groups.py` — all users default to `default`; `USER_GROUPS` configures
   non-default groups such as `starred`/`打星`, their members, submit delay, and rejection
   message. `submit_delay_sec > 0` enables dynamic per-user submit waits for that group:
@@ -159,9 +160,9 @@ This bot is a **reverse WebSocket server** plus a **NapCat HTTP API client**:
 - `kouhai_bot.napcat.client.NapCatServer` listens on `napcat_ws_host:napcat_ws_port`;
   NapCat must connect to it through a OneBot11 `websocketClients` entry.
 - Message sending uses `napcat_http_host:napcat_http_port` and calls NapCat OneBot11
-  HTTP actions such as `send_group_msg`, `send_private_msg`, and
-  `get_group_member_info`; NapCat must expose an enabled OneBot11 `httpServers`
-  entry on that port.
+  HTTP actions such as `send_group_msg`, `send_private_msg`,
+  `get_group_member_info`, and `set_friend_add_request`; NapCat must expose an
+  enabled OneBot11 `httpServers` entry on that port.
 
 When NapCat is deployed with Docker Compose, prefer this pattern:
 
@@ -431,6 +432,10 @@ Private dispatch maps DMs to `CURRENT_GROUP`, requires the sender to be a member
 service group, and only allows the private command whitelist: `/setproblem`, `/problem`,
 `/tag`, `/submit`, `/clarify`, `/review`, `/clear`, `/sync`, `/status`, and `/help`.
 Private commands do not require @mentions and should not send @ segments back.
+
+Friend request events are not commands and are not logged to command event logs.
+`process_event()` handles `type="request"` before message dispatch: it accepts only
+friend requests from confirmed `CURRENT_GROUP` members and otherwise returns silently.
 
 ### Command Event Log
 
@@ -874,20 +879,25 @@ See Configuration section above. Binding to `127.0.0.1` breaks Docker NapCat con
 NapCat's `set_msg_emoji_like` API expects `message_id` as int. Pass string and it
 silently fails.
 
-### 8. save_scoreboard needs indent=2
+### 8. Friend requests require confirmed service-group membership
+Auto-approval must remain fail-closed. Do not call `set_friend_add_request` unless
+NapCat confirms the requester is in `CURRENT_GROUP`; if member lookup fails, ignore
+the request rather than approving it.
+
+### 9. save_scoreboard needs indent=2
 Must pass `json.dump(sb, f, ensure_ascii=False, indent=2)` for backward compatibility
 with old scoreboard files.
 
-### 9. save_user_submission keeps full history
+### 10. save_user_submission keeps full history
 Per-user submission history is intentionally unbounded. Records with a `request_id`
 update the matching existing record in place; records without one append normally.
 
-### 10. Save Chinese summaries by pid if you need later reuse
+### 11. Save Chinese summaries by pid if you need later reuse
 The summary shown in the group post is now persisted in `groups/<gid>/problem_summaries.json`.
 Annotation export and the HTML labeling UI reuse this first before attempting any new
 translation. Do not force synchronous translation on detail-page clicks.
 
-### 11. Daily post uses merged-forward
+### 12. Daily post uses merged-forward
 `do_daily_post()` self-sends summary text, sample nodes, optional translated notes node,
 and snake image, then forwards them as one merged card. `daily_msg.json` must persist
 all node references (`msg_id`, `sample_msg_ids`, optional `note_msg_id`, `snake_msg_id`)
@@ -897,49 +907,49 @@ succeeds, `daily_msg.json` must still persist the current `pid` and rebuild inpu
 `state.json.today`.
 Complicated but essential for good UX.
 
-### 12. Dispatch uses create_task
+### 13. Dispatch uses create_task
 Commands are `asyncio.create_task`'d, not `await`ed. This prevents lightweight
 commands from queuing behind locked operations.
 
-### 13. Off-topic submissions are NOT saved
+### 14. Off-topic submissions are NOT saved
 If the judge returns `reaction: "123"`, the submission is marked as troll and
 NOT recorded to scoreboard. The save happens AFTER the reaction check.
 
-### 14. Do not add local off-topic blacklists for `/submit` or `/clarify`
+### 15. Do not add local off-topic blacklists for `/submit` or `/clarify`
 Off-topic handling belongs to the model output (`reaction="123"`), not substring
 matching in the command entrypoint. Local blacklists are too brittle and can
 misfire on normal solution text such as `操作`.
 
-### 15. Nickname fallback is user_id not "群友"
+### 16. Nickname fallback is user_id not "群友"
 `get_display_name()` / `_nick()` fall back to `str(user_id)` (as a string of digits),
 never a generic placeholder like "群友".
 
-### 16. Every message text matters
+### 17. Every message text matters
 The old bridge has specific wording for each message. Every difference was caught
 in review — validation messages, error messages, reminder text, greeting text.
 All must match exactly. See the commit history for the iterative alignment process.
 
-### 17. LaTeX in problem summaries
+### 18. LaTeX in problem summaries
 `summarize_problem()` prompt explicitly forbids LaTeX/markdown. The summary model
 sometimes still outputs LaTeX — ping the user if you see this happening.
 
-### 18. Annotation detail pages must not block on translation
+### 19. Annotation detail pages must not block on translation
 The annotation UI can show a placeholder for `summary_zh`, then fetch translation
 asynchronously. Clicking a problem in the left pane should open the right pane
 immediately; do not make `handle_detail()` await a long translation call.
 
-### 19. Active status tracking prevents confusing UX
+### 20. Active status tracking prevents confusing UX
 The scheduler exposes earliest active request metadata so `/status` can tell users
 there is in-flight stateful work. It is not a queue head and does not imply unrelated
 commands are blocked.
 
-### 20. Clarify reasoning controls
+### 21. Clarify reasoning controls
 `/clarify` sends `thinking={"type": "enabled"}` and `reasoning_effort` unconditionally.
 The upstream API silently ignores fields it doesn't support. The JSON output format
 may occasionally break if extra reasoning content leaks into the response —
 `robust_json_parse` handles this.
 
-### 21. `uv run start` / `restart` / `stop` / `status` are selected by NapCat WS port
+### 22. `uv run start` / `restart` / `stop` / `status` are selected by NapCat WS port
 The `start`, `restart`, `stop`, and `status` entrypoints must use the configured `NAPCAT_WS_PORT` to
 identify the target instance. Do not kill by broad process names like
 `kouhai_bot.worker`, because production and test instances may run at the same time.
@@ -949,45 +959,45 @@ start a fresh detached background instance. `uv run stop` should stop the existi
 listener on that port only. `uv run status` should report whether the port is occupied
 and whether the listener appears to come from the current worktree.
 
-### 22. Official tutorial: first AC only, two messages
+### 23. Official tutorial: first AC only, two messages
 Congrats must stay a direct `send_group_msg` with @mention. Editorial delivery is scheduled
 via `editorial_followup` **after** finalize returns (background task). Merged-forward when
 editorial exists; nothing sent when not. Never bundle congrats and editorial in one card.
 Never `await` editorial translation inside submit finalize — it blocks the whole group queue.
 
-### 23. Tutorial translation cache is per pid
+### 24. Tutorial translation cache is per pid
 `tutorial_translations/{pid}.txt` is not invalidated when scrape JSON changes. Delete the
 cache file to force re-translation after updating prompts or rescraping editorial text.
 
-### 24. Review vs group card use different editorial forms
+### 25. Review vs group card use different editorial forms
 `/review` gets English source (+ code in extracted text) for internal grounding.
 The post-AC card gets Chinese translation without code. Do not send Chinese translation
 into review unless product requirements change.
 
-### 25. Private judge sync must not erase on empty source
+### 26. Private judge sync must not erase on empty source
 `/sync` uses the other side as source and overwrites the current side for the current
 group problem only. If the source side has no records, abort with a friendly message and
 leave the target untouched. This protects users from accidental history loss.
 
-### 26. Private chats use messages, not group affordances
+### 27. Private chats use messages, not group affordances
 Private command handlers must not send @ segments or call `react_emoji`. Use plain
 private messages or face segments (`build_face`) instead. Long private review/history
 responses can use private merged-forward cards.
 
-### 27. Private problem cards should not reveal source identity
+### 28. Private problem cards should not reveal source identity
 When `/setproblem` builds a private card for an explicitly selected or random CF
 problem, the card title should stay generic. Do not include the original problem id,
 title, contest id, or rating there; anti-spoiler clarification also assumes the bot does
 not reveal the original problem identity to the user.
 
-### 27.5. High-rating problem cards need a caution
+### 28.5. High-rating problem cards need a caution
 After sending a problem card for a problem with rating greater than 2800, send a short
 follow-up warning that the problem is hard, the bot's reasoning may be limited, and the
 user should check the official/editorial solution if the bot seems wrong. Keep this as
 a separate message after the card, not inside private card titles where source identity
 could leak.
 
-### 28. Private judge state writes must be atomic
+### 29. Private judge state writes must be atomic
 `private_judge/users/<uid>.json` is user history, not a disposable cache. Write it via a
 same-directory temp file and `os.replace`, and log JSON/IO load failures before falling
 back to defaults so corruption or permission problems are diagnosable.

--- a/src/kouhai_bot/handlers/__init__.py
+++ b/src/kouhai_bot/handlers/__init__.py
@@ -21,6 +21,7 @@ from ..napcat.client import (
     send_group_msg,
     send_private_msg,
     react_emoji,
+    set_friend_add_request,
 )
 
 logger = logging.getLogger("kouhai-bot.handlers")
@@ -91,6 +92,43 @@ async def _is_service_group_member(group_id: int, user_id: int) -> bool:
         return False
 
 
+async def _handle_request_event(event: dict) -> None:
+    if event.get("request_type") != "friend":
+        return
+
+    cfg = get_config()
+    flag = str(event.get("flag", "") or "")
+    try:
+        user_id = int(event.get("user_id", 0) or 0)
+    except (TypeError, ValueError):
+        user_id = 0
+
+    if not flag or user_id <= 0:
+        logger.warning("ignoring malformed friend request event: %s", event.get("raw", event))
+        return
+    if str(user_id) == str(cfg.bot_qq):
+        return
+
+    if not await _is_service_group_member(cfg.current_group, user_id):
+        logger.info(
+            "friend request from user_%s ignored: not a confirmed member of group_%s",
+            user_id,
+            cfg.current_group,
+        )
+        return
+
+    if await set_friend_add_request(flag, approve=True):
+        logger.info(
+            "approved friend request from service group member user_%s",
+            user_id,
+        )
+    else:
+        logger.warning(
+            "failed to approve friend request from service group member user_%s",
+            user_id,
+        )
+
+
 def _normalize_leading_command_junk(text: str) -> str:
     """Strip invisible leading junk only when it prefixes a slash command.
 
@@ -126,6 +164,15 @@ async def process_event(
     for long-running command handlers. Tests can pass ``False`` to await a handler
     directly.
     """
+    if event["type"] == "request":
+        if spawn_handlers:
+            return asyncio.create_task(
+                _handle_request_event(event),
+                name=f"request_{event.get('request_type', 'unknown')}_{event.get('user_id', 0)}",
+            )
+        await _handle_request_event(event)
+        return None
+
     if event["type"] != "message":
         return
 

--- a/src/kouhai_bot/main.py
+++ b/src/kouhai_bot/main.py
@@ -30,16 +30,29 @@ def main() -> None:
     asyncio.run(main_async())
 
 
-def _listener_pids(port: int) -> set[int]:
+def _listener_lines(port: int) -> list[str]:
     try:
         result = subprocess.run(
             ["ss", "-ltnp", f"( sport = :{port} )"],
             capture_output=True, text=True, check=False,
         )
     except Exception:
-        return set()
+        return []
 
-    return {int(pid) for pid in re.findall(r"pid=(\d+)", result.stdout)}
+    return [
+        line
+        for line in result.stdout.splitlines()
+        if line.startswith("LISTEN")
+    ]
+
+
+def _listener_pids(port: int) -> set[int]:
+    lines = _listener_lines(port)
+    return {int(pid) for line in lines for pid in re.findall(r"pid=(\d+)", line)}
+
+
+def _port_has_listener(port: int) -> bool:
+    return bool(_listener_lines(port))
 
 
 def _kill_pids(pids: set[int], sig: int) -> None:
@@ -60,7 +73,7 @@ def _wait_for_port_release(port: int, timeout_sec: float) -> set[int]:
     deadline = time.monotonic() + timeout_sec
     while time.monotonic() < deadline:
         remaining = _current_port_listeners(port)
-        if not remaining:
+        if not _port_has_listener(port):
             return set()
         time.sleep(0.1)
     return _current_port_listeners(port)
@@ -69,16 +82,20 @@ def _wait_for_port_release(port: int, timeout_sec: float) -> set[int]:
 def _stop_existing_instance_on_port(port: int) -> bool:
     pids = _current_port_listeners(port)
     if not pids:
+        if _port_has_listener(port):
+            raise RuntimeError(
+                f"NapCat WS port {port} is occupied, but the listener PID is unavailable"
+            )
         return False
 
     _kill_pids(pids, signal.SIGTERM)
     remaining = _wait_for_port_release(port, timeout_sec=_PORT_WAIT_TIMEOUT_SEC)
-    if not remaining:
+    if not _port_has_listener(port):
         return True
 
     _kill_pids(remaining, signal.SIGKILL)
     remaining = _wait_for_port_release(port, timeout_sec=_PORT_WAIT_TIMEOUT_SEC)
-    if remaining:
+    if _port_has_listener(port):
         raise RuntimeError(
             f"Could not release NapCat WS port {port}; still listening: {sorted(remaining)}"
         )
@@ -116,10 +133,10 @@ def _current_worktree_listener_state(port: int) -> str:
 def _wait_for_port_bind(port: int, timeout_sec: float) -> bool:
     deadline = time.monotonic() + timeout_sec
     while time.monotonic() < deadline:
-        if _current_port_listeners(port):
+        if _port_has_listener(port):
             return True
         time.sleep(0.1)
-    return bool(_current_port_listeners(port))
+    return _port_has_listener(port)
 
 
 def _spawn_detached_bot(port: int, group_id: int, data_dir: str) -> tuple[int, Path]:
@@ -165,8 +182,7 @@ def start() -> None:
     """Start the bot instance in the background if its WS port is free."""
     cfg = get_config()
     port = cfg.napcat_ws_port
-    existing = _current_port_listeners(port)
-    if existing:
+    if _port_has_listener(port):
         _print_start_status(
             port=port,
             action="start",
@@ -232,12 +248,15 @@ def status() -> None:
     cfg = get_config()
     port = cfg.napcat_ws_port
     listeners = sorted(_current_port_listeners(port))
+    occupied = _port_has_listener(port)
     print("action=status")
     print(f"port={port}")
-    print(f"occupied={'yes' if listeners else 'no'}")
-    print(f"current_worktree_running={_current_worktree_listener_state(port) if listeners else 'no'}")
+    print(f"occupied={'yes' if occupied else 'no'}")
+    print(f"current_worktree_running={_current_worktree_listener_state(port) if occupied else 'no'}")
     if listeners:
         print("pids=" + ",".join(str(pid) for pid in listeners))
+    elif occupied:
+        print("pids=unknown")
 
 
 if __name__ == "__main__":

--- a/src/kouhai_bot/napcat/client.py
+++ b/src/kouhai_bot/napcat/client.py
@@ -99,6 +99,23 @@ async def send_private_forward_msg(user_id: int, messages: list[dict]) -> int | 
         return None
 
 
+async def set_friend_add_request(flag: str, *, approve: bool = True, remark: str = "") -> bool:
+    """Approve or reject a friend request by OneBot request flag."""
+    try:
+        result = await _http_post("set_friend_add_request", {
+            "flag": str(flag),
+            "approve": bool(approve),
+            "remark": str(remark or ""),
+        })
+        if isinstance(result, dict) and str(result.get("status", "") or "").lower() in {"", "ok"}:
+            return True
+        logger.warning("set_friend_add_request returned unexpected payload: %s", result)
+        return False
+    except Exception as e:
+        logger.error("set_friend_add_request failed: %s", e, exc_info=True)
+        return False
+
+
 async def react_emoji(message_id: str, emoji_id: str) -> None:
     """React with an emoji to a message."""
     try:
@@ -186,6 +203,8 @@ def parse_event(raw: str) -> dict | None:
         return _parse_message(event)
     elif post_type == "notice":
         return _parse_notice(event)
+    elif post_type == "request":
+        return _parse_request(event)
     return None
 
 
@@ -221,6 +240,17 @@ def _parse_notice(event: dict) -> dict:
     return {
         "type": "notice",
         "notice_type": event.get("notice_type", ""),
+        "raw": event,
+    }
+
+
+def _parse_request(event: dict) -> dict:
+    return {
+        "type": "request",
+        "request_type": event.get("request_type", ""),
+        "user_id": event.get("user_id", 0),
+        "comment": event.get("comment", ""),
+        "flag": event.get("flag", ""),
         "raw": event,
     }
 

--- a/tests/test_friend_requests.py
+++ b/tests/test_friend_requests.py
@@ -1,0 +1,104 @@
+"""Tests for automatic friend request approval."""
+
+import asyncio
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from kouhai_bot.handlers import process_event
+
+
+def _friend_request(user_id: int = 456, flag: str = "flag-123") -> dict:
+    return {
+        "type": "request",
+        "request_type": "friend",
+        "user_id": user_id,
+        "comment": "hello",
+        "flag": flag,
+        "raw": {},
+    }
+
+
+def _cfg() -> SimpleNamespace:
+    return SimpleNamespace(bot_qq=1, current_group=999999)
+
+
+def test_friend_request_from_service_group_member_is_approved(monkeypatch):
+    calls = []
+
+    async def fake_http_post(action, data):
+        assert action == "get_group_member_info"
+        assert data["group_id"] == 999999
+        assert data["user_id"] == 456
+        return {"status": "ok", "data": {"user_id": 456}}
+
+    async def fake_set_friend_add_request(flag, *, approve=True, remark=""):
+        calls.append({"flag": flag, "approve": approve, "remark": remark})
+        return True
+
+    monkeypatch.setattr("kouhai_bot.handlers.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.napcat.client._http_post", fake_http_post)
+    monkeypatch.setattr("kouhai_bot.handlers.set_friend_add_request", fake_set_friend_add_request)
+
+    asyncio.run(process_event(_friend_request(), spawn_handlers=False))
+
+    assert calls == [{"flag": "flag-123", "approve": True, "remark": ""}]
+
+
+def test_friend_request_from_non_member_is_ignored(monkeypatch):
+    calls = []
+
+    async def fake_http_post(action, data):
+        if action == "get_group_member_info":
+            return {"status": "failed", "data": None}
+        if action == "get_group_member_list":
+            return {"status": "ok", "data": [{"user_id": 999}]}
+        raise AssertionError(action)
+
+    async def fake_set_friend_add_request(flag, *, approve=True, remark=""):
+        calls.append(flag)
+        return True
+
+    monkeypatch.setattr("kouhai_bot.handlers.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.napcat.client._http_post", fake_http_post)
+    monkeypatch.setattr("kouhai_bot.handlers.set_friend_add_request", fake_set_friend_add_request)
+
+    asyncio.run(process_event(_friend_request(), spawn_handlers=False))
+
+    assert calls == []
+
+
+def test_friend_request_member_lookup_failure_is_ignored(monkeypatch):
+    calls = []
+
+    async def fake_http_post(action, data):
+        raise RuntimeError("napcat unavailable")
+
+    async def fake_set_friend_add_request(flag, *, approve=True, remark=""):
+        calls.append(flag)
+        return True
+
+    monkeypatch.setattr("kouhai_bot.handlers.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.napcat.client._http_post", fake_http_post)
+    monkeypatch.setattr("kouhai_bot.handlers.set_friend_add_request", fake_set_friend_add_request)
+
+    asyncio.run(process_event(_friend_request(), spawn_handlers=False))
+
+    assert calls == []
+
+
+def test_non_friend_request_is_ignored(monkeypatch):
+    calls = []
+
+    async def fake_set_friend_add_request(flag, *, approve=True, remark=""):
+        calls.append(flag)
+        return True
+
+    monkeypatch.setattr("kouhai_bot.handlers.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.handlers.set_friend_add_request", fake_set_friend_add_request)
+
+    asyncio.run(process_event({"type": "request", "request_type": "group", "user_id": 456, "flag": "f"}, spawn_handlers=False))
+
+    assert calls == []

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,7 +24,7 @@ def test_start_reports_already_running_without_spawning():
     printed = []
 
     with patch("kouhai_bot.main.get_config", return_value=cfg), \
-            patch("kouhai_bot.main._current_port_listeners", return_value={1111}), \
+            patch("kouhai_bot.main._port_has_listener", return_value=True), \
             patch("builtins.print", side_effect=printed.append):
         main.start()
 
@@ -80,6 +80,7 @@ def test_status_reports_idle_when_port_is_free():
 
     with patch("kouhai_bot.main.get_config", return_value=cfg), \
             patch("kouhai_bot.main._current_port_listeners", return_value=set()), \
+            patch("kouhai_bot.main._port_has_listener", return_value=False), \
             patch("builtins.print", side_effect=printed.append):
         main.status()
 
@@ -98,6 +99,7 @@ def test_status_reports_current_worktree_listener():
 
     with patch("kouhai_bot.main.get_config", return_value=cfg), \
             patch("kouhai_bot.main._current_port_listeners", return_value={2201}), \
+            patch("kouhai_bot.main._port_has_listener", return_value=True), \
             patch("kouhai_bot.main._repo_root", return_value=repo_root), \
             patch("kouhai_bot.main._pid_cwd", return_value=repo_root), \
             patch("builtins.print", side_effect=printed.append):
@@ -118,6 +120,7 @@ def test_status_reports_other_listener_when_worktree_differs():
 
     with patch("kouhai_bot.main.get_config", return_value=cfg), \
             patch("kouhai_bot.main._current_port_listeners", return_value={3311, 3312}), \
+            patch("kouhai_bot.main._port_has_listener", return_value=True), \
             patch("kouhai_bot.main._repo_root", return_value=Path("/repo/current")), \
             patch("kouhai_bot.main._pid_cwd", side_effect=[Path("/repo/other"), Path("/repo/elsewhere")]), \
             patch("builtins.print", side_effect=printed.append):
@@ -131,6 +134,25 @@ def test_status_reports_other_listener_when_worktree_differs():
         "pids=3311,3312",
     ]
 
+
+
+def test_status_reports_pidless_listener_as_occupied():
+    cfg = SimpleNamespace(napcat_ws_port=8103, current_group=123456, data_dir="/tmp/data")
+    printed = []
+
+    with patch("kouhai_bot.main.get_config", return_value=cfg), \
+            patch("kouhai_bot.main._current_port_listeners", return_value=set()), \
+            patch("kouhai_bot.main._port_has_listener", return_value=True), \
+            patch("builtins.print", side_effect=printed.append):
+        main.status()
+
+    assert printed == [
+        "action=status",
+        "port=8103",
+        "occupied=yes",
+        "current_worktree_running=no",
+        "pids=unknown",
+    ]
 
 def test_spawn_detached_bot_uses_nohup_and_group_daily_log(tmp_path):
     fake_proc = SimpleNamespace(pid=2468)

--- a/tests/test_napcat.py
+++ b/tests/test_napcat.py
@@ -39,5 +39,16 @@ def test_build_text():
     assert seg["data"]["text"] == "hi"
 
 
+def test_parse_friend_request_event():
+    raw = '{"post_type":"request","request_type":"friend","user_id":456,"comment":"hi","flag":"flag-123"}'
+    event = parse_event(raw)
+    assert event is not None
+    assert event["type"] == "request"
+    assert event["request_type"] == "friend"
+    assert event["user_id"] == 456
+    assert event["comment"] == "hi"
+    assert event["flag"] == "flag-123"
+
+
 def test_parse_invalid_json():
     assert parse_event("not json") is None


### PR DESCRIPTION
## What changed

- Parse OneBot/NapCat `post_type=request` events, including friend request `flag` values.
- Add a `set_friend_add_request` HTTP action wrapper.
- Auto-approve friend requests only when the requester is confirmed to be a member of `current_group`.
- Ignore non-friend requests, malformed requests, non-members, and member lookup failures without approving.

## Why

Private judge needs users to be able to friend the bot, but blindly accepting all friend requests is too broad. This keeps the behavior scoped to confirmed service group members.

## Validation

- `python3 -m py_compile src/kouhai_bot/napcat/client.py src/kouhai_bot/handlers/__init__.py tests/test_napcat.py tests/test_friend_requests.py`
- `.venv/bin/pytest tests/test_napcat.py tests/test_friend_requests.py`
- `.venv/bin/pytest tests/test_eventlog.py`
- `.venv/bin/python tests/test_commands.py`