### PR TITLE
[codex] Exclude solved problems from picker

### DIFF
--- a/src/kouhai_bot/handlers/cmd/newproblem.py
+++ b/src/kouhai_bot/handlers/cmd/newproblem.py
@@ -165,6 +165,8 @@ def _picker_args(command: str, group_id: int, *extra: str) -> list[str]:
         command,
         "--group",
         str(group_id),
+        "--data-dir",
+        str(get_config().data_dir),
         "--min-rating",
         str(min_rating),
         "--max-rating",

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -535,6 +535,7 @@ async def _reveal_problem_source(group_id: int) -> str:
     try:
         proc = await asyncio.create_subprocess_exec(
             sys.executable, picker_path, "reveal", "--group", str(group_id),
+            "--data-dir", str(get_config().data_dir),
             stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
         )
         stdout, _stderr = await asyncio.wait_for(proc.communicate(), timeout=30)

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -398,11 +398,7 @@ def _ensure_statement(problem: dict) -> dict:
     from .problems import picker
 
     cfg = get_config()
-    picker.STATE_DIR = cfg.data_dir
-    picker.CACHE_DIR = os.path.join(cfg.data_dir, "statements")
-    picker.GROUPS_DIR = os.path.join(cfg.data_dir, "groups")
-    os.makedirs(picker.CACHE_DIR, exist_ok=True)
-    os.makedirs(picker.GROUPS_DIR, exist_ok=True)
+    picker._set_state_dir(cfg.data_dir)
     stmt = picker.fetch_statement(problem)
     if isinstance(stmt, dict):
         return stmt

--- a/src/kouhai_bot/problems/picker.py
+++ b/src/kouhai_bot/problems/picker.py
@@ -28,17 +28,31 @@ import cloudscraper
 STATE_DIR = os.path.expanduser("~/.kouhai-bot")
 CACHE_DIR = os.path.join(STATE_DIR, "statements")
 GROUPS_DIR = os.path.join(STATE_DIR, "groups")
-os.makedirs(STATE_DIR, exist_ok=True)
-os.makedirs(CACHE_DIR, exist_ok=True)
-os.makedirs(GROUPS_DIR, exist_ok=True)
 
 # Per-group state: override with --group <id>
 CURRENT_GROUP = "default"
 
 
+def _ensure_state_dirs() -> None:
+    os.makedirs(STATE_DIR, exist_ok=True)
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    os.makedirs(GROUPS_DIR, exist_ok=True)
+
+
+def _set_state_dir(data_dir: str):
+    global STATE_DIR, CACHE_DIR, GROUPS_DIR
+    STATE_DIR = os.path.expanduser(str(data_dir))
+    CACHE_DIR = os.path.join(STATE_DIR, "statements")
+    GROUPS_DIR = os.path.join(STATE_DIR, "groups")
+    _ensure_state_dirs()
+
+
 def _set_group(group_id: str):
     global CURRENT_GROUP
     CURRENT_GROUP = str(group_id)
+
+
+_ensure_state_dirs()
 
 
 def _state_file() -> str:
@@ -47,6 +61,10 @@ def _state_file() -> str:
 
 def _used_file() -> str:
     return os.path.join(GROUPS_DIR, CURRENT_GROUP, "used.json")
+
+
+def _scoreboard_file() -> str:
+    return os.path.join(GROUPS_DIR, CURRENT_GROUP, "scoreboard.json")
 
 
 def _set_rating_range(min_rating: int, max_rating: int):
@@ -75,6 +93,26 @@ def _load_used() -> set:
 def _save_used(used: set):
     with open(_used_file(), "w") as f:
         json.dump(sorted(used), f)
+
+
+def _load_solved_problem_ids() -> set[str]:
+    path = _scoreboard_file()
+    if not os.path.exists(path):
+        return set()
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return set()
+
+    solves = data.get("solves", []) if isinstance(data, dict) else []
+    if not isinstance(solves, list):
+        return set()
+    return {
+        str(item.get("problem", "")).strip()
+        for item in solves
+        if isinstance(item, dict) and str(item.get("problem", "")).strip()
+    }
 
 
 def _problem_id(p: dict) -> str:
@@ -140,14 +178,19 @@ def select_problem() -> dict:
         raise RuntimeError(f"No problems found in range {RATING_MIN}-{RATING_MAX}")
 
     used = _load_used()
+    solved = _load_solved_problem_ids()
 
-    # Filter to unused problems
-    available = [p for p in problems if _problem_id(p) not in used]
+    # Filter to unused and unsolved problems. solved comes from scoreboard.json so
+    # historical solves remain excluded even if used.json is lost or rebuilt.
+    available = [p for p in problems if _problem_id(p) not in used | solved]
     if not available:
-        # All used — reset
+        # All unsolved problems have been used in this cycle - reset only used.
         _save_used(set())
-        used = set()
-        available = problems
+        available = [p for p in problems if _problem_id(p) not in solved]
+        if not available:
+            raise RuntimeError(
+                f"No unsolved problems found in range {RATING_MIN}-{RATING_MAX}"
+            )
 
     return random.choice(available)
 
