### PR TITLE
[codex] Add private cd command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ NapCat (QQ) ──WS──> worker.py
 - **Command auto-discovery**: Each command in `handlers/cmd/*.py` calls `register()` at module load. The `registry.discover_commands()` scans with `pkgutil.iter_modules`. Adding a new command = create a `.py` file with a `register()` function.
 - **Limited aliases**: Only six short aliases are supported: `/newproblem`→`/np`, `/problem`→`/pb`, `/submit`→`/sbm`, `/review`→`/rv`, `/clarify`→`/clrf`, `/setproblem`→`/sp`. Old aliases such as `/sb`, `/排名`, and Chinese aliases remain unsupported. New commands default to `aliases=[]` unless explicitly approved.
 - **Help auto-generation**: `handlers/cmd/help.py` reads `registry.all_commands()` and builds the help text dynamically. Descriptions must match old bridge.py wording.
-  `usage` field = args suffix in /help display (e.g. `usage="你的做法"` → `/submit 你的做法`). Group help hides private-only details for `/setproblem` and `/sync` and only briefly mentions private judge; private help lists the private-judge command set.
+  `usage` field = args suffix in /help display (e.g. `usage="你的做法"` → `/submit 你的做法`). Group help hides private-only details for `/setproblem`, `/sync`, and `/cd` and only briefly mentions private judge; private help lists the private-judge command set.
   Group and private help are both delivered as merged-forward cards, with direct text
   only as fallback.
 - **Scheduler current-group config**: `~/.kouhai-bot/scheduler_config.json` stores job list + time overrides for `CURRENT_GROUP`. Jobs are defined in `scheduler/jobs.py`.
@@ -344,6 +344,7 @@ No repository-local runtime queue is used.
 | `/status` | stubs.py | `handle_status` | ❌ | — | Check whether this group or private judge has active stateful work |
 | `/setproblem` (`/sp`) | setproblem.py | `handle` | ❌ | — | Private-only; set current private problem from current group problem, CF pid/link, or `random` |
 | `/sync` | sync.py | `handle` | ✅ short group state lock for group writes | — | Sync current group problem history between group and private judge; empty source aborts without overwrite |
+| `/cd` | cd.py | `handle` | ❌ | — | Private-only; show whether this user can submit the current group problem or how long remains in dynamic submit CD |
 
 ### Stateful Command Runtime
 
@@ -432,7 +433,7 @@ Read-only commands (`/problem`, `/tag`, `/scoreboard`, `/help`, `/status`) still
 not enter the state scheduler.
 Private dispatch maps DMs to `CURRENT_GROUP`, requires the sender to be a member of that
 service group, and only allows the private command whitelist: `/setproblem`, `/problem`,
-`/tag`, `/submit`, `/clarify`, `/review`, `/clear`, `/sync`, `/status`, and `/help`.
+`/tag`, `/submit`, `/clarify`, `/review`, `/clear`, `/sync`, `/cd`, `/status`, and `/help`.
 Private commands do not require @mentions and should not send @ segments back.
 
 Friend request events are not commands and are not logged to command event logs.
@@ -621,7 +622,9 @@ commands are rejected in private with a friendly message.
   ability on image-dependent statements and suggest choosing another problem.
 - `/problem` in private resends the selected private problem card. `/tag`, `/status`,
   `/clear`, `/submit`, `/clarify`, and `/review` all operate on private state and do
-  not emit group @mentions.
+  not emit group @mentions. `/cd` is private-only and reports the current service-group
+  submit CD: it says the user can submit now when `submit_remaining_sec()` is zero,
+  otherwise it formats the remaining time as days/hours/minutes/seconds.
 - `/sync` copies the **current group problem only** between group and private judge.
   In a group chat it copies private → group; in private it copies group → private.
   If the source side has no relevant records, it aborts and does not overwrite the

