### PR TITLE
[codex] track private problem card refs

### DIFF
--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -23,6 +23,7 @@ from .handlers.shared import (
     high_difficulty_notice,
     load_scoreboard,
     save_problem_summary,
+    save_problem_card_ref,
     summarize_problem,
     translate_sample_notes,
 )
@@ -624,6 +625,15 @@ async def _send_high_difficulty_notice_private(user_id: int, problem: dict) -> N
         logger.warning("failed to send private high-difficulty notice: %s", e)
 
 
+def _save_private_problem_card_ref(group_id: int, message_id: int | None, pid: str) -> None:
+    if not message_id or not pid:
+        return
+    try:
+        save_problem_card_ref(group_id, message_id, pid, "private_problem_card")
+    except Exception as e:
+        logger.warning("failed to save private problem card ref for %s: %s", pid, e)
+
+
 async def send_problem_card_private(user_id: int, group_id: int, problem: dict, *, prefer_group_card: bool = True) -> bool:
     cfg = get_config()
     pid = str(problem.get("today", "") or "")
@@ -649,7 +659,9 @@ async def send_problem_card_private(user_id: int, group_id: int, problem: dict, 
             value = payload.get(key)
             if value:
                 node_ids.append(str(value))
-        if await _send_forward_nodes_private(user_id, node_ids):
+        fwd_resp = await _send_forward_nodes_private(user_id, node_ids)
+        if fwd_resp:
+            _save_private_problem_card_ref(group_id, fwd_resp, pid)
             await _send_high_difficulty_notice_private(user_id, problem)
             return True
 
@@ -672,15 +684,21 @@ async def send_problem_card_private(user_id: int, group_id: int, problem: dict, 
             resp = await send_private_msg(cfg.bot_qq, build_plain_message(text))
             if resp:
                 node_ids.append(str(resp))
-    if main_node_id and await _send_forward_nodes_private(user_id, node_ids):
-        await _send_high_difficulty_notice_private(user_id, problem)
-        return True
+    if main_node_id:
+        fwd_resp = await _send_forward_nodes_private(user_id, node_ids)
+        if fwd_resp:
+            _save_private_problem_card_ref(group_id, fwd_resp, pid)
+            await _send_high_difficulty_notice_private(user_id, problem)
+            return True
 
-    await send_private_msg(user_id, build_plain_message(post_msg))
+    direct_id = await send_private_msg(user_id, build_plain_message(post_msg))
+    _save_private_problem_card_ref(group_id, direct_id, pid)
     for sample in sample_messages:
-        await send_private_msg(user_id, build_plain_message(str(sample)))
+        sample_id = await send_private_msg(user_id, build_plain_message(str(sample)))
+        _save_private_problem_card_ref(group_id, sample_id, pid)
     if notes_message:
-        await send_private_msg(user_id, build_plain_message(notes_message))
+        notes_id = await send_private_msg(user_id, build_plain_message(notes_message))
+        _save_private_problem_card_ref(group_id, notes_id, pid)
     await _send_high_difficulty_notice_private(user_id, problem)
     return True
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4015,6 +4015,10 @@ def test_private_problem_card_high_difficulty_warns_after_card():
 
     assert ok
     assert len(_private_forwarded) == 1, f"Expected private problem card, got: {_private_forwarded}"
+    with open(os.path.join(_data_dir(), "groups", str(GID), "problem_card_refs.json"), encoding="utf-8") as f:
+        refs = json.load(f)
+    assert refs[str(3001)]["problem"] == PID
+    assert refs[str(3001)]["source"] == "private_problem_card"
     private_text = "\n".join(
         " ".join(seg.get("data", {}).get("text", "") for seg in item["message"] if seg.get("type") == "text")
         for item in _private_sent
@@ -4057,6 +4061,10 @@ def test_private_problem_card_falls_back_when_main_self_send_fails():
 
     assert ok
     assert _private_forwarded == [], f"Should not forward without main card node: {_private_forwarded}"
+    with open(os.path.join(_data_dir(), "groups", str(GID), "problem_card_refs.json"), encoding="utf-8") as f:
+        refs = json.load(f)
+    saved_pids = [item["problem"] for item in refs.values() if item.get("source") == "private_problem_card"]
+    assert saved_pids == [PID, PID, PID], refs
     private_text = "\n".join(_last_text_item(item) for item in _private_sent)
     assert "MAIN CARD" in private_text, private_text
     assert "SAMPLE CARD" in private_text, private_text


### PR DESCRIPTION
## Summary
- save private problem card message ids into `problem_card_refs.json`
- cover both private merged-forward success and direct-message fallback paths
- this lets `/sp` + private-card quote resolve when NapCat includes a reply id

## Investigation
For 941697390's latest private chat, NapCat sometimes displayed a private card quote in its own log but sent the bot only plain `/sp` with no `reply` segment, while logging `获取不到带记录的引用消息`. In that no-reply-id case the bot cannot recover the quoted target. This PR fixes the resolvable case where NapCat does include a reply id for a private problem card.

## Validation
- `uv run pytest tests/test_commands.py -k "setproblem or private_problem_card"`
- `uv run pytest tests/test_commands.py`