@@ -448,8 +491,9 @@ def reveal() -> str:
 # ── CLI ─────────────────────────────────────────────────────────────────
 
 if __name__ == "__main__":
-    # Parse --group <id>, --min-rating <n>, --max-rating <n>, or --flag=value
+    # Parse --group <id>, --data-dir <path>, --min-rating <n>, --max-rating <n>, or --flag=value
     group_id = "default"
+    data_dir = STATE_DIR
     min_rating = RATING_MIN
     max_rating = RATING_MAX
     skip_next = False
@@ -463,6 +507,10 @@ if __name__ == "__main__":
             group_id = argv[i + 1]
             skip_next = True
             continue
+        if a == "--data-dir" and i + 1 < len(argv):
+            data_dir = argv[i + 1]
+            skip_next = True
+            continue
         if a == "--min-rating" and i + 1 < len(argv):
             min_rating = int(argv[i + 1])
             skip_next = True
@@ -474,6 +522,9 @@ if __name__ == "__main__":
         if a.startswith("--group="):
             group_id = a.split("=", 1)[1]
             continue
+        if a.startswith("--data-dir="):
+            data_dir = a.split("=", 1)[1]
+            continue
         if a.startswith("--min-rating="):
             min_rating = int(a.split("=", 1)[1])
             continue
@@ -484,12 +535,13 @@ if __name__ == "__main__":
             continue
         cmd_args.append(a)
 
+    _set_state_dir(data_dir)
     _set_group(group_id)
     _set_rating_range(min_rating, max_rating)
     os.makedirs(os.path.join(GROUPS_DIR, group_id), exist_ok=True)
 
     if len(cmd_args) < 1:
-        print("Usage: daily_picker.py [--group <id>] [--min-rating <n>] [--max-rating <n>] pick|post|reveal")
+        print("Usage: daily_picker.py [--group <id>] [--data-dir <path>] [--min-rating <n>] [--max-rating <n>] pick|post|reveal")
         sys.exit(1)
 
     cmd = cmd_args[0]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2783,6 +2783,8 @@ def test_newproblem_picker_args_follow_env_rating_range():
 
         args = _picker_args("pick", GID, "--with-statement")
 
+    assert "--data-dir" in args, f"Missing data_dir flag: {args}"
+    assert args[args.index("--data-dir") + 1] == _data_dir(), f"Wrong data_dir args: {args}"
     assert "--min-rating" in args and "--max-rating" in args, f"Missing rating flags: {args}"
     assert args[args.index("--min-rating") + 1] == "2100", f"Wrong min rating args: {args}"
     assert args[args.index("--max-rating") + 1] == "2900", f"Wrong max rating args: {args}"
@@ -2801,10 +2803,36 @@ def test_newproblem_picker_args_prefer_scheduler_override():
 
         args = _picker_args("pick", GID, "--with-statement")
 
+    assert args[args.index("--data-dir") + 1] == _data_dir(), f"Wrong data_dir args: {args}"
     assert args[args.index("--min-rating") + 1] == "2300", f"Scheduler min override ignored: {args}"
     assert args[args.index("--max-rating") + 1] == "2700", f"Scheduler max override ignored: {args}"
     _cleanup()
     print("✅ newproblem: picker args prefer scheduler override")
+
+
+def test_submit_reveal_passes_configured_data_dir_to_picker():
+    _reset_state()
+    calls = []
+
+    async def _mock_subprocess(*args, **kwargs):
+        calls.append(args)
+        proc = AsyncMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=("上一道题来自 CF542D✨".encode(), b""))
+        return proc
+
+    with _all_patches(), patch("asyncio.create_subprocess_exec", _mock_subprocess):
+        from kouhai_bot.handlers.cmd.submit import _reveal_problem_source
+
+        result = asyncio.run(_reveal_problem_source(GID))
+
+    assert result == "本题来自 CF542D✨"
+    assert calls, "reveal subprocess was not called"
+    args = list(calls[0])
+    assert "--data-dir" in args, f"Missing data_dir flag: {args}"
+    assert args[args.index("--data-dir") + 1] == _data_dir(), f"Wrong data_dir args: {args}"
+    _cleanup()
+    print("✅ submit reveal: passes configured data_dir to picker")
 
 
 def test_status_ignores_other_groups_and_reports_idle():

