### PR TITLE
[codex] Fix private judge ack and success pid

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ NapCat (QQ) ──WS──> worker.py
 - **Stale cache detection**: `picker.py:fetch_statement()` detects caches created before VL pipeline via `_vl_processed` flag. Stale caches with images are re-fetched with Qwen-VL. Problems with non-formula images (tex-graphics / diagrams) are skipped.
 - **No hermes cron involvement**: The bot runs its own scheduler loop (`scheduler/engine.py`), not hermes cron jobs.
 - **Single worker runtime**: `worker.py` keeps the NapCat reverse-WS connection, dispatches commands, and owns the scheduler in one process. There is no SQLite event queue, ingress supervisor, worker hot-swap, or auto-update loop.
-- **Friend request auto-approval**: Normal OneBot `post_type="request"` / `request_type="friend"` events are parsed by `napcat/client.py`, routed by `handlers.process_event()`, and approved via `set_friend_add_request`. QQ/NapCat "doubtful" friend requests are not reliably pushed as request events, so `worker.py` also runs `friend_requests.doubt_friend_request_loop()`, which polls `get_doubt_friends_add_request` and approves with `set_doubt_friends_add_request`. Both paths approve only after the requester is confirmed to be a member of `CURRENT_GROUP`; lookup failure, malformed events, non-friend requests, and non-members are ignored without approving.
+- **Friend request auto-approval**: Normal OneBot `post_type="request"` / `request_type="friend"` events are parsed by `napcat/client.py`, routed by `handlers.process_event()`, and approved via `set_friend_add_request`. QQ/NapCat "doubtful" friend requests are not reliably pushed as request events, so `worker.py` also runs `friend_requests.doubt_friend_request_loop()`, which polls `get_doubt_friends_add_request` every 60 seconds and approves with `set_doubt_friends_add_request`. Both paths approve only after the requester is confirmed to be a member of `CURRENT_GROUP`; lookup failure, malformed events, non-friend requests, and non-members are ignored without approving. Requests that were already consumed by another QQ client may not appear in the doubtful-request poll.
 - **User groups**: `user_groups.py` — all users default to `default`; `USER_GROUPS` configures
   non-default groups such as `starred`/`打星`, their members, submit delay, and rejection
   message. `submit_delay_sec > 0` enables dynamic per-user submit waits for that group:
@@ -161,8 +161,9 @@ This bot is a **reverse WebSocket server** plus a **NapCat HTTP API client**:
   NapCat must connect to it through a OneBot11 `websocketClients` entry.
 - Message sending uses `napcat_http_host:napcat_http_port` and calls NapCat OneBot11
   HTTP actions such as `send_group_msg`, `send_private_msg`,
-  `get_group_member_info`, and `set_friend_add_request`; NapCat must expose an
-  enabled OneBot11 `httpServers` entry on that port.
+  `get_group_member_info`, `set_friend_add_request`,
+  `get_doubt_friends_add_request`, and `set_doubt_friends_add_request`; NapCat
+  must expose an enabled OneBot11 `httpServers` entry on that port.
 
 When NapCat is deployed with Docker Compose, prefer this pattern:
 
@@ -417,8 +418,9 @@ Status helpers used by `/status`:
 - Runs through the state scheduler and records a clear watermark so earlier in-flight
   requests for that user/problem cannot write history after clear
 - On group success it reacts to the triggering message with the typed `👌` emoji payload
-  (`type=2`, `id=128076`) and sends no extra text. In private chats it sends the same
-  face instead of a message reaction.
+  (`type=2`, `id=128076`) and sends no extra text. In private chats it cannot use
+  message reactions, so it sends a plain text `👌` private message instead of a
+  `face` segment.
 
 ### Dispatch Pattern
 
@@ -436,8 +438,10 @@ Private commands do not require @mentions and should not send @ segments back.
 Friend request events are not commands and are not logged to command event logs.
 `process_event()` handles normal `type="request"` friend requests before message
 dispatch. `worker.py` separately polls NapCat's doubtful friend request list because
-those requests may only appear through `get_doubt_friends_add_request`. Both paths
-accept only confirmed `CURRENT_GROUP` members and otherwise return silently.
+those requests may only appear through `get_doubt_friends_add_request`. The poller
+runs every 60 seconds. Both paths accept only confirmed `CURRENT_GROUP` members and
+otherwise return silently; requests already consumed by another QQ client may not be
+visible to the poller.
 
 ### Command Event Log
 
