### PR TITLE
[codex] Allow starred sync after cooldown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -640,9 +640,11 @@ commands are rejected in private with a friendly message.
   the group coordinator lock, reveals the original problem source, schedules the official
   editorial follow-up, writes the private records into group `scoreboard.json`, and logs
   the imported records for daily achievements.
-- Dynamic-wait/starred users redirected to private judge can still `/sync`, but only
-  `clarify` records are copied; submit/review/correct records are ignored and never
-  score.
+- Dynamic-wait/starred users redirected to private judge can still `/sync`. While
+  their current group problem submit CD is active, only `clarify` records are copied
+  in either direction and submit/review/correct records are ignored. Once the CD
+  expires, `/sync` behaves like it does for normal users, including private AC scoring
+  when the group has not already solved that pid.
 
 ### 8.5. Review parallelism depends on enqueue-time pid snapshot
 If `/review` is meant to compute in parallel with later same-group requests, do not

--- a/src/kouhai_bot/handlers/cmd/help.py
+++ b/src/kouhai_bot/handlers/cmd/help.py
@@ -75,7 +75,7 @@ async def handle(group_id: int, user_id: int, sender: dict,
         lines.append(
             "🔒 private judge：私聊可用 /setproblem(/sp) 选当前群题、CF题号/链接或 random；"
             "private 通过不自动加分，只有当前群题可在群里 /sync 同步。"
-            "/sync 会用另一侧记录覆盖当前侧，可能丢掉当前侧这题交流历史；打星用户只同步 clarify。"
+            "/sync 会用另一侧记录覆盖当前侧，可能丢掉当前侧这题交流历史；打星用户提交 CD 内只同步 clarify，CD 后可正常同步。"
         )
     else:
         visible = [cmd for cmd in cmds if cmd.name not in _GROUP_HELP_HIDDEN_COMMANDS]

--- a/src/kouhai_bot/handlers/cmd/sync.py
+++ b/src/kouhai_bot/handlers/cmd/sync.py
@@ -27,7 +27,7 @@ from ...private_judge import (
     replace_private_problem_history,
     send_history_card,
 )
-from ...user_groups import get_user_group, is_dynamic_submit_delay_enabled
+from ...user_groups import get_user_group, is_dynamic_submit_delay_enabled, submit_remaining_sec
 from ..shared import (
     fetch_group_member_nickname_map,
     format_points,
@@ -48,8 +48,8 @@ logger = logging.getLogger("kouhai-bot.cmd.sync")
 OK_REACTION_ID = "128076"
 
 
-def _is_starred_limited(user_id: int) -> bool:
-    return is_dynamic_submit_delay_enabled(get_user_group(user_id))
+def _is_starred_limited(user_id: int, group_id: int) -> bool:
+    return is_dynamic_submit_delay_enabled(get_user_group(user_id)) and submit_remaining_sec(user_id, group_id) > 0
 
 
 def _only_clarifies(records: list[dict]) -> list[dict]:
@@ -183,7 +183,7 @@ async def handle(group_id: int, user_id: int, sender: dict,
     else:
         source_records = group_problem_history(group_id, user_id, pid)
 
-    starred_limited = _is_starred_limited(user_id)
+    starred_limited = _is_starred_limited(user_id, group_id)
     if starred_limited:
         source_records = _only_clarifies(source_records)
 
@@ -193,6 +193,7 @@ async def handle(group_id: int, user_id: int, sender: dict,
                 target_scope,
                 group_id,
                 user_id,
+                "你是打星用户且目前还在提交 CD 内，仅能同步 clarify 记录；"
                 "对面没有可同步的 clarify 记录，本次 sync 已取消，没有覆盖任何历史。",
             )
         else:
@@ -235,7 +236,7 @@ async def handle(group_id: int, user_id: int, sender: dict,
         if private_record_has_correct(source_records, pid):
             extra, scored_correct = await _score_synced_private_ac(group_id, user_id, sender, pid)
     elif starred_limited:
-        extra = "打星模式下本次只同步 clarify，submit/review/通过记录已忽略。"
+        extra = "你是打星用户且目前还在提交 CD 内，本次仅同步 clarify，submit/review/通过记录已忽略。"
 
     if target_scope == GROUP_SCOPE:
         await _react_group_success(message_id)
@@ -251,6 +252,8 @@ async def handle(group_id: int, user_id: int, sender: dict,
         )
         if extra:
             await _send_text(target_scope, group_id, user_id, extra)
+    elif extra:
+        await _send_text(target_scope, group_id, user_id, extra)
 
 
 def register() -> None:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -446,6 +446,23 @@ def _all_patches():
     return stack
 
 
+def _starred_config_for_user(user_id: int = UID, *, submit_delay_sec: int = 300) -> _LazyConfig:
+    lazy = _LazyConfig()
+    lazy._config = {
+        **_config_dict(),
+        "user_groups": [
+            UserGroupConfig(
+                name="starred",
+                display_name="打星",
+                user_ids=[user_id],
+                submit_delay_sec=submit_delay_sec,
+                submit_delay_message="将机会多留给年轻人吧～{wait}",
+            )
+        ],
+    }
+    return lazy
+
+
 # ═══════════════════════════════════════════════════════════════════════
 # Tests: /submit
 # ═══════════════════════════════════════════════════════════════════════
@@ -3989,6 +4006,152 @@ def test_sync_private_correct_current_problem_scores_for_normal_user():
     print("✅ sync: private AC scores current group problem for normal user")
 
 
+def test_starred_sync_within_cd_only_syncs_clarify_and_rejects_empty_source():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _write_state(GID, {
+        "today": PID,
+        "contestId": 542,
+        "index": "D",
+        "name": "Superhero's Job",
+        "rating": 2600,
+        "tags": ["number theory", "dp"],
+        "date": "2026-05-14",
+        "posted_at": int(time.time()),
+    })
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
+    private_record = {
+        "timestamp": "2026-05-14T12:00:00+08:00",
+        "type": "submit",
+        "content": "private ac in cd",
+        "result": "correct",
+        "reason": "ok",
+        "reply": "",
+        "problem": PID,
+    }
+
+    with _all_patches(), patch("kouhai_bot.config._config", _starred_config_for_user()):
+        from kouhai_bot.private_judge import save_private_submission
+        from kouhai_bot.handlers.cmd.sync import handle
+
+        save_private_submission(UID, private_record)
+        asyncio.run(handle(**_kwargs(_make_event("/sync"))))
+
+    with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
+        saved = json.load(f)
+    assert saved.get("solves", []) == [], saved
+    assert saved.get("user_submissions", {}) == {}, saved
+    text = "\n".join(_last_text_item(item) for item in _sent)
+    assert "打星用户" in text and "CD 内" in text and "仅能同步 clarify" in text, text
+    assert "没有可同步的 clarify" in text, text
+    assert not _reacted, _reacted
+    _cleanup()
+    print("✅ sync: starred user in CD cannot sync private submit")
+
+
+def test_starred_sync_after_cd_scores_like_normal_user():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _write_state(GID, {
+        "today": PID,
+        "contestId": 542,
+        "index": "D",
+        "name": "Superhero's Job",
+        "rating": 2600,
+        "tags": ["number theory", "dp"],
+        "date": "2026-05-14",
+        "posted_at": int(time.time()) - 301,
+    })
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
+    private_record = {
+        "timestamp": "2026-05-14T12:00:00+08:00",
+        "type": "submit",
+        "content": "private ac after cd",
+        "result": "correct",
+        "reason": "ok",
+        "reply": "",
+        "problem": PID,
+    }
+
+    with _all_patches(), patch("kouhai_bot.config._config", _starred_config_for_user()), patch(
+        "kouhai_bot.handlers.cmd.sync._reveal_problem_source",
+        AsyncMock(return_value=""),
+    ):
+        from kouhai_bot.private_judge import save_private_submission
+        from kouhai_bot.handlers.cmd.sync import handle
+
+        save_private_submission(UID, private_record)
+        asyncio.run(handle(**_kwargs(_make_event("/sync"))))
+
+    with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
+        saved = json.load(f)
+    assert saved["solves"] and str(saved["solves"][0]["user_id"]) == str(UID), saved
+    assert saved["user_submissions"][str(UID)][0]["content"] == "private ac after cd"
+    text = "\n".join(_last_text_item(item) for item in _sent)
+    assert "本题 +" in text, text
+    assert "CD 内" not in text and "仅同步 clarify" not in text, text
+    assert ("msg_001", "128076") in _reacted, _reacted
+    _cleanup()
+    print("✅ sync: starred user after CD scores like normal user")
+
+
+def test_private_sync_for_starred_user_within_cd_only_syncs_clarify():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _write_state(GID, {
+        "today": PID,
+        "contestId": 542,
+        "index": "D",
+        "name": "Superhero's Job",
+        "rating": 2600,
+        "tags": ["number theory", "dp"],
+        "date": "2026-05-14",
+        "posted_at": int(time.time()),
+    })
+    group_clarify = {
+        "timestamp": "2026-05-14T12:00:00+08:00",
+        "type": "clarify",
+        "content": "group clarify",
+        "result": "clarify",
+        "reply": "group reply",
+        "problem": PID,
+    }
+    group_submit = {
+        "timestamp": "2026-05-14T12:01:00+08:00",
+        "type": "submit",
+        "content": "group ac should not sync during cd",
+        "result": "correct",
+        "reason": "ok",
+        "reply": "",
+        "problem": PID,
+    }
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {str(UID): [group_clarify, group_submit]}})
+
+    with _all_patches(), patch("kouhai_bot.config._config", _starred_config_for_user()):
+        from kouhai_bot.private_judge import load_private_state, set_private_current_problem
+        from kouhai_bot.handlers.cmd.sync import handle
+
+        set_private_current_problem(UID, {
+            "today": PID,
+            "contestId": 542,
+            "index": "D",
+            "name": "Superhero's Job",
+            "rating": 2600,
+            "tags": [],
+        })
+        asyncio.run(handle(**_kwargs(_make_private_event("/sync"))))
+        private_state = load_private_state(UID)
+
+    records = [item for item in private_state["user_submissions"] if item.get("problem") == PID]
+    assert len(records) == 1 and records[0]["type"] == "clarify", records
+    assert records[0]["content"] == "group clarify", records
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent)
+    assert "打星用户" in private_text and "CD 内" in private_text and "仅同步 clarify" in private_text, private_text
+    assert "group ac should not sync" not in private_text, private_text
+    _cleanup()
+    print("✅ private sync: starred user in CD only syncs clarify")
+
+
 def test_sync_history_card_uses_friendly_visible_format():
     _reset_state()
     _setup_problem_for(GID, PID)
@@ -4193,5 +4356,13 @@ if __name__ == "__main__":
     test_submit_starred_user_shows_own_group_top5()
     test_submit_alias_dispatches_to_submit_handler()
     test_submit_user_group_blocked_within_window()
+    test_sync_aborts_when_source_has_no_history_without_clearing_target()
+    test_sync_private_correct_current_problem_scores_for_normal_user()
+    test_starred_sync_within_cd_only_syncs_clarify_and_rejects_empty_source()
+    test_starred_sync_after_cd_scores_like_normal_user()
+    test_private_sync_for_starred_user_within_cd_only_syncs_clarify()
+    test_sync_history_card_uses_friendly_visible_format()
+    test_sync_history_card_chunks_long_history()
+    test_private_sync_from_solved_group_marks_private_review_state()
     test_parse_problem_ref_accepts_loose_codeforces_links()
     print(f"\n🎉 E2E tests passed")


### PR DESCRIPTION
## Summary
- let dynamic-wait/starred users sync like normal users after their current problem submit cooldown expires
- keep clarify-only sync behavior while the cooldown is active, in both group and private sync directions
- update private help and AGENTS.md with the cooldown-based rule

## Tests
- .venv/bin/python -m pytest tests/test_commands.py -q -k 'sync'
- .venv/bin/python -m pytest tests/test_commands.py -q
- .venv/bin/python tests/test_commands.py
- .venv/bin/python -m pytest tests/test_user_groups.py -q