### PR TITLE
[codex] Rename private cd command to testcd

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ NapCat (QQ) ──WS──> worker.py
 - **Command auto-discovery**: Each command in `handlers/cmd/*.py` calls `register()` at module load. The `registry.discover_commands()` scans with `pkgutil.iter_modules`. Adding a new command = create a `.py` file with a `register()` function.
 - **Limited aliases**: Only six short aliases are supported: `/newproblem`→`/np`, `/problem`→`/pb`, `/submit`→`/sbm`, `/review`→`/rv`, `/clarify`→`/clrf`, `/setproblem`→`/sp`. Old aliases such as `/sb`, `/排名`, and Chinese aliases remain unsupported. New commands default to `aliases=[]` unless explicitly approved.
 - **Help auto-generation**: `handlers/cmd/help.py` reads `registry.all_commands()` and builds the help text dynamically. Descriptions must match old bridge.py wording.
-  `usage` field = args suffix in /help display (e.g. `usage="你的做法"` → `/submit 你的做法`). Group help hides private-only details for `/setproblem`, `/sync`, and `/cd` and only briefly mentions private judge; private help lists the private-judge command set.
+  `usage` field = args suffix in /help display (e.g. `usage="你的做法"` → `/submit 你的做法`). Group help hides private-only details for `/setproblem`, `/sync`, and `/testcd` and only briefly mentions private judge; private help lists the private-judge command set.
   Group and private help are both delivered as merged-forward cards, with direct text
   only as fallback.
 - **Scheduler current-group config**: `~/.kouhai-bot/scheduler_config.json` stores job list + time overrides for `CURRENT_GROUP`. Jobs are defined in `scheduler/jobs.py`.
@@ -344,7 +344,7 @@ No repository-local runtime queue is used.
 | `/status` | stubs.py | `handle_status` | ❌ | — | Check whether this group or private judge has active stateful work |
 | `/setproblem` (`/sp`) | setproblem.py | `handle` | ❌ | — | Private-only; set current private problem from current group problem, CF pid/link, or `random` |
 | `/sync` | sync.py | `handle` | ✅ short group state lock for group writes | — | Sync current group problem history between group and private judge; empty source aborts without overwrite |
-| `/cd` | cd.py | `handle` | ❌ | — | Private-only; show whether this user can submit the current group problem or how long remains in dynamic submit CD |
+| `/testcd` | testcd.py | `handle` | ❌ | — | Private-only; show whether this user can submit the current group problem or how long remains in dynamic submit CD |
 
 ### Stateful Command Runtime
 
@@ -433,7 +433,7 @@ Read-only commands (`/problem`, `/tag`, `/scoreboard`, `/help`, `/status`) still
 not enter the state scheduler.
 Private dispatch maps DMs to `CURRENT_GROUP`, requires the sender to be a member of that
 service group, and only allows the private command whitelist: `/setproblem`, `/problem`,
-`/tag`, `/submit`, `/clarify`, `/review`, `/clear`, `/sync`, `/cd`, `/status`, and `/help`.
+`/tag`, `/submit`, `/clarify`, `/review`, `/clear`, `/sync`, `/testcd`, `/status`, and `/help`.
 Private commands do not require @mentions and should not send @ segments back.
 
 Friend request events are not commands and are not logged to command event logs.
@@ -622,7 +622,7 @@ commands are rejected in private with a friendly message.
   ability on image-dependent statements and suggest choosing another problem.
 - `/problem` in private resends the selected private problem card. `/tag`, `/status`,
   `/clear`, `/submit`, `/clarify`, and `/review` all operate on private state and do
-  not emit group @mentions. `/cd` is private-only and reports the current service-group
+  not emit group @mentions. `/testcd` is private-only and reports the current service-group
   submit CD: it says the user can submit now when `submit_remaining_sec()` is zero,
   otherwise it formats the remaining time as days/hours/minutes/seconds.
 - `/sync` copies the **current group problem only** between group and private judge.