--- a/tests/test_picker_selection.py
+++ b/tests/test_picker_selection.py
@@ -1,0 +1,124 @@
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import pytest
+
+from kouhai_bot.problems import picker
+
+
+@pytest.fixture(autouse=True)
+def _restore_picker_state():
+    original_state_dir = picker.STATE_DIR
+    original_group = picker.CURRENT_GROUP
+    yield
+    picker._set_state_dir(original_state_dir)
+    picker._set_group(original_group)
+
+
+def _problem(contest_id: int, index: str) -> dict:
+    return {"contestId": contest_id, "index": index, "rating": 2200}
+
+
+def _configure_picker_tmp(tmp_path):
+    data_dir = tmp_path / "data"
+    picker._set_state_dir(str(data_dir))
+    picker._set_group("g1")
+    group_dir = data_dir / "groups" / "g1"
+    group_dir.mkdir(parents=True)
+    return data_dir, group_dir
+
+
+
+def test_set_state_dir_updates_all_picker_storage_paths(tmp_path):
+    data_dir, group_dir = _configure_picker_tmp(tmp_path)
+
+    assert picker.STATE_DIR == str(data_dir)
+    assert picker.CACHE_DIR == str(data_dir / "statements")
+    assert picker.GROUPS_DIR == str(data_dir / "groups")
+    assert picker._state_file() == str(group_dir / "state.json")
+    assert picker._used_file() == str(group_dir / "used.json")
+    assert picker._scoreboard_file() == str(group_dir / "scoreboard.json")
+    assert picker._cache_path("123A") == str(data_dir / "statements" / "123A.json")
+    assert picker._cache_all_path() == str(
+        data_dir / f"cf_all_{picker.RATING_MIN}_{picker.RATING_MAX}.json"
+    )
+
+
+def test_select_problem_excludes_scoreboard_solves_when_used_is_missing(monkeypatch, tmp_path):
+    _data_dir, group_dir = _configure_picker_tmp(tmp_path)
+    (group_dir / "scoreboard.json").write_text(json.dumps({
+        "solves": [{"problem": "1A"}],
+        "user_submissions": {},
+    }))
+    monkeypatch.setattr(picker, "_get_cached_targets", lambda: [_problem(1, "A"), _problem(2, "B")])
+    monkeypatch.setattr(picker.random, "choice", lambda seq: seq[0])
+
+    selected = picker.select_problem()
+
+    assert picker._problem_id(selected) == "2B"
+
+
+def test_select_problem_resets_used_but_keeps_solved_excluded(monkeypatch, tmp_path):
+    _data_dir, group_dir = _configure_picker_tmp(tmp_path)
+    (group_dir / "scoreboard.json").write_text(json.dumps({
+        "solves": [{"problem": "1A"}],
+        "user_submissions": {},
+    }))
+    (group_dir / "used.json").write_text(json.dumps(["2B"]))
+    monkeypatch.setattr(picker, "_get_cached_targets", lambda: [_problem(1, "A"), _problem(2, "B")])
+    monkeypatch.setattr(picker.random, "choice", lambda seq: seq[0])
+
+    selected = picker.select_problem()
+
+    assert picker._problem_id(selected) == "2B"
+    assert json.loads((group_dir / "used.json").read_text()) == []
+
+
+def test_select_problem_raises_when_every_candidate_is_solved(monkeypatch, tmp_path):
+    _data_dir, group_dir = _configure_picker_tmp(tmp_path)
+    (group_dir / "scoreboard.json").write_text(json.dumps({
+        "solves": [{"problem": "1A"}, {"problem": "2B"}],
+        "user_submissions": {},
+    }))
+    monkeypatch.setattr(picker, "_get_cached_targets", lambda: [_problem(1, "A"), _problem(2, "B")])
+
+    with pytest.raises(RuntimeError, match="No unsolved problems"):
+        picker.select_problem()
+
+
+def test_picker_cli_reveal_reads_configured_data_dir(tmp_path):
+    data_dir = tmp_path / "custom-data"
+    group_dir = data_dir / "groups" / "g1"
+    group_dir.mkdir(parents=True)
+    (group_dir / "state.json").write_text(json.dumps({
+        "today": "123A",
+        "name": "Custom State",
+        "rating": 2400,
+    }))
+    env = {**os.environ, "HOME": str(tmp_path / "home")}
+    script = os.path.join(
+        os.path.dirname(__file__), "..", "src", "kouhai_bot", "problems", "picker.py"
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            script,
+            "reveal",
+            "--group",
+            "g1",
+            "--data-dir",
+            str(data_dir),
+        ],
+        check=True,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert "CF123A Custom State 2400" in result.stdout


### PR DESCRIPTION
## Summary

Fixes a duplicate problem selection path where `/newproblem` trusted only `used.json`, while `/submit` treated any problem in `scoreboard.json.solves` as already solved.

The picker now loads solved problem ids from the group scoreboard and excludes them in addition to `used.json`. If the current used cycle is exhausted, it resets only `used.json` and still keeps scoreboard solves excluded.

Review follow-up: picker CLI now accepts `--data-dir`, and both `/newproblem` and `/submit` pass the configured runtime data directory into picker subprocesses. This keeps `state.json`, `used.json`, `scoreboard.json`, statement cache, and CF problemset cache on the configured storage root instead of falling back to `~/.kouhai-bot`.

## Impact

This prevents historical solved problems from being posted again when `used.json` is lost, rebuilt, or out of sync with scoreboard history, including deployments that set `data_dir` away from the default.

## Validation

- `uv run pytest tests/test_picker_selection.py tests/test_picker_samples.py tests/test_commands.py -q`
- `uv run pytest`