### PR TITLE
[codex] Support doubtful friend request approval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ NapCat (QQ) ──WS──> worker.py
 - **Stale cache detection**: `picker.py:fetch_statement()` detects caches created before VL pipeline via `_vl_processed` flag. Stale caches with images are re-fetched with Qwen-VL. Problems with non-formula images (tex-graphics / diagrams) are skipped.
 - **No hermes cron involvement**: The bot runs its own scheduler loop (`scheduler/engine.py`), not hermes cron jobs.
 - **Single worker runtime**: `worker.py` keeps the NapCat reverse-WS connection, dispatches commands, and owns the scheduler in one process. There is no SQLite event queue, ingress supervisor, worker hot-swap, or auto-update loop.
-- **Friend request auto-approval**: OneBot `post_type="request"` events are parsed by `napcat/client.py` and handled in `handlers.process_event()`. Only `request_type="friend"` is considered. The bot calls `set_friend_add_request` only when the requester is confirmed to be a member of `CURRENT_GROUP` via NapCat member lookup; lookup failure, malformed events, non-friend requests, and non-members are ignored without approving.
+- **Friend request auto-approval**: Normal OneBot `post_type="request"` / `request_type="friend"` events are parsed by `napcat/client.py`, routed by `handlers.process_event()`, and approved via `set_friend_add_request`. QQ/NapCat "doubtful" friend requests are not reliably pushed as request events, so `worker.py` also runs `friend_requests.doubt_friend_request_loop()`, which polls `get_doubt_friends_add_request` and approves with `set_doubt_friends_add_request`. Both paths approve only after the requester is confirmed to be a member of `CURRENT_GROUP`; lookup failure, malformed events, non-friend requests, and non-members are ignored without approving.
 - **User groups**: `user_groups.py` — all users default to `default`; `USER_GROUPS` configures
   non-default groups such as `starred`/`打星`, their members, submit delay, and rejection
   message. `submit_delay_sec > 0` enables dynamic per-user submit waits for that group:
