### PR TITLE
[codex] Add DashScope streaming chat completions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,12 @@ NapCat (QQ) ──WS──> worker.py
 - **LLM fallback**: `llm.py` — providers are tried in list order defined by
   `llm.providers` in `config.yaml`. Each provider is retried internally
   (`llm.max_retries`) before moving to the next. All providers use the
-  OpenAI-compatible `/chat/completions` format. Per-task model overrides
-  (`judge_model`, `clarify_model`, etc.) are defined per provider. `thinking`
-  and `reasoning_effort` are sent unconditionally; unsupported fields are
-  silently ignored by upstream APIs.
+  OpenAI-compatible `/chat/completions` format. DashScope/阿里云百炼 providers
+  are called with HTTP+SSE streaming to avoid the 10-minute synchronous HTTP
+  limit; other providers use the normal JSON response path. Per-task model
+  overrides (`judge_model`, `clarify_model`, etc.) are defined per provider.
+  `thinking` and `reasoning_effort` are sent unconditionally; unsupported
+  fields are silently ignored by upstream APIs.
 - **Official CF tutorials**: Scraped editorials live under `{data_dir}/tutorials/{pid}.json`
   (see `tools/scrape_cf_tutorial.py`). Runtime extraction is in `tutorials.py`. On the
   On **new problem** (`do_daily_post` / `/newproblem`), `schedule_prefetch_editorial(pid)`