--- a/src/kouhai_bot/handlers/__init__.py
+++ b/src/kouhai_bot/handlers/__init__.py
@@ -34,7 +34,7 @@ _PRIVATE_ALLOWED_COMMANDS = {
     "review",
     "clear",
     "sync",
-    "cd",
+    "testcd",
     "status",
     "help",
     "tag",

--- a/src/kouhai_bot/handlers/cmd/help.py
+++ b/src/kouhai_bot/handlers/cmd/help.py
@@ -12,11 +12,11 @@ _PRIVATE_HELP_COMMANDS = {
     "review",
     "clear",
     "sync",
-    "cd",
+    "testcd",
     "status",
     "help",
 }
-_GROUP_HELP_HIDDEN_COMMANDS = {"setproblem", "sync", "cd"}
+_GROUP_HELP_HIDDEN_COMMANDS = {"setproblem", "sync", "testcd"}
 
 
 def _format_command_name(cmd: CommandDef) -> str:

--- a/src/kouhai_bot/handlers/cmd/testcd.py
+++ b/src/kouhai_bot/handlers/cmd/testcd.py
@@ -1,4 +1,4 @@
-"""/cd — check private judge submit cooldown for the current group problem."""
+"""/testcd — check private judge submit cooldown for the current group problem."""
 
 from __future__ import annotations
 
@@ -27,15 +27,15 @@ def _format_friendly_duration(seconds: int) -> str:
 async def handle(group_id: int, user_id: int, sender: dict,
                  message_id: str, raw_text: str, segments: list,
                  event: dict) -> None:
-    if raw_text.strip() != "/cd":
+    if raw_text.strip() != "/testcd":
         if event.get("message_type") == "private":
-            await send_private_msg(user_id, build_plain_message("用法：/cd"))
+            await send_private_msg(user_id, build_plain_message("用法：/testcd"))
         else:
-            await send_group_msg(group_id, build_plain_message("/cd 请在私聊里使用～"))
+            await send_group_msg(group_id, build_plain_message("/testcd 请在私聊里使用～"))
         return
 
     if event.get("message_type") != "private":
-        await send_group_msg(group_id, build_plain_message("/cd 请在私聊里使用～"))
+        await send_group_msg(group_id, build_plain_message("/testcd 请在私聊里使用～"))
         return
 
     remaining = submit_remaining_sec(user_id, group_id)
@@ -48,7 +48,7 @@ async def handle(group_id: int, user_id: int, sender: dict,
 
 def register() -> None:
     registry.register(CommandDef(
-        name="cd",
+        name="testcd",
         aliases=[],
         description="查看当前群题提交 CD",
         usage="",

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -433,8 +433,8 @@ def _all_patches():
     stack.enter_context(patch("kouhai_bot.handlers.cmd.sync.send_group_msg", _mock_send_group))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.sync.send_private_msg", _mock_send_private))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.sync.react_emoji", _mock_react))
-    stack.enter_context(patch("kouhai_bot.handlers.cmd.cd.send_group_msg", _mock_send_group))
-    stack.enter_context(patch("kouhai_bot.handlers.cmd.cd.send_private_msg", _mock_send_private))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.testcd.send_group_msg", _mock_send_group))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.testcd.send_private_msg", _mock_send_private))
     stack.enter_context(patch("kouhai_bot.editorial_followup.send_private_msg", _mock_send_private))
     stack.enter_context(patch("kouhai_bot.editorial_followup.send_group_forward_msg", _mock_send_group_forward))
     stack.enter_context(patch("kouhai_bot.private_judge.send_group_msg", _mock_send_group))
@@ -2259,7 +2259,7 @@ def test_help_shows_short_aliases_and_configured_newproblem_cooldown():
     assert "/clarify(/clrf) 你的问题 — 向AI澄清题目细节，只回答题目本身不剧透做法" in text, text
     assert "/setproblem(/sp)" not in text, text
     assert "/sync —" not in text, text
-    assert "/cd —" not in text, text
+    assert "/testcd —" not in text, text
     assert "private judge" in text and "详细用法请私聊发 /help" in text, text
     _cleanup()
     print("✅ help: aliases and dynamic cooldown")
@@ -2284,7 +2284,7 @@ def test_private_help_only_shows_private_judge_commands():
     )
     assert "/setproblem(/sp) [题号|链接|random] — 设置 private judge 当前题" in text, text
     assert "/sync — 在群聊和 private judge 间同步当前群题记录" in text, text
-    assert "/cd — 查看当前群题提交 CD" in text, text
+    assert "/testcd — 查看当前群题提交 CD" in text, text
     assert "/newproblem(/np)" not in text, text
     assert "/scoreboard" not in text, text
     assert "可能丢掉当前侧这题交流历史" in text, text
@@ -2292,7 +2292,7 @@ def test_private_help_only_shows_private_judge_commands():
     print("✅ private help: filters group-only commands")
 
 
-def test_private_cd_allows_submit_when_no_cooldown_and_dispatches():
+def test_private_testcd_allows_submit_when_no_cooldown_and_dispatches():
     _reset_state()
     _setup_problem_for(GID, PID)
 
@@ -2301,15 +2301,15 @@ def test_private_cd_allows_submit_when_no_cooldown_and_dispatches():
         from kouhai_bot.handlers.registry import discover_commands
 
         discover_commands()