@@ -514,9 +518,12 @@ achievement reports.
    pending archive record is excluded by `request_id`; superseded unanswered `/submit`
    text is visible as `result="superseded"` context.
 6. If `SUBMIT_AC_BACKDOOR` is non-empty and the submission contains that string, return a correct verdict before calling the judge LLM
-7. Otherwise load user history, react with 👀/[睁眼] ack, and call `judge_submission()`
-   `[睁眼]` is a QQ special emoji reaction (emoji id), not plain message text. In private
-   judge, send face messages instead of group message reactions.
+7. Otherwise load user history, react with 👀/[睁眼] ack, and call `judge_submission()`.
+   `[睁眼]` is a QQ special emoji reaction (group emoji id `128064` / face id `289`),
+   not plain message text. In private judge, send `face` id `289` instead of group
+   message reactions or literal `[睁眼]` text. If the judge returns
+   `reaction="123"` for spam/off-topic, private judge sends `face` id `123` instead
+   of text.
 8. Incorrect/off-topic/failure results finalize immediately when compute finishes
 9. If the problem was already solved when this `/submit` entered the queue: reply
    "已经有人解出..." without calling the judge.
@@ -538,9 +545,11 @@ achievement reports.
 
 Private `/submit` uses the same judge path and private history, but a correct result
 only marks the problem solved in `private_judge/users/<uid>.json`; it does not update
-the group scoreboard or daily achievements. If the private problem is the current group
-problem, the success message tells the user they can `/sync` in the service group to
-score it if the group has not already solved it.
+the group scoreboard or daily achievements. The private success message includes the
+problem id (for example `做对了 1234A！`) so users can tell which private problem was
+accepted. If the private problem is the current group problem, the success message
+tells the user they can `/sync` in the service group to score it if the group has not
+already solved it.
 
 ### `/clarify` — Anti-Spoiler Clarification
 
@@ -915,7 +924,8 @@ commands from queuing behind locked operations.
 
 ### 14. Off-topic submissions are NOT saved
 If the judge returns `reaction: "123"`, the submission is marked as troll and
-NOT recorded to scoreboard. The save happens AFTER the reaction check.
+NOT recorded to scoreboard. The save happens AFTER the reaction check. In private
+judge this reaction is delivered as QQ `face` id `123`, not the fallback text `😵`.
 
 ### 15. Do not add local off-topic blacklists for `/submit` or `/clarify`
 Off-topic handling belongs to the model output (`reaction="123"`), not substring

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -907,11 +907,11 @@ class GroupCoordinator:
             current_pid = str(current.get("today", "") or "")
         if current_pid and current_pid == pid:
             text = (
-                "做对了！🎉 private judge 不直接加分。"
+                f"做对了 {pid}！🎉 private judge 不直接加分。"
                 "如果群里还没人通过这题，可以到服务群发 /sync，把这次通过同步到群榜。"
             )
         else:
-            text = "做对了！🎉 这次通过只记录在 private judge，不计入群榜。"
+            text = f"做对了 {pid}！🎉 这次通过只记录在 private judge，不计入群榜。"
         if model_tag:
             text = text.rstrip() + model_tag
         self._log_finished(req, "correct", problem=pid, extra={"scope": PRIVATE_SCOPE})

--- a/src/kouhai_bot/napcat/client.py
+++ b/src/kouhai_bot/napcat/client.py
@@ -200,11 +200,11 @@ def build_face(emoji_id: str | int) -> dict:
 
 def build_private_reaction_message(emoji_id: str | int) -> list[dict]:
     emoji = str(emoji_id)
+    if emoji in {"128064", "289"}:
+        return [build_face("289")]
     if emoji == "123":
         return [build_face("123")]
     text = {
-        "128064": "👀",
-        "289": "[睁眼]",
         "10060": "👌",
     }.get(emoji, "收到～")
     return build_plain_message(text)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1620,7 +1620,8 @@ def test_private_submit_off_topic_sends_face_123():
         for item in _private_sent if item["user_id"] == UID
         for seg in item["message"] if isinstance(seg, dict) and seg.get("type") == "face"
     ]
-    assert {seg.get("data", {}).get("id") for seg in face_segments} == {"123"}, _private_sent
+    face_ids = {seg.get("data", {}).get("id") for seg in face_segments}
+    assert "123" in face_ids, _private_sent
     private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
     assert "😵" not in private_text, private_text
     _cleanup()
@@ -1650,7 +1651,7 @@ def test_submit_operation_not_blocked():
     print("✅ submit: 操作 not blocked")
 
 