--- a/src/kouhai_bot/handlers/__init__.py
+++ b/src/kouhai_bot/handlers/__init__.py
@@ -34,6 +34,7 @@ _PRIVATE_ALLOWED_COMMANDS = {
     "review",
     "clear",
     "sync",
+    "cd",
     "status",
     "help",
     "tag",

--- a/src/kouhai_bot/handlers/cmd/cd.py
+++ b/src/kouhai_bot/handlers/cmd/cd.py
@@ -1,0 +1,57 @@
+"""/cd — check private judge submit cooldown for the current group problem."""
+
+from __future__ import annotations
+
+from .. import registry
+from ..registry import CommandDef
+from ...napcat.client import build_plain_message, send_group_msg, send_private_msg
+from ...user_groups import submit_remaining_sec
+
+
+def _format_friendly_duration(seconds: int) -> str:
+    remaining = max(0, int(seconds))
+    parts: list[str] = []
+    units = [
+        (86400, "天"),
+        (3600, "小时"),
+        (60, "分钟"),
+        (1, "秒"),
+    ]
+    for unit_seconds, label in units:
+        value, remaining = divmod(remaining, unit_seconds)
+        if value:
+            parts.append(f"{value}{label}")
+    return "".join(parts) if parts else "0秒"
+
+
+async def handle(group_id: int, user_id: int, sender: dict,
+                 message_id: str, raw_text: str, segments: list,
+                 event: dict) -> None:
+    if raw_text.strip() != "/cd":
+        if event.get("message_type") == "private":
+            await send_private_msg(user_id, build_plain_message("用法：/cd"))
+        else:
+            await send_group_msg(group_id, build_plain_message("/cd 请在私聊里使用～"))
+        return
+
+    if event.get("message_type") != "private":
+        await send_group_msg(group_id, build_plain_message("/cd 请在私聊里使用～"))
+        return
+
+    remaining = submit_remaining_sec(user_id, group_id)
+    if remaining <= 0:
+        text = "你现在可以提交当前群内的题目！"
+    else:
+        text = f"你在{_format_friendly_duration(remaining)}后才能提交当前群内的题目，先休息一下吧～"
+    await send_private_msg(user_id, build_plain_message(text))
+
+
+def register() -> None:
+    registry.register(CommandDef(
+        name="cd",
+        aliases=[],
+        description="查看当前群题提交 CD",
+        usage="",
+        handler=handle,
+        cooldown=3,
+    ))

--- a/src/kouhai_bot/handlers/cmd/help.py
+++ b/src/kouhai_bot/handlers/cmd/help.py
@@ -12,10 +12,11 @@ _PRIVATE_HELP_COMMANDS = {
     "review",
     "clear",
     "sync",
+    "cd",
     "status",
     "help",
 }
-_GROUP_HELP_HIDDEN_COMMANDS = {"setproblem", "sync"}
+_GROUP_HELP_HIDDEN_COMMANDS = {"setproblem", "sync", "cd"}
 
 
 def _format_command_name(cmd: CommandDef) -> str:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -433,6 +433,8 @@ def _all_patches():
     stack.enter_context(patch("kouhai_bot.handlers.cmd.sync.send_group_msg", _mock_send_group))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.sync.send_private_msg", _mock_send_private))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.sync.react_emoji", _mock_react))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.cd.send_group_msg", _mock_send_group))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.cd.send_private_msg", _mock_send_private))
     stack.enter_context(patch("kouhai_bot.editorial_followup.send_private_msg", _mock_send_private))
     stack.enter_context(patch("kouhai_bot.editorial_followup.send_group_forward_msg", _mock_send_group_forward))
     stack.enter_context(patch("kouhai_bot.private_judge.send_group_msg", _mock_send_group))
@@ -2257,6 +2259,7 @@ def test_help_shows_short_aliases_and_configured_newproblem_cooldown():
     assert "/clarify(/clrf) 你的问题 — 向AI澄清题目细节，只回答题目本身不剧透做法" in text, text
     assert "/setproblem(/sp)" not in text, text
     assert "/sync —" not in text, text
+    assert "/cd —" not in text, text
     assert "private judge" in text and "详细用法请私聊发 /help" in text, text
     _cleanup()
     print("✅ help: aliases and dynamic cooldown")
@@ -2281,11 +2284,110 @@ def test_private_help_only_shows_private_judge_commands():
     )
     assert "/setproblem(/sp) [题号|链接|random] — 设置 private judge 当前题" in text, text
     assert "/sync — 在群聊和 private judge 间同步当前群题记录" in text, text
+    assert "/cd — 查看当前群题提交 CD" in text, text
     assert "/newproblem(/np)" not in text, text
     assert "/scoreboard" not in text, text
     assert "可能丢掉当前侧这题交流历史" in text, text
     _cleanup()
     print("✅ private help: filters group-only commands")