@@ -434,8 +434,10 @@ service group, and only allows the private command whitelist: `/setproblem`, `/p
 Private commands do not require @mentions and should not send @ segments back.
 
 Friend request events are not commands and are not logged to command event logs.
-`process_event()` handles `type="request"` before message dispatch: it accepts only
-friend requests from confirmed `CURRENT_GROUP` members and otherwise returns silently.
+`process_event()` handles normal `type="request"` friend requests before message
+dispatch. `worker.py` separately polls NapCat's doubtful friend request list because
+those requests may only appear through `get_doubt_friends_add_request`. Both paths
+accept only confirmed `CURRENT_GROUP` members and otherwise return silently.
 
 ### Command Event Log
 
@@ -880,9 +882,9 @@ NapCat's `set_msg_emoji_like` API expects `message_id` as int. Pass string and i
 silently fails.
 
 ### 8. Friend requests require confirmed service-group membership
-Auto-approval must remain fail-closed. Do not call `set_friend_add_request` unless
-NapCat confirms the requester is in `CURRENT_GROUP`; if member lookup fails, ignore
-the request rather than approving it.
+Auto-approval must remain fail-closed. Do not call `set_friend_add_request` or
+`set_doubt_friends_add_request` unless NapCat confirms the requester is in
+`CURRENT_GROUP`; if member lookup fails, ignore the request rather than approving it.
 
 ### 9. save_scoreboard needs indent=2
 Must pass `json.dump(sb, f, ensure_ascii=False, indent=2)` for backward compatibility

--- a/src/kouhai_bot/friend_requests.py
+++ b/src/kouhai_bot/friend_requests.py
@@ -1,0 +1,122 @@
+"""Automatic approval for service-group friend requests."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from .config import get_config
+from .napcat.client import (
+    get_doubt_friends_add_requests,
+    set_doubt_friends_add_request,
+    set_friend_add_request,
+)
+
+logger = logging.getLogger("kouhai-bot.friend_requests")
+
+
+def _to_int(value: object) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+async def is_service_group_member(group_id: int, user_id: int) -> bool:
+    from .napcat import client as napcat_client
+
+    try:
+        resp = await napcat_client._http_post(
+            "get_group_member_info",
+            {"group_id": group_id, "user_id": user_id, "no_cache": True},
+        )
+        if isinstance(resp, dict) and resp.get("status") == "ok" and isinstance(resp.get("data"), dict):
+            return bool(resp["data"])
+    except Exception:
+        pass
+    try:
+        resp = await napcat_client._http_post("get_group_member_list", {"group_id": group_id})
+        members = resp.get("data", []) if isinstance(resp, dict) and resp.get("status") == "ok" else []
+        return any(str(item.get("user_id", "")) == str(user_id) for item in members if isinstance(item, dict))
+    except Exception:
+        return False
+
+
+async def handle_friend_request_event(event: dict) -> None:
+    """Approve a normal OneBot friend request when the requester is in CURRENT_GROUP."""
+    if event.get("request_type") != "friend":
+        return
+
+    cfg = get_config()
+    flag = str(event.get("flag", "") or "")
+    user_id = _to_int(event.get("user_id", 0))
+
+    if not flag or user_id <= 0:
+        logger.warning("ignoring malformed friend request event: %s", event.get("raw", event))
+        return
+    if str(user_id) == str(cfg.bot_qq):
+        return
+
+    if not await is_service_group_member(cfg.current_group, user_id):
+        logger.info(
+            "friend request from user_%s ignored: not a confirmed member of group_%s",
+            user_id,
+            cfg.current_group,
+        )
+        return
+
+    if await set_friend_add_request(flag, approve=True):
+        logger.info("approved friend request from service group member user_%s", user_id)
+    else:
+        logger.warning("failed to approve friend request from service group member user_%s", user_id)
+
+
+async def approve_doubt_friend_requests(*, count: int = 50) -> int:
+    """Approve pending doubtful friend requests from service-group members."""
+    cfg = get_config()
+    approved = 0
+    for req in await get_doubt_friends_add_requests(count=count):
+        flag = str(req.get("flag", "") or "")
+        user_id = _to_int(req.get("uin") or req.get("user_id"))
+        if not flag or user_id <= 0:
+            logger.warning("ignoring malformed doubtful friend request: %s", req)
+            continue
+        if str(user_id) == str(cfg.bot_qq):
+            continue
+        if not await is_service_group_member(cfg.current_group, user_id):
+            logger.info(
+                "doubtful friend request from user_%s ignored: not a confirmed member of group_%s",
+                user_id,
+                cfg.current_group,
+            )
+            continue
+        if await set_doubt_friends_add_request(flag, approve=True):
+            approved += 1
+            logger.info("approved doubtful friend request from service group member user_%s", user_id)
+        else:
+            logger.warning(
+                "failed to approve doubtful friend request from service group member user_%s",
+                user_id,
+            )
+    return approved
+
+
+async def doubt_friend_request_loop(
+    *,
+    stop_event: asyncio.Event,
+    interval_seconds: float = 60.0,
+) -> None:
+    """Poll NapCat's doubtful friend request list until shutdown."""
+    logger.info("Doubtful friend request poller started")
+    while True:
+        try:
+            await approve_doubt_friend_requests()
+        except Exception as e:
+            logger.error("doubtful friend request poll failed: %s", e, exc_info=True)
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)
+            break
+        except asyncio.TimeoutError:
+            continue
+    logger.info("Doubtful friend request poller stopped")

--- a/src/kouhai_bot/handlers/__init__.py
+++ b/src/kouhai_bot/handlers/__init__.py
@@ -15,13 +15,13 @@ from ..eventlog import (
     log_command_finished,
     log_command_received,
 )
+from ..friend_requests import handle_friend_request_event
 from ..napcat.client import (
     build_plain_message,
     build_reply,
     send_group_msg,
     send_private_msg,
     react_emoji,
-    set_friend_add_request,
 )
 
 logger = logging.getLogger("kouhai-bot.handlers")
@@ -72,63 +72,6 @@ def should_respond(msg_type: str, was_mentioned: bool) -> bool:
     return was_mentioned
 
 
-async def _is_service_group_member(group_id: int, user_id: int) -> bool:
-    from ..napcat import client as napcat_client
-
-    try:
-        resp = await napcat_client._http_post(
-            "get_group_member_info",
-            {"group_id": group_id, "user_id": user_id, "no_cache": True},
-        )
-        if isinstance(resp, dict) and resp.get("status") == "ok" and isinstance(resp.get("data"), dict):
-            return bool(resp["data"])
-    except Exception:
-        pass
-    try:
-        resp = await napcat_client._http_post("get_group_member_list", {"group_id": group_id})
-        members = resp.get("data", []) if isinstance(resp, dict) and resp.get("status") == "ok" else []
-        return any(str(item.get("user_id", "")) == str(user_id) for item in members if isinstance(item, dict))
-    except Exception:
-        return False
-
-
-async def _handle_request_event(event: dict) -> None:
-    if event.get("request_type") != "friend":
-        return
-
-    cfg = get_config()
-    flag = str(event.get("flag", "") or "")
-    try:
-        user_id = int(event.get("user_id", 0) or 0)
-    except (TypeError, ValueError):
-        user_id = 0
-
-    if not flag or user_id <= 0:
-        logger.warning("ignoring malformed friend request event: %s", event.get("raw", event))
-        return
-    if str(user_id) == str(cfg.bot_qq):
-        return
-
-    if not await _is_service_group_member(cfg.current_group, user_id):
-        logger.info(
-            "friend request from user_%s ignored: not a confirmed member of group_%s",
-            user_id,
-            cfg.current_group,
-        )
-        return
-
-    if await set_friend_add_request(flag, approve=True):
-        logger.info(
-            "approved friend request from service group member user_%s",
-            user_id,
-        )
-    else:
-        logger.warning(
-            "failed to approve friend request from service group member user_%s",
-            user_id,
-        )
-
-
 def _normalize_leading_command_junk(text: str) -> str:
     """Strip invisible leading junk only when it prefixes a slash command.
 
@@ -167,10 +110,10 @@ async def process_event(
     if event["type"] == "request":
         if spawn_handlers:
             return asyncio.create_task(
-                _handle_request_event(event),
+                handle_friend_request_event(event),
                 name=f"request_{event.get('request_type', 'unknown')}_{event.get('user_id', 0)}",
             )
-        await _handle_request_event(event)
+        await handle_friend_request_event(event)
         return None
 
     if event["type"] != "message":

--- a/src/kouhai_bot/napcat/client.py
+++ b/src/kouhai_bot/napcat/client.py
@@ -116,6 +116,38 @@ async def set_friend_add_request(flag: str, *, approve: bool = True, remark: str
         return False
 
 
+async def get_doubt_friends_add_requests(*, count: int = 50) -> list[dict]:
+    """Return QQ/NapCat's pending doubtful friend requests."""
+    try:
+        result = await _http_post("get_doubt_friends_add_request", {
+            "count": int(count),
+        })
+        if isinstance(result, dict) and str(result.get("status", "") or "").lower() in {"", "ok"}:
+            data = result.get("data", [])
+            if isinstance(data, list):
+                return [item for item in data if isinstance(item, dict)]
+        logger.warning("get_doubt_friends_add_request returned unexpected payload: %s", result)
+    except Exception as e:
+        logger.error("get_doubt_friends_add_request failed: %s", e, exc_info=True)
+    return []
+
+
+async def set_doubt_friends_add_request(flag: str, *, approve: bool = True) -> bool:
+    """Approve or reject a doubtful friend request by NapCat doubt-request flag."""
+    try:
+        result = await _http_post("set_doubt_friends_add_request", {
+            "flag": str(flag),
+            "approve": bool(approve),
+        })
+        if isinstance(result, dict) and str(result.get("status", "") or "").lower() in {"", "ok"}:
+            return True
+        logger.warning("set_doubt_friends_add_request returned unexpected payload: %s", result)
+        return False
+    except Exception as e:
+        logger.error("set_doubt_friends_add_request failed: %s", e, exc_info=True)
+        return False
+
+
 async def react_emoji(message_id: str, emoji_id: str) -> None:
     """React with an emoji to a message."""
     try:

--- a/src/kouhai_bot/worker.py
+++ b/src/kouhai_bot/worker.py
@@ -8,6 +8,7 @@ import signal
 from contextlib import suppress
 
 from .config import get_config
+from .friend_requests import doubt_friend_request_loop
 from .handlers import process_event
 from .napcat.client import NapCatServer
 from .runtime import bootstrap_runtime, setup_logging
@@ -22,7 +23,9 @@ class WorkerRuntime:
         self.napcat = NapCatServer(on_event=self._on_event)
         self._shutdown = asyncio.Event()
         self._scheduler_stop = asyncio.Event()
+        self._friend_request_stop = asyncio.Event()
         self._scheduler_task: asyncio.Task | None = None
+        self._friend_request_task: asyncio.Task | None = None
 
     async def run(self) -> None:
         bootstrap_runtime()
@@ -30,6 +33,10 @@ class WorkerRuntime:
         self._scheduler_task = asyncio.create_task(
             scheduler_loop(stop_event=self._scheduler_stop),
             name="worker_scheduler",
+        )
+        self._friend_request_task = asyncio.create_task(
+            doubt_friend_request_loop(stop_event=self._friend_request_stop),
+            name="worker_doubt_friend_requests",
         )
         self._install_signal_handlers()
         logger.info("Worker runtime is running. Press Ctrl+C to stop.")
@@ -41,10 +48,14 @@ class WorkerRuntime:
     async def stop(self) -> None:
         self._shutdown.set()
         self._scheduler_stop.set()
+        self._friend_request_stop.set()
         await self.napcat.stop()
         if self._scheduler_task is not None:
             with suppress(asyncio.CancelledError):
                 await self._scheduler_task
+        if self._friend_request_task is not None:
+            with suppress(asyncio.CancelledError):
+                await self._friend_request_task
         await self._wait_for_background_tasks()
 
     async def _on_event(self, event: dict) -> None:
@@ -65,6 +76,7 @@ class WorkerRuntime:
                 for task in asyncio.all_tasks()
                 if task is not current
                 and task is not self._scheduler_task
+                and task is not self._friend_request_task
                 and not task.done()
             ]
             if not pending:

--- a/tests/test_friend_requests.py
+++ b/tests/test_friend_requests.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from kouhai_bot.handlers import process_event
+from kouhai_bot.friend_requests import approve_doubt_friend_requests
 
 
 def _friend_request(user_id: int = 456, flag: str = "flag-123") -> dict:
@@ -38,9 +39,9 @@ def test_friend_request_from_service_group_member_is_approved(monkeypatch):
         calls.append({"flag": flag, "approve": approve, "remark": remark})
         return True
 
-    monkeypatch.setattr("kouhai_bot.handlers.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.friend_requests.get_config", _cfg)
     monkeypatch.setattr("kouhai_bot.napcat.client._http_post", fake_http_post)
-    monkeypatch.setattr("kouhai_bot.handlers.set_friend_add_request", fake_set_friend_add_request)
+    monkeypatch.setattr("kouhai_bot.friend_requests.set_friend_add_request", fake_set_friend_add_request)
 
     asyncio.run(process_event(_friend_request(), spawn_handlers=False))
 
@@ -61,9 +62,9 @@ def test_friend_request_from_non_member_is_ignored(monkeypatch):
         calls.append(flag)
         return True
 
-    monkeypatch.setattr("kouhai_bot.handlers.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.friend_requests.get_config", _cfg)
     monkeypatch.setattr("kouhai_bot.napcat.client._http_post", fake_http_post)
-    monkeypatch.setattr("kouhai_bot.handlers.set_friend_add_request", fake_set_friend_add_request)
+    monkeypatch.setattr("kouhai_bot.friend_requests.set_friend_add_request", fake_set_friend_add_request)
 
     asyncio.run(process_event(_friend_request(), spawn_handlers=False))
 
@@ -80,9 +81,9 @@ def test_friend_request_member_lookup_failure_is_ignored(monkeypatch):
         calls.append(flag)
         return True
 
-    monkeypatch.setattr("kouhai_bot.handlers.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.friend_requests.get_config", _cfg)
     monkeypatch.setattr("kouhai_bot.napcat.client._http_post", fake_http_post)
-    monkeypatch.setattr("kouhai_bot.handlers.set_friend_add_request", fake_set_friend_add_request)
+    monkeypatch.setattr("kouhai_bot.friend_requests.set_friend_add_request", fake_set_friend_add_request)
 
     asyncio.run(process_event(_friend_request(), spawn_handlers=False))
 
@@ -96,9 +97,64 @@ def test_non_friend_request_is_ignored(monkeypatch):
         calls.append(flag)
         return True
 
-    monkeypatch.setattr("kouhai_bot.handlers.get_config", _cfg)
-    monkeypatch.setattr("kouhai_bot.handlers.set_friend_add_request", fake_set_friend_add_request)
+    monkeypatch.setattr("kouhai_bot.friend_requests.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.friend_requests.set_friend_add_request", fake_set_friend_add_request)
 
     asyncio.run(process_event({"type": "request", "request_type": "group", "user_id": 456, "flag": "f"}, spawn_handlers=False))
 
+    assert calls == []
+
+
+def test_doubt_friend_request_from_service_group_member_is_approved(monkeypatch):
+    calls = []
+
+    async def fake_get_doubt_friends_add_requests(*, count=50):
+        return [{"flag": "uid-flag", "uin": "456", "source": "QQ群"}]
+
+    async def fake_http_post(action, data):
+        assert action == "get_group_member_info"
+        assert data["group_id"] == 999999
+        assert data["user_id"] == 456
+        return {"status": "ok", "data": {"user_id": 456}}
+
+    async def fake_set_doubt_friends_add_request(flag, *, approve=True):
+        calls.append({"flag": flag, "approve": approve})
+        return True
+
+    monkeypatch.setattr("kouhai_bot.friend_requests.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.friend_requests.get_doubt_friends_add_requests", fake_get_doubt_friends_add_requests)
+    monkeypatch.setattr("kouhai_bot.napcat.client._http_post", fake_http_post)
+    monkeypatch.setattr("kouhai_bot.friend_requests.set_doubt_friends_add_request", fake_set_doubt_friends_add_request)
+
+    approved = asyncio.run(approve_doubt_friend_requests())
+
+    assert approved == 1
+    assert calls == [{"flag": "uid-flag", "approve": True}]
+
+
+def test_doubt_friend_request_from_non_member_is_ignored(monkeypatch):
+    calls = []
+
+    async def fake_get_doubt_friends_add_requests(*, count=50):
+        return [{"flag": "uid-flag", "uin": "456"}]
+
+    async def fake_http_post(action, data):
+        if action == "get_group_member_info":
+            return {"status": "failed", "data": None}
+        if action == "get_group_member_list":
+            return {"status": "ok", "data": [{"user_id": 999}]}
+        raise AssertionError(action)
+
+    async def fake_set_doubt_friends_add_request(flag, *, approve=True):
+        calls.append(flag)
+        return True
+
+    monkeypatch.setattr("kouhai_bot.friend_requests.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.friend_requests.get_doubt_friends_add_requests", fake_get_doubt_friends_add_requests)
+    monkeypatch.setattr("kouhai_bot.napcat.client._http_post", fake_http_post)
+    monkeypatch.setattr("kouhai_bot.friend_requests.set_doubt_friends_add_request", fake_set_doubt_friends_add_request)
+
+    approved = asyncio.run(approve_doubt_friend_requests())
+
+    assert approved == 0
     assert calls == []

--- a/tests/test_napcat.py
+++ b/tests/test_napcat.py
@@ -3,7 +3,13 @@
 import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from kouhai_bot.napcat.client import parse_event, build_plain_message, build_text
+from kouhai_bot.napcat.client import (
+    build_plain_message,
+    build_text,
+    get_doubt_friends_add_requests,
+    parse_event,
+    set_doubt_friends_add_request,
+)
 
 
 def test_parse_group_message():
@@ -52,3 +58,35 @@ def test_parse_friend_request_event():
 
 def test_parse_invalid_json():
     assert parse_event("not json") is None
+
+
+def test_get_doubt_friends_add_requests(monkeypatch):
+    calls = []
+
+    async def fake_http_post(action, data):
+        calls.append((action, data))
+        return {"status": "ok", "data": [{"flag": "uid-flag", "uin": "456"}]}
+
+    monkeypatch.setattr("kouhai_bot.napcat.client._http_post", fake_http_post)
+
+    import asyncio
+
+    result = asyncio.run(get_doubt_friends_add_requests(count=3))
+
+    assert calls == [("get_doubt_friends_add_request", {"count": 3})]
+    assert result == [{"flag": "uid-flag", "uin": "456"}]
+
+
+def test_set_doubt_friends_add_request(monkeypatch):
+    calls = []
+
+    async def fake_http_post(action, data):
+        calls.append((action, data))
+        return {"status": "ok", "data": None}
+
+    monkeypatch.setattr("kouhai_bot.napcat.client._http_post", fake_http_post)
+
+    import asyncio
+
+    assert asyncio.run(set_doubt_friends_add_request("uid-flag", approve=True)) is True
+    assert calls == [("set_doubt_friends_add_request", {"flag": "uid-flag", "approve": True})]


### PR DESCRIPTION
## Summary
- move service-group friend request approval into a shared friend_requests module
- keep normal OneBot friend request approval via set_friend_add_request
- add a worker poller for NapCat doubtful friend requests using get_doubt_friends_add_request and set_doubt_friends_add_request
- update AGENTS.md and tests for both friend request paths

## Root cause
QQ/NapCat can classify some add-friend attempts as doubtful friend requests. Those do not reliably arrive as normal OneBot request events, so the previous event-only implementation never saw them.

## Validation
- python3 -m py_compile src/kouhai_bot/napcat/client.py src/kouhai_bot/friend_requests.py src/kouhai_bot/handlers/__init__.py src/kouhai_bot/worker.py tests/test_friend_requests.py tests/test_napcat.py
- .venv/bin/pytest tests/test_friend_requests.py tests/test_napcat.py
- .venv/bin/pytest tests/test_eventlog.py tests/test_scheduler.py
- .venv/bin/python tests/test_commands.py