-def test_private_submit_sends_text_ack_instead_of_face_or_reaction():
+def test_private_submit_sends_face_ack_instead_of_text_or_reaction():
     _reset_state()
     _setup_problem()
     global _deepseek_response
@@ -1674,13 +1675,13 @@ def test_private_submit_sends_text_ack_instead_of_face_or_reaction():
         for item in _private_sent if item["user_id"] == UID
         for seg in item["message"] if isinstance(seg, dict) and seg.get("type") == "face"
     ]
-    assert not face_segments, f"Private ack should avoid face segments NapCat may reject: {_private_sent}"
+    assert {seg.get("data", {}).get("id") for seg in face_segments} == {"289"}, _private_sent
     assert not _reacted, f"Private submit should not use group reactions: {_reacted}"
     private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
-    assert any(token in private_text for token in ("👀", "[睁眼]")), private_text
+    assert "[睁眼]" not in private_text, private_text
     assert "关键证明" in private_text, private_text
     _cleanup()
-    print("✅ private submit: ack uses safe text message")
+    print("✅ private submit: ack uses face message")
 
 
 def test_private_clear_invalid_usage_sends_text_ack_instead_of_face():
@@ -1740,6 +1741,27 @@ def test_clarify_with_problem():
         f"Expected clarification, got: {_last_text()}"
     _cleanup()
     print("✅ clarify: with problem")
+
+
+def test_private_submit_correct_message_includes_problem_id():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    global _deepseek_response
+    _deepseek_response = {"correct": True, "reason": "ok", "reply": ""}
+
+    with _all_patches():
+        from kouhai_bot.handlers.cmd.submit import handle
+        from kouhai_bot.handlers.shared import get_today_problem
+        from kouhai_bot.private_judge import set_private_current_problem
+
+        set_private_current_problem(UID, get_today_problem(GID))
+        asyncio.run(handle(**_kwargs(_make_private_event("/submit valid private solution"))))
+
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
+    assert f"做对了 {PID}" in private_text, private_text
+    assert "/sync" in private_text, private_text
+    _cleanup()
+    print("✅ private submit: correct message includes pid")
 
 
 def test_private_clarify_uses_private_problem_summary():
@@ -4125,10 +4147,11 @@ if __name__ == "__main__":
     test_submit_off_topic()
     test_submit_operation_not_blocked()
     test_private_submit_off_topic_sends_face_123()
-    test_private_submit_sends_text_ack_instead_of_face_or_reaction()
+    test_private_submit_sends_face_ack_instead_of_text_or_reaction()
     test_private_clear_invalid_usage_sends_text_ack_instead_of_face()
     test_submit_no_problem()
     test_clarify_with_problem()
+    test_private_submit_correct_message_includes_problem_id()
     test_clarify_no_problem()
     test_clarify_alias_dispatches_to_clarify_handler()
     test_problem_with_data()

--- a/tests/test_napcat.py
+++ b/tests/test_napcat.py
@@ -46,8 +46,19 @@ def test_build_text():
     assert seg["data"]["text"] == "hi"
 
 
+def test_build_private_submit_ack_uses_face_289():
+    for emoji_id in ("128064", "289"):
+        msg = build_private_reaction_message(emoji_id)
+        assert msg == [{"type": "face", "data": {"id": "289"}}]
+
+
 def test_build_private_troll_reaction_uses_face_123():
     assert build_private_reaction_message("123") == [{"type": "face", "data": {"id": "123"}}]
+
+
+def test_build_private_clear_ack_uses_text():
+    msg = build_private_reaction_message("10060")
+    assert msg == [{"type": "text", "data": {"text": "👌"}}]
 
 
 def test_parse_friend_request_event():


### PR DESCRIPTION
## Summary
- send private submit ack as QQ face id 289 instead of literal [睁眼] text
- normalize private 👀/睁眼 ack choices to the supported 289 face segment
- include the problem id in private judge correct-submit messages
- add tests for the private ack builder and private correct message

## Root cause
The previous private-message safety fallback converted [睁眼] into plain text. Private submit also randomly used 128064, which is not the same OneBot face id. Private judge success text also omitted the pid, so a correct private solve did not say which problem passed.

## Validation
- python3 -m py_compile src/kouhai_bot/napcat/client.py src/kouhai_bot/handlers/cmd/submit.py tests/test_napcat.py tests/test_commands.py
- .venv/bin/pytest tests/test_napcat.py tests/test_commands.py -k 'private_submit or private_clear or build_private'
- .venv/bin/pytest tests/test_napcat.py
- .venv/bin/python tests/test_commands.py