@@ -272,17 +274,23 @@ llm:
       model: "deepseek-v4-pro"
 ```
 
-All providers receive the same request payload. Non-applicable fields (e.g.
+All providers receive the same base request payload. Non-applicable fields (e.g.
 `reasoning_effort` on DeepSeek, `thinking` on OpenAI) are silently ignored by the
 upstream API. `thinking={"type": "enabled"}` is always sent when the judge handler
 requests it — it's an OpenAI-compatible extension that DeepSeek supports.
+DashScope/阿里云百炼 providers (detected by `dashscope.aliyuncs.com` base URL or
+`aliyun`/`bailian`/`dashscope` provider name) additionally receive
+`stream=true`; `llm.py` reads the SSE `data:` stream and concatenates
+`choices[].delta.content`. Do not blindly send `stream=true` to every provider:
+some OpenAI-compatible gateways reject unknown or unsupported fields instead of
+ignoring them.
 
 ### Transient failures
 
 Transient LLM failures (timeouts, `aiohttp` client errors, `408/409/429/5xx`,
-malformed empty-choice responses) are retried inside `llm.py` with exponential
-backoff at the per-provider level. Non-retryable errors (4xx besides 408/409/429)
-cause immediate fallback to the next provider.
+malformed empty-choice responses, malformed DashScope SSE responses) are retried
+inside `llm.py` with exponential backoff at the per-provider level. Non-retryable
+errors (4xx besides 408/409/429) cause immediate fallback to the next provider.
 
 If all providers are exhausted, the user-facing reply should suggest contacting
 an administrator rather than claiming the model is "thinking too long".
@@ -554,10 +562,11 @@ already solved it.
 
 ### `/clarify` — Anti-Spoiler Clarification
 
-LLM `timeout=600` (10 minutes per HTTP attempt; retries in `shared.py` can extend total wait).
+LLM timeout comes from `llm.clarify_timeout_sec`; DashScope/阿里云百炼 uses
+HTTP+SSE streaming, while other providers use the normal JSON response path.
 Uses `response_format: json_object`. `thinking: enabled` and `reasoning_effort`
 are sent unconditionally; unsupported fields are ignored by the upstream API.
-Timeout comes from `llm.clarify_timeout_sec`. Output:
+Output:
 `{"reply": "...", "reaction": ""}`.
 - `reaction="123"` for spam/off-topic → react only, no text
 - Normal: reply text only, must not leak solution hints

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -36,7 +36,7 @@ llm:
       reasoning_effort: "high"  # minimal/low/medium/high/xhigh
       model_tag: "『֎AI』"        # appended to LLM output; empty to disable
 
-    # ── Fallback: Qwen (supports OpenAI-compatible format) ──
+    # ── Fallback: Qwen/DashScope (auto-uses SSE streaming) ──
     - name: qwen
       api_key: "..."
       base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1"

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
 import aiohttp
 
@@ -59,6 +61,18 @@ def _message_content_text(message: dict) -> str:
     return str(content).strip()
 
 
+def _provider_uses_stream(provider_name: str, base_url: str) -> bool:
+    name = (provider_name or "").strip().lower()
+    if name in {"aliyun", "bailian", "dashscope"}:
+        return True
+
+    parsed = urlparse((base_url or "").strip())
+    host = (parsed.hostname or "").lower()
+    if not host and "://" not in (base_url or ""):
+        host = (base_url or "").split("/", 1)[0].lower()
+    return host == "dashscope.aliyuncs.com" or host.endswith(".dashscope.aliyuncs.com")
+
+
 def _should_retry_status(status: int) -> bool:
     return status in {408, 409, 429} or status >= 500
 
@@ -83,6 +97,122 @@ def _retry_delay_seconds(
         return max(0.0, min(retry_after_sec, max_delay_sec))
     delay = base_delay_sec * (2 ** max(retry_number - 1, 0))
     return max(0.0, min(delay, max_delay_sec))
+
+
+def _stream_content_text(message: dict) -> str:
+    content = message.get("content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            text = item.get("text", "")
+            if isinstance(text, str):
+                parts.append(text)
+        return "".join(parts)
+    if content is None:
+        return ""
+    return str(content)
+
+
+def _choice_delta_text(choice: dict) -> str:
+    delta = choice.get("delta", {})
+    if isinstance(delta, dict):
+        text = _stream_content_text(delta)
+        if text:
+            return text
+
+    message = choice.get("message", {})
+    if isinstance(message, dict):
+        return _stream_content_text(message)
+    return ""
+
+
+def _stream_event_text(data: dict) -> tuple[str, bool]:
+    choices = data.get("choices", [])
+    if not choices:
+        return "", False
+    choice = choices[0]
+    if not isinstance(choice, dict):
+        return "", False
+    return _choice_delta_text(choice), True
+
+
+async def _read_streaming_chat_completion(
+    resp: aiohttp.ClientResponse,
+    *,
+    provider_name: str,
+) -> _ChatCompletionAttempt:
+    parts: list[str] = []
+    event_lines: list[str] = []
+
+    def finish(text: str) -> _ChatCompletionAttempt:
+        if not text:
+            logger.warning("%s API stream returned no text", provider_name)
+        return _ChatCompletionAttempt(
+            text=text or None,
+            retryable=not bool(text),
+            retry_after_sec=None,
+            failure_kind=None if text else "service_unavailable",
+        )
+
+    def malformed(reason: str) -> _ChatCompletionAttempt:
+        logger.warning("%s API returned malformed SSE data: %s", provider_name, reason)
+        return _ChatCompletionAttempt(
+            text=None,
+            retryable=True,
+            retry_after_sec=None,
+            failure_kind="service_unavailable",
+        )
+
+    def handle_event(raw_data: str) -> tuple[bool, _ChatCompletionAttempt | None]:
+        data_text = raw_data.strip()
+        if not data_text:
+            return False, None
+        if data_text == "[DONE]":
+            return True, None
+        try:
+            data = json.loads(data_text)
+        except json.JSONDecodeError:
+            return False, malformed("invalid json")
+
+        text, had_choice = _stream_event_text(data)
+        if text:
+            parts.append(text)
+        if not had_choice:
+            return False, malformed("missing choices")
+        return False, None
+
+    try:
+        async for raw_line in resp.content:
+            line = raw_line.decode("utf-8").strip()
+            if not line:
+                if event_lines:
+                    done, failure = handle_event("\n".join(event_lines))
+                    event_lines.clear()
+                    if failure is not None:
+                        return failure
+                    if done:
+                        return finish("".join(parts).strip())
+                continue
+            if line.startswith(":"):
+                continue
+            if not line.startswith("data:"):
+                continue
+            event_lines.append(line[5:].lstrip())
+
+        if event_lines:
+            done, failure = handle_event("\n".join(event_lines))
+            if failure is not None:
+                return failure
+            if done:
+                event_lines.clear()
+
+        return finish("".join(parts).strip())
+    except UnicodeDecodeError:
+        return malformed("invalid utf-8")
 
 
 async def _post_chat_completion_once(
@@ -115,6 +245,12 @@ async def _post_chat_completion_once(
                         resp.headers.get("Retry-After")
                     ),
                     failure_kind="service_unavailable" if retryable else "error",
+                )
+
+            if payload.get("stream") is True:
+                return await _read_streaming_chat_completion(
+                    resp,
+                    provider_name=provider_name,
                 )
 
             data = await resp.json()
@@ -210,6 +346,8 @@ async def chat_completion(
             reasoning_effort = provider.reasoning_effort.strip().lower()
             if reasoning_effort:
                 payload["reasoning_effort"] = reasoning_effort
+            if _provider_uses_stream(provider.name, provider.base_url):
+                payload["stream"] = True
 
             for attempt in range(max_retries + 1):
                 result = await _post_chat_completion_once(

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -158,8 +158,8 @@ async def _read_streaming_chat_completion(
             failure_kind=None if text else "service_unavailable",
         )
 
-    def malformed(reason: str) -> _ChatCompletionAttempt:
-        logger.warning("%s API returned malformed SSE data: %s", provider_name, reason)
+    def stream_failure(reason: str) -> _ChatCompletionAttempt:
+        logger.warning("%s API stream failed: %s", provider_name, reason)
         return _ChatCompletionAttempt(
             text=None,
             retryable=True,
@@ -176,13 +176,13 @@ async def _read_streaming_chat_completion(
         try:
             data = json.loads(data_text)
         except json.JSONDecodeError:
-            return False, malformed("invalid json")
+            return False, stream_failure("invalid json")
 
         text, had_choice = _stream_event_text(data)
         if text:
             parts.append(text)
         if not had_choice:
-            return False, malformed("missing choices")
+            return False, stream_failure("missing choices")
         return False, None
 
     try:
@@ -208,11 +208,11 @@ async def _read_streaming_chat_completion(
             if failure is not None:
                 return failure
             if done:
-                event_lines.clear()
+                return finish("".join(parts).strip())
 
-        return finish("".join(parts).strip())
+        return stream_failure("missing done sentinel")
     except UnicodeDecodeError:
-        return malformed("invalid utf-8")
+        return stream_failure("invalid utf-8")
 
 
 async def _post_chat_completion_once(

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 from kouhai_bot.config import BotConfig
 from kouhai_bot.llm_config import LlmProviderConfig
 from kouhai_bot.handlers.shared import call_chat_completion, summarize_problem
-from kouhai_bot.llm import _ChatCompletionAttempt
+from kouhai_bot.llm import _ChatCompletionAttempt, _post_chat_completion_once
 
 
 class _DummySession:
@@ -17,6 +17,53 @@ class _DummySession:
 
     async def __aexit__(self, exc_type, exc, tb):
         return False
+
+
+class _AsyncByteLines:
+    def __init__(self, lines):
+        self._lines = [line if isinstance(line, bytes) else line.encode("utf-8") for line in lines]
+        self._index = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._index >= len(self._lines):
+            raise StopAsyncIteration
+        line = self._lines[self._index]
+        self._index += 1
+        return line
+
+
+class _DummyResponse:
+    def __init__(self, *, status=200, headers=None, text="", json_data=None, lines=None):
+        self.status = status
+        self.headers = headers or {}
+        self._text = text
+        self._json_data = json_data or {}
+        self.content = _AsyncByteLines(lines or [])
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def text(self):
+        return self._text
+
+    async def json(self):
+        return self._json_data
+
+
+class _PostSession:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def post(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return self.response
 
 
 def _openai_cfg(**overrides):
@@ -130,3 +177,96 @@ def test_summarize_problem_uses_configured_timeout():
         summary, tag = asyncio.run(summarize_problem("stmt", "input", "limits"))
         assert summary == "summary ok"
         assert tag == "🐳"
+
+
+def test_dashscope_provider_payload_enables_stream():
+    provider = LlmProviderConfig(
+        name="qwen",
+        api_key="sk-test",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        model="qwen-test",
+    )
+    cfg = _openai_cfg(llm_providers=[provider])
+    calls = []
+
+    async def fake_once(session, **kwargs):
+        calls.append(kwargs["payload"].copy())
+        return _ChatCompletionAttempt(text="OK", retryable=False, retry_after_sec=None)
+
+    with patch("kouhai_bot.llm.get_config", return_value=cfg), \
+            patch("kouhai_bot.llm.aiohttp.ClientSession", _DummySession), \
+            patch("kouhai_bot.llm._post_chat_completion_once", side_effect=fake_once):
+        result = asyncio.run(call_chat_completion(
+            [{"role": "user", "content": "Reply with exactly OK."}],
+            task="judge",
+        ))
+
+    assert result == "OK"
+    assert calls[0]["stream"] is True
+
+
+def test_non_dashscope_provider_payload_does_not_enable_stream():
+    cfg = _openai_cfg()
+    calls = []
+
+    async def fake_once(session, **kwargs):
+        calls.append(kwargs["payload"].copy())
+        return _ChatCompletionAttempt(text="OK", retryable=False, retry_after_sec=None)
+
+    with patch("kouhai_bot.llm.get_config", return_value=cfg), \
+            patch("kouhai_bot.llm.aiohttp.ClientSession", _DummySession), \
+            patch("kouhai_bot.llm._post_chat_completion_once", side_effect=fake_once):
+        result = asyncio.run(call_chat_completion(
+            [{"role": "user", "content": "Reply with exactly OK."}],
+            task="judge",
+        ))
+
+    assert result == "OK"
+    assert "stream" not in calls[0]
+
+
+def test_streaming_chat_completion_reads_sse_delta_chunks():
+    response = _DummyResponse(lines=[
+        ': keep-alive\n',
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+        '\n',
+        'data: {"choices":[{"delta":{"content":" world"}}]}\n',
+        '\n',
+        'data: [DONE]\n',
+        '\n',
+    ])
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="qwen",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        headers={},
+        payload={"stream": True},
+        timeout=120,
+    ))
+
+    assert result.text == "Hello world"
+    assert result.retryable is False
+    assert session.calls[0][1]["json"] == {"stream": True}
+
+
+def test_streaming_chat_completion_malformed_sse_is_retryable():
+    response = _DummyResponse(lines=[
+        'data: not-json\n',
+        '\n',
+    ])
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="qwen",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        headers={},
+        payload={"stream": True},
+        timeout=120,
+    ))
+
+    assert result.text is None
+    assert result.retryable is True
+    assert result.failure_kind == "service_unavailable"

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -251,6 +251,27 @@ def test_streaming_chat_completion_reads_sse_delta_chunks():
     assert session.calls[0][1]["json"] == {"stream": True}
 
 
+def test_streaming_chat_completion_eof_without_done_is_retryable():
+    response = _DummyResponse(lines=[
+        'data: {"choices":[{"delta":{"content":"partial"}}]}\n',
+        '\n',
+    ])
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="qwen",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        headers={},
+        payload={"stream": True},
+        timeout=120,
+    ))
+
+    assert result.text is None
+    assert result.retryable is True
+    assert result.failure_kind == "service_unavailable"
+
+
 def test_streaming_chat_completion_malformed_sse_is_retryable():
     response = _DummyResponse(lines=[
         'data: not-json\n',


### PR DESCRIPTION
## Summary
- Enable HTTP+SSE streaming for DashScope/阿里云百炼 OpenAI-compatible chat-completions providers.
- Parse SSE `data:` events and concatenate `choices[].delta.content` while keeping other providers on the existing JSON response path.
- Document the DashScope streaming behavior in `AGENTS.md` and `config.example.yaml`.

## Why
阿里云百炼 synchronous HTTP calls have a hard 10-minute limit. Long GLM/Qwen-style judge, clarify, review, and summary calls can hit that limit when using the normal blocking JSON response. Streaming keeps the HTTP response active and avoids that synchronous timeout path.

## Validation
- `uv run pytest tests/test_shared.py tests/test_config.py`
- `uv run pytest`