### PR TITLE
[codex] Fix private dispatch member check

### DIFF
--- a/src/kouhai_bot/handlers/__init__.py
+++ b/src/kouhai_bot/handlers/__init__.py
@@ -15,7 +15,7 @@ from ..eventlog import (
     log_command_finished,
     log_command_received,
 )
-from ..friend_requests import handle_friend_request_event
+from ..friend_requests import handle_friend_request_event, is_service_group_member
 from ..napcat.client import (
     build_plain_message,
     build_reply,
@@ -167,7 +167,7 @@ async def process_event(
                 "这个命令暂时只能在服务群里使用～private judge 可用 /help 查看支持的命令。"
             ))
             return
-        if not await _is_service_group_member(group_id, user_id):
+        if not await is_service_group_member(group_id, user_id):
             await send_private_msg(user_id, build_plain_message(
                 "private judge 目前只服务当前服务群成员。如果你已经在群里，稍后再试试。"
             ))

--- a/tests/test_friend_requests.py
+++ b/tests/test_friend_requests.py
@@ -158,3 +158,40 @@ def test_doubt_friend_request_from_non_member_is_ignored(monkeypatch):
 
     assert approved == 0
     assert calls == []
+
+
+def test_private_dispatch_uses_shared_service_group_member_check(monkeypatch):
+    calls = []
+
+    async def fake_handler(**kwargs):
+        calls.append(kwargs)
+
+    async def fake_is_service_group_member(group_id, user_id):
+        assert group_id == 999999
+        assert user_id == 456
+        return True
+
+    monkeypatch.setattr("kouhai_bot.handlers.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.handlers.is_service_group_member", fake_is_service_group_member)
+    monkeypatch.setattr(
+        "kouhai_bot.handlers.registry.get",
+        lambda name: SimpleNamespace(name="status", handler=fake_handler) if name == "status" else None,
+    )
+
+    event = {
+        "type": "message",
+        "message_type": "private",
+        "group_id": 0,
+        "user_id": 456,
+        "sender": {"nickname": "Tester", "card": "", "user_id": 456},
+        "message_id": "priv-1",
+        "raw_message": "/status",
+        "message": [{"type": "text", "data": {"text": "/status"}}],
+        "raw": {},
+    }
+
+    asyncio.run(process_event(event, spawn_handlers=False))
+
+    assert len(calls) == 1
+    assert calls[0]["group_id"] == 999999
+    assert calls[0]["user_id"] == 456


### PR DESCRIPTION
## Summary
- fix private command dispatch to use the shared service-group member checker from friend_requests
- add a regression test that drives a private command through process_event

## Root cause
#17 moved service-group membership lookup into friend_requests.py, but private command dispatch still referenced the removed _is_service_group_member helper. Any private command therefore raised a NameError before reaching its handler.

## Validation
- python3 -m py_compile src/kouhai_bot/handlers/__init__.py tests/test_friend_requests.py
- .venv/bin/pytest tests/test_friend_requests.py
- .venv/bin/pytest tests/test_eventlog.py