### PR TITLE
[codex] Fix private shake-finger face

### DIFF
--- a/src/kouhai_bot/napcat/client.py
+++ b/src/kouhai_bot/napcat/client.py
@@ -199,12 +199,14 @@ def build_face(emoji_id: str | int) -> dict:
 
 
 def build_private_reaction_message(emoji_id: str | int) -> list[dict]:
+    emoji = str(emoji_id)
+    if emoji == "123":
+        return [build_face("123")]
     text = {
         "128064": "👀",
         "289": "[睁眼]",
         "10060": "👌",
-        "123": "😵",
-    }.get(str(emoji_id), "收到～")
+    }.get(emoji, "收到～")
     return build_plain_message(text)
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1601,6 +1601,32 @@ def test_submit_off_topic():
     print("✅ submit: off-topic")
 
 
+def test_private_submit_off_topic_sends_face_123():
+    _reset_state()
+    _setup_problem()
+    global _deepseek_response
+    _deepseek_response = {"correct": False, "reason": "", "reply": "", "reaction": "123"}
+
+    with _all_patches():
+        from kouhai_bot.handlers.cmd.submit import handle
+        from kouhai_bot.handlers.shared import get_today_problem
+        from kouhai_bot.private_judge import set_private_current_problem
+
+        set_private_current_problem(UID, get_today_problem(GID))
+        asyncio.run(handle(**_kwargs(_make_private_event("/submit 傻逼"))))
+
+    face_segments = [
+        seg
+        for item in _private_sent if item["user_id"] == UID
+        for seg in item["message"] if isinstance(seg, dict) and seg.get("type") == "face"
+    ]
+    assert {seg.get("data", {}).get("id") for seg in face_segments} == {"123"}, _private_sent
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
+    assert "😵" not in private_text, private_text
+    _cleanup()
+    print("✅ private submit: off-topic uses face 123")
+
+
 def test_submit_operation_not_blocked():
     """Normal text containing 操作 should not be blocked by a local blacklist."""
     _reset_state()
@@ -4098,6 +4124,7 @@ if __name__ == "__main__":
     test_review_after_pending_submit_uses_snapshotted_solved_problem()
     test_submit_off_topic()
     test_submit_operation_not_blocked()
+    test_private_submit_off_topic_sends_face_123()
     test_private_submit_sends_text_ack_instead_of_face_or_reaction()
     test_private_clear_invalid_usage_sends_text_ack_instead_of_face()
     test_submit_no_problem()

--- a/tests/test_napcat.py
+++ b/tests/test_napcat.py
@@ -5,6 +5,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from kouhai_bot.napcat.client import (
     build_plain_message,
+    build_private_reaction_message,
     build_text,
     get_doubt_friends_add_requests,
     parse_event,
@@ -43,6 +44,10 @@ def test_build_text():
     seg = build_text("hi")
     assert seg["type"] == "text"
     assert seg["data"]["text"] == "hi"
+
+
+def test_build_private_troll_reaction_uses_face_123():
+    assert build_private_reaction_message("123") == [{"type": "face", "data": {"id": "123"}}]
 
 
 def test_parse_friend_request_event():


### PR DESCRIPTION
## Summary
- send private off-topic/troll reaction 123 as a QQ face segment instead of 😵 text
- keep group behavior unchanged: group submits still use set_msg_emoji_like with emoji id 123
- add tests for the private reaction builder and private off-topic submit path

## Root cause
Private chats cannot use group message reactions, so the bot simulates reaction messages. The private fallback mapped reaction 123 to plain text 😵, while group behavior uses emoji id 123. This made private judge show the wrong response for spam/off-topic submissions.

## Validation
- python3 -m py_compile src/kouhai_bot/napcat/client.py tests/test_napcat.py tests/test_commands.py
- .venv/bin/pytest tests/test_napcat.py tests/test_commands.py -k 'private_submit_off_topic or build_private_troll'
- .venv/bin/python tests/test_commands.py