-        asyncio.run(process_event(_make_private_event("/cd"), spawn_handlers=False))
+        asyncio.run(process_event(_make_private_event("/testcd"), spawn_handlers=False))
 
     private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
     assert "你现在可以提交当前群内的题目！" in private_text, private_text
     _cleanup()
-    print("✅ private cd: no cooldown allows submit")
+    print("✅ private testcd: no cooldown allows submit")
 
 
-def test_private_cd_shows_remaining_for_starred_user():
+def test_private_testcd_shows_remaining_for_starred_user():
     _reset_state()
     _setup_problem_for(GID, PID)
     _write_state(GID, {
@@ -2327,16 +2327,16 @@ def test_private_cd_shows_remaining_for_starred_user():
         "kouhai_bot.user_groups.time.time",
         return_value=1000,
     ):
-        from kouhai_bot.handlers.cmd.cd import handle
-        asyncio.run(handle(**_kwargs(_make_private_event("/cd"))))
+        from kouhai_bot.handlers.cmd.testcd import handle
+        asyncio.run(handle(**_kwargs(_make_private_event("/testcd"))))
 
     private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
     assert "你在5分钟后才能提交当前群内的题目，先休息一下吧～" in private_text, private_text
     _cleanup()
-    print("✅ private cd: shows starred cooldown")
+    print("✅ private testcd: shows starred cooldown")
 
 
-def test_private_cd_formats_multi_unit_remaining():
+def test_private_testcd_formats_multi_unit_remaining():
     _reset_state()
     _setup_problem_for(GID, PID)
     _write_state(GID, {
@@ -2354,16 +2354,16 @@ def test_private_cd_formats_multi_unit_remaining():
         "kouhai_bot.config._config",
         _starred_config_for_user(submit_delay_sec=90061),
     ), patch("kouhai_bot.user_groups.time.time", return_value=1000):
-        from kouhai_bot.handlers.cmd.cd import handle
-        asyncio.run(handle(**_kwargs(_make_private_event("/cd"))))
+        from kouhai_bot.handlers.cmd.testcd import handle
+        asyncio.run(handle(**_kwargs(_make_private_event("/testcd"))))
 
     private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
     assert "你在1天1小时1分钟1秒后才能提交当前群内的题目，先休息一下吧～" in private_text, private_text
     _cleanup()
-    print("✅ private cd: formats multi-unit cooldown")
+    print("✅ private testcd: formats multi-unit cooldown")
 
 
-def test_private_cd_allows_after_cooldown_expires():
+def test_private_testcd_allows_after_cooldown_expires():
     _reset_state()
     _setup_problem_for(GID, PID)
     _write_state(GID, {
@@ -2381,13 +2381,13 @@ def test_private_cd_allows_after_cooldown_expires():
         "kouhai_bot.user_groups.time.time",
         return_value=1000,
     ):
-        from kouhai_bot.handlers.cmd.cd import handle
-        asyncio.run(handle(**_kwargs(_make_private_event("/cd"))))
+        from kouhai_bot.handlers.cmd.testcd import handle
+        asyncio.run(handle(**_kwargs(_make_private_event("/testcd"))))
 
     private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
     assert "你现在可以提交当前群内的题目！" in private_text, private_text
     _cleanup()
-    print("✅ private cd: allows after cooldown expires")
+    print("✅ private testcd: allows after cooldown expires")
 
 
 def test_newproblem_cooldown():
@@ -4431,10 +4431,10 @@ if __name__ == "__main__":
     test_scoreboard_splits_default_and_starred_groups()
     test_help_shows_short_aliases_and_configured_newproblem_cooldown()
     test_private_help_only_shows_private_judge_commands()
-    test_private_cd_allows_submit_when_no_cooldown_and_dispatches()
-    test_private_cd_shows_remaining_for_starred_user()
-    test_private_cd_formats_multi_unit_remaining()
-    test_private_cd_allows_after_cooldown_expires()
+    test_private_testcd_allows_submit_when_no_cooldown_and_dispatches()
+    test_private_testcd_shows_remaining_for_starred_user()
+    test_private_testcd_formats_multi_unit_remaining()
+    test_private_testcd_allows_after_cooldown_expires()
     test_newproblem_cooldown()
     test_newproblem_busy_rejects_concurrent_force()
     test_newproblem_unsolved_rejects()


### PR DESCRIPTION
## Summary
- rename private judge cooldown command from /cd to /testcd to avoid QQ emoji substitution
- update private dispatch, private help, AGENTS.md, and command tests
- keep cooldown behavior and messages unchanged

## Tests
- .venv/bin/python -m pytest tests/test_commands.py -q -k 'testcd or help'
- .venv/bin/python -m pytest tests/test_commands.py -q
- .venv/bin/python tests/test_commands.py