### PR TITLE
[codex] support quoted cards in private setproblem

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,7 +342,7 @@ No repository-local runtime queue is used.
 | `/help` | help.py | `handle` | ❌ | — | Auto-generated help (forward card) |
 | `/review` (`/rv`) | review.py | `handle` | ✅ state scheduler | per-provider `review_model` | Discuss the latest solved group/private problem by default; quoted group problem cards can target older problems |
 | `/status` | stubs.py | `handle_status` | ❌ | — | Check whether this group or private judge has active stateful work |
-| `/setproblem` (`/sp`) | setproblem.py | `handle` | ❌ | — | Private-only; set current private problem from current group problem, CF pid/link, or `random` |
+| `/setproblem` (`/sp`) | setproblem.py | `handle` | ❌ | — | Private-only; set current private problem from current group problem, CF pid/link, `random`, or a quoted problem card |
 | `/sync` | sync.py | `handle` | ✅ short group state lock for group writes | — | Sync current group problem history between group and private judge; empty source aborts without overwrite |
 | `/testcd` | testcd.py | `handle` | ❌ | — | Private-only; show whether this user can submit the current group problem or how long remains in dynamic submit CD |
 
@@ -610,7 +610,8 @@ commands are rejected in private with a friendly message.
 - Private and group contexts are independent by default. `copy_records()` is used when
   copying history between sides so later writes do not share dict instances.
 - `/setproblem` (`/sp`) is private-only. Empty args select the current group problem;
-  `CF2234B`, `2234B`, Codeforces problemset/contest links, path fragments such as
+  replying to a known problem card with `/sp` selects that card's pid. `CF2234B`,
+  `2234B`, Codeforces problemset/contest links, path fragments such as
   `/contest/2233/problem/F` and `problem/2230/F`, and `random` are supported.
   If private history is empty and group history exists for the selected pid, it copies
   group history into private. If the group has already solved that pid, it marks private

