### PR TITLE
[codex] hide quoted setproblem pid

### DIFF
--- a/src/kouhai_bot/handlers/cmd/setproblem.py
+++ b/src/kouhai_bot/handlers/cmd/setproblem.py
@@ -73,6 +73,7 @@ async def handle(group_id: int, user_id: int, sender: dict,
     arg = _strip_command(raw_text)
     problem: dict | None = None
     prefer_group_card = False
+    from_quoted_card = False
     reply_to = _reply_to_message_id(segments)
 
     if reply_to and not arg:
@@ -81,6 +82,7 @@ async def handle(group_id: int, user_id: int, sender: dict,
             await send_private_msg(user_id, build_plain_message(_UNKNOWN_CARD_REPLY))
             return
         arg = pid
+        from_quoted_card = True
 
     if not arg:
         problem = get_today_problem(group_id)
@@ -109,20 +111,34 @@ async def handle(group_id: int, user_id: int, sender: dict,
             ))
             return
         pid = problem_id_from_ref(*parsed)
-        await send_private_msg(user_id, build_plain_message(f"正在设置 CF{pid}，稍等一下～"))
+        if from_quoted_card:
+            await send_private_msg(user_id, build_plain_message("正在设置引用的题目，稍等一下～"))
+        else:
+            await send_private_msg(user_id, build_plain_message(f"正在设置 CF{pid}，稍等一下～"))
         try:
             problem = await asyncio.to_thread(resolve_problem_by_pid, pid)
         except NonFormulaImageProblem:
-            await send_private_msg(user_id, build_plain_message(
-                f"CF{pid} 的题面里包含非公式图片，我现在对这类题目的处理能力有限，"
-                "可能看不完整题意。建议先换一道题～"
-            ))
+            if from_quoted_card:
+                await send_private_msg(user_id, build_plain_message(
+                    "这道题的题面里包含非公式图片，我现在对这类题目的处理能力有限，"
+                    "可能看不完整题意。建议先换一道题～"
+                ))
+            else:
+                await send_private_msg(user_id, build_plain_message(
+                    f"CF{pid} 的题面里包含非公式图片，我现在对这类题目的处理能力有限，"
+                    "可能看不完整题意。建议先换一道题～"
+                ))
             return
         except Exception as e:
             logger.warning("private setproblem resolve failed for %s: %s", pid, e, exc_info=True)
-            await send_private_msg(user_id, build_plain_message(
-                f"CF{pid} 的题面暂时拉不到，稍后再试试？"
-            ))
+            if from_quoted_card:
+                await send_private_msg(user_id, build_plain_message(
+                    "这道题的题面暂时拉不到，稍后再试试？"
+                ))
+            else:
+                await send_private_msg(user_id, build_plain_message(
+                    f"CF{pid} 的题面暂时拉不到，稍后再试试？"
+                ))
             return
 
     if not problem:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3761,7 +3761,8 @@ def test_private_setproblem_uses_referenced_problem_card():
         " ".join(seg.get("data", {}).get("text", "") for seg in item["message"] if seg.get("type") == "text")
         for item in _private_sent
     )
-    assert f"正在设置 CF{PID2}" in private_text, private_text
+    assert "正在设置引用的题目" in private_text, private_text
+    assert PID2 not in private_text and f"CF{PID2}" not in private_text, private_text
     _cleanup()
     print("✅ private setproblem: referenced problem card works")
 
@@ -3804,6 +3805,35 @@ def test_private_setproblem_unknown_referenced_card_is_friendly():
     print("✅ private setproblem: unknown referenced card is friendly")
 
 
+def test_private_setproblem_referenced_card_resolve_error_hides_problem_id():
+    _reset_state()
+    _write_group_file(GID, "problem_card_refs.json", {
+        "card_old": {"problem": PID2, "source": "private_card", "created_at": 1},
+    })
+
+    with _all_patches(), \
+        patch("kouhai_bot.handlers.cmd.setproblem.resolve_problem_by_pid", side_effect=RuntimeError("boom")):
+        from kouhai_bot.handlers.cmd.setproblem import handle
+
+        event = _make_private_event(
+            "/sp",
+            message=[
+                {"type": "reply", "data": {"id": "card_old"}},
+                {"type": "text", "data": {"text": "/sp"}},
+            ],
+        )
+        asyncio.run(handle(**_kwargs(event)))
+
+    private_text = "\n".join(
+        " ".join(seg.get("data", {}).get("text", "") for seg in item["message"] if seg.get("type") == "text")
+        for item in _private_sent
+    )
+    assert "这道题的题面暂时拉不到" in private_text, private_text
+    assert PID2 not in private_text and f"CF{PID2}" not in private_text, private_text
+    _cleanup()
+    print("✅ private setproblem: referenced card resolve error hides problem id")
+
+
 def test_private_setproblem_explicit_arg_wins_over_referenced_card():
     _reset_state()
     _write_group_file(GID, "problem_card_refs.json", {
@@ -3836,6 +3866,11 @@ def test_private_setproblem_explicit_arg_wins_over_referenced_card():
 
     resolve.assert_called_once_with(PID)
     assert current and current["today"] == PID, current
+    private_text = "\n".join(
+        " ".join(seg.get("data", {}).get("text", "") for seg in item["message"] if seg.get("type") == "text")
+        for item in _private_sent
+    )
+    assert f"正在设置 CF{PID}" in private_text, private_text
     _cleanup()
     print("✅ private setproblem: explicit arg wins over referenced card")
 
@@ -4598,5 +4633,6 @@ if __name__ == "__main__":
     test_private_setproblem_current_copies_empty_private_history()
     test_private_setproblem_uses_referenced_problem_card()
     test_private_setproblem_unknown_referenced_card_is_friendly()
+    test_private_setproblem_referenced_card_resolve_error_hides_problem_id()
     test_private_setproblem_explicit_arg_wins_over_referenced_card()
     print(f"\n🎉 E2E tests passed")


### PR DESCRIPTION
## Summary
- hide the CF id in `/sp` status messages when the target comes from a quoted problem card
- keep explicit `/sp <pid|link>` behavior unchanged, since the user already supplied the id
- also hide the pid in quoted-card resolve failure messages

## Validation
- `uv run pytest tests/test_commands.py -k "setproblem"`
- `uv run pytest tests/test_commands.py`