+
+
+def test_private_cd_allows_submit_when_no_cooldown_and_dispatches():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+
+    with _all_patches():
+        from kouhai_bot.handlers import process_event
+        from kouhai_bot.handlers.registry import discover_commands
+
+        discover_commands()
+        asyncio.run(process_event(_make_private_event("/cd"), spawn_handlers=False))
+
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
+    assert "你现在可以提交当前群内的题目！" in private_text, private_text
+    _cleanup()
+    print("✅ private cd: no cooldown allows submit")
+
+
+def test_private_cd_shows_remaining_for_starred_user():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _write_state(GID, {
+        "today": PID,
+        "contestId": 542,
+        "index": "D",
+        "name": "Superhero's Job",
+        "rating": 2600,
+        "tags": ["number theory", "dp"],
+        "date": "2026-05-14",
+        "posted_at": 1000,
+    })
+
+    with _all_patches(), patch("kouhai_bot.config._config", _starred_config_for_user()), patch(
+        "kouhai_bot.user_groups.time.time",
+        return_value=1000,
+    ):
+        from kouhai_bot.handlers.cmd.cd import handle
+        asyncio.run(handle(**_kwargs(_make_private_event("/cd"))))
+
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
+    assert "你在5分钟后才能提交当前群内的题目，先休息一下吧～" in private_text, private_text
+    _cleanup()
+    print("✅ private cd: shows starred cooldown")
+
+
+def test_private_cd_formats_multi_unit_remaining():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _write_state(GID, {
+        "today": PID,
+        "contestId": 542,
+        "index": "D",
+        "name": "Superhero's Job",
+        "rating": 2600,
+        "tags": ["number theory", "dp"],
+        "date": "2026-05-14",
+        "posted_at": 1000,
+    })
+
+    with _all_patches(), patch(
+        "kouhai_bot.config._config",
+        _starred_config_for_user(submit_delay_sec=90061),
+    ), patch("kouhai_bot.user_groups.time.time", return_value=1000):
+        from kouhai_bot.handlers.cmd.cd import handle
+        asyncio.run(handle(**_kwargs(_make_private_event("/cd"))))
+
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
+    assert "你在1天1小时1分钟1秒后才能提交当前群内的题目，先休息一下吧～" in private_text, private_text
+    _cleanup()
+    print("✅ private cd: formats multi-unit cooldown")
+
+
+def test_private_cd_allows_after_cooldown_expires():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _write_state(GID, {
+        "today": PID,
+        "contestId": 542,
+        "index": "D",
+        "name": "Superhero's Job",
+        "rating": 2600,
+        "tags": ["number theory", "dp"],
+        "date": "2026-05-14",
+        "posted_at": 699,
+    })
+
+    with _all_patches(), patch("kouhai_bot.config._config", _starred_config_for_user()), patch(
+        "kouhai_bot.user_groups.time.time",
+        return_value=1000,
+    ):
+        from kouhai_bot.handlers.cmd.cd import handle
+        asyncio.run(handle(**_kwargs(_make_private_event("/cd"))))
+
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
+    assert "你现在可以提交当前群内的题目！" in private_text, private_text
+    _cleanup()
+    print("✅ private cd: allows after cooldown expires")
 
 
 def test_newproblem_cooldown():
@@ -4329,6 +4431,10 @@ if __name__ == "__main__":
     test_scoreboard_splits_default_and_starred_groups()
     test_help_shows_short_aliases_and_configured_newproblem_cooldown()
     test_private_help_only_shows_private_judge_commands()
+    test_private_cd_allows_submit_when_no_cooldown_and_dispatches()
+    test_private_cd_shows_remaining_for_starred_user()
+    test_private_cd_formats_multi_unit_remaining()
+    test_private_cd_allows_after_cooldown_expires()
     test_newproblem_cooldown()
     test_newproblem_busy_rejects_concurrent_force()
     test_newproblem_unsolved_rejects()


### PR DESCRIPTION
## Summary
- add private judge /cd command for current group submit cooldown checks
- show either the ready-to-submit message or a days/hours/minutes/seconds remaining message
- expose /cd in private help while keeping it hidden from group help

## Tests
- .venv/bin/python -m pytest tests/test_commands.py -q -k 'cd or help'
- .venv/bin/python -m pytest tests/test_commands.py -q
- .venv/bin/python -m pytest tests/test_user_groups.py -q
- .venv/bin/python tests/test_commands.py