--- a/src/kouhai_bot/handlers/cmd/help.py
+++ b/src/kouhai_bot/handlers/cmd/help.py
@@ -74,7 +74,7 @@ async def handle(group_id: int, user_id: int, sender: dict,
         lines.extend(_command_lines(visible, cfg.newproblem_cooldown))
         lines.append("")
         lines.append(
-            "🔒 private judge：私聊可用 /setproblem(/sp) 选当前群题、CF题号/链接或 random；"
+            "🔒 private judge：私聊可用 /setproblem(/sp) 选当前群题、CF题号/链接、random 或引用题目卡片；"
             "private 通过不自动加分，只有当前群题可在群里 /sync 同步。"
             "/sync 会用另一侧记录覆盖当前侧，可能丢掉当前侧这题交流历史；打星用户提交 CD 内只同步 clarify，CD 后可正常同步。"
         )

--- a/src/kouhai_bot/handlers/cmd/setproblem.py
+++ b/src/kouhai_bot/handlers/cmd/setproblem.py
@@ -25,19 +25,30 @@ from ...private_judge import (
     send_problem_card_private,
     set_private_current_problem,
 )
-from ..shared import get_today_problem
+from ..shared import get_problem_card_ref_pid, get_today_problem
 
 logger = logging.getLogger("kouhai-bot.cmd.setproblem")
 
 _RANDOM_ARGS = {"random", "rand", "r"}
+_UNKNOWN_CARD_REPLY = (
+    "这条引用我认不出对应哪道题哦，可能不是题目卡片，"
+    "也可能卡片太久了～你可以直接发 /sp 当前群题、/sp random，或者发 CF 题号/链接。"
+)
 
 
 def _strip_command(raw_text: str) -> str:
     text = raw_text.lstrip()
-    match = re.match(r"/setproblem(?:\s+|$)", text)
+    match = re.match(r"/(?:setproblem|sp)(?:\s+|$)", text)
     if not match:
         return ""
     return text[match.end():].strip()
+
+
+def _reply_to_message_id(segments: list) -> str:
+    for seg in segments:
+        if seg.get("type") == "reply":
+            return str(seg.get("data", {}).get("id", "") or "")
+    return ""
 
 
 def _history_message(*, private_count: int, group_count: int, copied: bool) -> str:
@@ -62,6 +73,14 @@ async def handle(group_id: int, user_id: int, sender: dict,
     arg = _strip_command(raw_text)
     problem: dict | None = None
     prefer_group_card = False
+    reply_to = _reply_to_message_id(segments)
+
+    if reply_to and not arg:
+        pid = get_problem_card_ref_pid(group_id, reply_to)
+        if not pid:
+            await send_private_msg(user_id, build_plain_message(_UNKNOWN_CARD_REPLY))
+            return
+        arg = pid
 
     if not arg:
         problem = get_today_problem(group_id)
@@ -142,7 +161,7 @@ def register() -> None:
     registry.register(CommandDef(
         name="setproblem",
         aliases=["sp"],
-        description="设置 private judge 当前题（题号/链接/random；空参数使用当前群题）",
+        description="设置 private judge 当前题（题号/链接/random；空参数或引用题目卡片）",
         usage="[题号|链接|random]",
         handler=handle,
         cooldown=3,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3724,6 +3724,122 @@ def test_private_setproblem_current_copies_empty_private_history():
     print("✅ private setproblem: copies empty private history")
 
 
+def test_private_setproblem_uses_referenced_problem_card():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _write_group_file(GID, "problem_card_refs.json", {
+        "card_old": {"problem": PID2, "source": "private_card", "created_at": 1},
+    })
+    quoted_problem = {
+        "today": PID2,
+        "contestId": 100,
+        "index": "A",
+        "name": "Old Problem",
+        "rating": 2200,
+        "tags": ["dp"],
+    }
+
+    with _all_patches(), \
+        patch("kouhai_bot.handlers.cmd.setproblem.resolve_problem_by_pid", return_value=quoted_problem) as resolve, \
+        patch("kouhai_bot.handlers.cmd.setproblem.send_problem_card_private", new=AsyncMock(return_value=True)):
+        from kouhai_bot.handlers.cmd.setproblem import handle
+        from kouhai_bot.private_judge import get_private_current_problem
+
+        event = _make_private_event(
+            "/sp",
+            message=[
+                {"type": "reply", "data": {"id": "card_old"}},
+                {"type": "text", "data": {"text": "/sp"}},
+            ],
+        )
+        asyncio.run(handle(**_kwargs(event)))
+        current = get_private_current_problem(UID)
+
+    resolve.assert_called_once_with(PID2)
+    assert current and current["today"] == PID2, current
+    private_text = "\n".join(
+        " ".join(seg.get("data", {}).get("text", "") for seg in item["message"] if seg.get("type") == "text")
+        for item in _private_sent
+    )
+    assert f"正在设置 CF{PID2}" in private_text, private_text
+    _cleanup()
+    print("✅ private setproblem: referenced problem card works")
+
+
+def test_private_setproblem_unknown_referenced_card_is_friendly():
+    _reset_state()
+    existing_problem = {
+        "today": PID,
+        "contestId": 542,
+        "index": "D",
+        "name": "Existing Problem",
+        "rating": 2600,
+        "tags": [],
+    }
+
+    with _all_patches(), \
+        patch("kouhai_bot.handlers.cmd.setproblem.resolve_problem_by_pid") as resolve:
+        from kouhai_bot.handlers.cmd.setproblem import handle
+        from kouhai_bot.private_judge import get_private_current_problem, set_private_current_problem
+
+        set_private_current_problem(UID, existing_problem)
+        event = _make_private_event(
+            "/sp",
+            message=[
+                {"type": "reply", "data": {"id": "missing_card"}},
+                {"type": "text", "data": {"text": "/sp"}},
+            ],
+        )
+        asyncio.run(handle(**_kwargs(event)))
+        current = get_private_current_problem(UID)
+
+    resolve.assert_not_called()
+    assert current and current["today"] == PID, current
+    private_text = "\n".join(
+        " ".join(seg.get("data", {}).get("text", "") for seg in item["message"] if seg.get("type") == "text")
+        for item in _private_sent
+    )
+    assert "认不出对应哪道题" in private_text and "可能不是题目卡片" in private_text, private_text
+    _cleanup()
+    print("✅ private setproblem: unknown referenced card is friendly")
+
+
+def test_private_setproblem_explicit_arg_wins_over_referenced_card():
+    _reset_state()
+    _write_group_file(GID, "problem_card_refs.json", {
+        "card_old": {"problem": PID2, "source": "private_card", "created_at": 1},
+    })
+    explicit_problem = {
+        "today": PID,
+        "contestId": 542,
+        "index": "D",
+        "name": "Explicit Problem",
+        "rating": 2600,
+        "tags": ["math"],
+    }
+
+    with _all_patches(), \
+        patch("kouhai_bot.handlers.cmd.setproblem.resolve_problem_by_pid", return_value=explicit_problem) as resolve, \
+        patch("kouhai_bot.handlers.cmd.setproblem.send_problem_card_private", new=AsyncMock(return_value=True)):
+        from kouhai_bot.handlers.cmd.setproblem import handle
+        from kouhai_bot.private_judge import get_private_current_problem
+
+        event = _make_private_event(
+            f"/sp {PID}",
+            message=[
+                {"type": "reply", "data": {"id": "card_old"}},
+                {"type": "text", "data": {"text": f"/sp {PID}"}},
+            ],
+        )
+        asyncio.run(handle(**_kwargs(event)))
+        current = get_private_current_problem(UID)
+
+    resolve.assert_called_once_with(PID)
+    assert current and current["today"] == PID, current
+    _cleanup()
+    print("✅ private setproblem: explicit arg wins over referenced card")
+
+
 def test_resolve_problem_by_pid_revalidates_cached_statement():
     _reset_state()
     _write_statement(PID, {
@@ -4471,4 +4587,8 @@ if __name__ == "__main__":
     test_sync_history_card_chunks_long_history()
     test_private_sync_from_solved_group_marks_private_review_state()
     test_parse_problem_ref_accepts_loose_codeforces_links()
+    test_private_setproblem_current_copies_empty_private_history()
+    test_private_setproblem_uses_referenced_problem_card()
+    test_private_setproblem_unknown_referenced_card_is_friendly()
+    test_private_setproblem_explicit_arg_wins_over_referenced_card()
     print(f"\n🎉 E2E tests passed")


### PR DESCRIPTION
## Summary
- let private `/sp` use a quoted problem card when no explicit argument is provided
- keep explicit `/sp <pid|link|random>` arguments higher priority than quoted cards
- update private help and AGENTS.md docs for the new card-reference flow

## Validation
- `uv run pytest tests/test_commands.py -k "setproblem or review or private_help"`
- `uv run pytest tests/test_commands.py`
