### PR TITLE
[codex] add provider streaming option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,8 @@ NapCat (QQ) ──WS──> worker.py
   (`llm.max_retries`) before moving to the next. All providers use the
   OpenAI-compatible `/chat/completions` format. DashScope/阿里云百炼 providers
   are called with HTTP+SSE streaming to avoid the 10-minute synchronous HTTP
-  limit; other providers use the normal JSON response path. Per-task model
+  limit; providers with `stream: true` do the same; other providers use the
+  normal JSON response path. Per-task model
   overrides (`judge_model`, `clarify_model`, etc.) are defined per provider.
   `thinking` and `reasoning_effort` are sent unconditionally; unsupported
   fields are silently ignored by upstream APIs.
@@ -108,6 +109,7 @@ Each provider in `llm.providers`:
 | `review_model` | `model` | Per-task override for `/review` |
 | `summary_model` | `model` | Per-task override for `/summary` + editorial translation |
 | `reasoning_effort` | — | OpenAI reasoning effort: `minimal`/`low`/`medium`/`high`/`xhigh` |
+| `stream` | `false` | Send `stream=true` and read SSE chunks for this provider; DashScope/阿里云百炼 streams automatically |
 | `model_tag` | `""` | Short string appended to every LLM-generated user message (judge/clarify/review/summary/editorial); empty means no tag |
 
 #### `qwen` section
@@ -279,7 +281,8 @@ All providers receive the same base request payload. Non-applicable fields (e.g.
 upstream API. `thinking={"type": "enabled"}` is always sent when the judge handler
 requests it — it's an OpenAI-compatible extension that DeepSeek supports.
 DashScope/阿里云百炼 providers (detected by `dashscope.aliyuncs.com` base URL or
-`aliyun`/`bailian`/`dashscope` provider name) additionally receive
+`aliyun`/`bailian`/`dashscope` provider name) and providers with `stream: true`
+additionally receive
 `stream=true`; `llm.py` reads the SSE `data:` stream and concatenates
 `choices[].delta.content`. Do not blindly send `stream=true` to every provider:
 some OpenAI-compatible gateways reject unknown or unsupported fields instead of
@@ -562,8 +565,9 @@ already solved it.
 
 ### `/clarify` — Anti-Spoiler Clarification
 
-LLM timeout comes from `llm.clarify_timeout_sec`; DashScope/阿里云百炼 uses
-HTTP+SSE streaming, while other providers use the normal JSON response path.
+LLM timeout comes from `llm.clarify_timeout_sec`; DashScope/阿里云百炼 and
+providers with `stream: true` use HTTP+SSE streaming, while other providers use
+the normal JSON response path.
 Uses `response_format: json_object`. `thinking: enabled` and `reasoning_effort`
 are sent unconditionally; unsupported fields are ignored by the upstream API.
 Output:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -33,6 +33,7 @@ llm:
       api_key: "..."
       base_url: "..."
       model: "gpt-5.5"
+      stream: true               # use SSE streaming; recommended for sub2api/OpenAI
       reasoning_effort: "high"  # minimal/low/medium/high/xhigh
       model_tag: "『֎AI』"        # appended to LLM output; empty to disable
 

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -61,7 +61,15 @@ def _message_content_text(message: dict) -> str:
     return str(content).strip()
 
 
-def _provider_uses_stream(provider_name: str, base_url: str) -> bool:
+def _provider_uses_stream(
+    provider_name: str,
+    base_url: str,
+    *,
+    explicit_stream: bool = False,
+) -> bool:
+    if explicit_stream:
+        return True
+
     name = (provider_name or "").strip().lower()
     if name in {"aliyun", "bailian", "dashscope"}:
         return True
@@ -130,14 +138,62 @@ def _choice_delta_text(choice: dict) -> str:
     return ""
 
 
-def _stream_event_text(data: dict) -> tuple[str, bool]:
+def _stream_event_text(data: dict) -> tuple[str, bool, str | None]:
+    error = data.get("error")
+    if isinstance(error, dict):
+        message = str(error.get("message") or error.get("type") or "error")
+        return "", True, message
+
+    event_type = str(data.get("type") or "").strip()
+    if event_type in {"response.failed", "response.incomplete"}:
+        error_obj = data.get("error") or data.get("response", {}).get("error")
+        if isinstance(error_obj, dict):
+            message = str(error_obj.get("message") or error_obj.get("type") or event_type)
+        else:
+            message = event_type
+        return "", True, message
+
     choices = data.get("choices", [])
-    if not choices:
-        return "", False
-    choice = choices[0]
-    if not isinstance(choice, dict):
-        return "", False
-    return _choice_delta_text(choice), True
+    if choices:
+        choice = choices[0]
+        if isinstance(choice, dict):
+            return _choice_delta_text(choice), True, None
+        return "", True, None
+
+    if event_type == "response.output_text.delta":
+        delta = data.get("delta", "")
+        return delta if isinstance(delta, str) else "", True, None
+
+    if event_type in {"response.output_text.done", "response.completed"}:
+        text = _responses_event_text(data)
+        return text, True, None
+
+    # Streaming APIs often emit lifecycle, usage, or reasoning events with no
+    # chat-completions choice payload. They are valid SSE frames, just not answer text.
+    return "", True, None
+
+
+def _responses_event_text(data: dict) -> str:
+    text = data.get("text", "")
+    if isinstance(text, str):
+        return text
+
+    response = data.get("response")
+    if not isinstance(response, dict):
+        return ""
+
+    parts: list[str] = []
+    for item in response.get("output", []) or []:
+        if not isinstance(item, dict):
+            continue
+        for content in item.get("content", []) or []:
+            if not isinstance(content, dict):
+                continue
+            if content.get("type") in {"output_text", "text"}:
+                value = content.get("text", "")
+                if isinstance(value, str):
+                    parts.append(value)
+    return "".join(parts)
 
 
 async def _read_streaming_chat_completion(
@@ -178,11 +234,14 @@ async def _read_streaming_chat_completion(
         except json.JSONDecodeError:
             return False, stream_failure("invalid json")
 
-        text, had_choice = _stream_event_text(data)
-        if text:
+        text, valid_event, error_message = _stream_event_text(data)
+        if error_message:
+            return False, stream_failure(error_message)
+        event_type = str(data.get("type") or "").strip()
+        if text and not (parts and event_type in {"response.output_text.done", "response.completed"}):
             parts.append(text)
-        if not had_choice:
-            return False, stream_failure("missing choices")
+        if not valid_event:
+            return False, stream_failure("invalid event")
         return False, None
 
     try:
@@ -346,7 +405,11 @@ async def chat_completion(
             reasoning_effort = provider.reasoning_effort.strip().lower()
             if reasoning_effort:
                 payload["reasoning_effort"] = reasoning_effort
-            if _provider_uses_stream(provider.name, provider.base_url):
+            if _provider_uses_stream(
+                provider.name,
+                provider.base_url,
+                explicit_stream=provider.stream,
+            ):
                 payload["stream"] = True
 
             for attempt in range(max_retries + 1):

--- a/src/kouhai_bot/llm_config.py
+++ b/src/kouhai_bot/llm_config.py
@@ -6,6 +6,22 @@ from dataclasses import dataclass
 from typing import Any
 
 
+def _parse_bool(value: Any, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
 @dataclass(frozen=True)
 class LlmProviderConfig:
     """A single LLM provider with its own credentials and per-task model mapping.
@@ -23,6 +39,7 @@ class LlmProviderConfig:
     summary_model: str = ""
     reasoning_effort: str = ""
     model_tag: str = ""
+    stream: bool = False
 
     def model_for(self, task: str = "", explicit_model: str = "") -> str:
         """Resolve the model name for a given task.
@@ -100,6 +117,7 @@ def build_providers_from_yaml(llm_section: dict[str, Any]) -> list[LlmProviderCo
                 summary_model=str(p.get("summary_model", "")).strip(),
                 reasoning_effort=str(p.get("reasoning_effort", "")).strip(),
                 model_tag=str(p.get("model_tag", "")).strip(),
+                stream=_parse_bool(p.get("stream", False)),
             )
         )
     return providers

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -103,6 +103,14 @@ def test_llm_timeouts_load_from_yaml(monkeypatch, tmp_path):
     assert cfg.summary_timeout_sec == 180
 
 
+def test_provider_stream_loads_from_yaml(monkeypatch, tmp_path):
+    data = yaml.safe_load(_make_yaml())
+    data["llm"]["providers"][0]["stream"] = True
+    cfg = _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
+
+    assert cfg.llm_providers[0].stream is True
+
+
 def test_current_group_loaded(monkeypatch, tmp_path):
     cfg = _from_yaml(_make_yaml(current_group=123456), monkeypatch, tmp_path)
     assert cfg.current_group == 123456

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -225,9 +225,38 @@ def test_non_dashscope_provider_payload_does_not_enable_stream():
     assert "stream" not in calls[0]
 
 
+def test_explicit_stream_provider_payload_enables_stream():
+    provider = LlmProviderConfig(
+        name="openai",
+        api_key="sk-test",
+        base_url="http://localhost:8080/v1",
+        model="gpt-5.5",
+        stream=True,
+    )
+    cfg = _openai_cfg(llm_providers=[provider])
+    calls = []
+
+    async def fake_once(session, **kwargs):
+        calls.append(kwargs["payload"].copy())
+        return _ChatCompletionAttempt(text="OK", retryable=False, retry_after_sec=None)
+
+    with patch("kouhai_bot.llm.get_config", return_value=cfg), \
+            patch("kouhai_bot.llm.aiohttp.ClientSession", _DummySession), \
+            patch("kouhai_bot.llm._post_chat_completion_once", side_effect=fake_once):
+        result = asyncio.run(call_chat_completion(
+            [{"role": "user", "content": "Reply with exactly OK."}],
+            task="judge",
+        ))
+
+    assert result == "OK"
+    assert calls[0]["stream"] is True
+
+
 def test_streaming_chat_completion_reads_sse_delta_chunks():
     response = _DummyResponse(lines=[
         ': keep-alive\n',
+        'data: {"choices":[{"delta":{"reasoning_content":"thinking"}}]}\n',
+        '\n',
         'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
         '\n',
         'data: {"choices":[{"delta":{"content":" world"}}]}\n',
@@ -249,6 +278,79 @@ def test_streaming_chat_completion_reads_sse_delta_chunks():
     assert result.text == "Hello world"
     assert result.retryable is False
     assert session.calls[0][1]["json"] == {"stream": True}
+
+
+def test_streaming_chat_completion_ignores_metadata_events():
+    response = _DummyResponse(lines=[
+        'data: {"id":"evt_1","model":"qwen-test","created":1}\n',
+        '\n',
+        'data: {"choices":[{"delta":{"content":"OK"}}]}\n',
+        '\n',
+        'data: [DONE]\n',
+        '\n',
+    ])
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="qwen",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        headers={},
+        payload={"stream": True},
+        timeout=120,
+    ))
+
+    assert result.text == "OK"
+    assert result.retryable is False
+
+
+def test_streaming_chat_completion_reads_responses_delta_events():
+    response = _DummyResponse(lines=[
+        'data: {"type":"response.created","response":{"id":"resp_1"}}\n',
+        '\n',
+        'data: {"type":"response.output_text.delta","delta":"{\\"correct\\":"}\n',
+        '\n',
+        'data: {"type":"response.output_text.delta","delta":"false}"}\n',
+        '\n',
+        'data: {"type":"response.output_text.done","text":"{\\"correct\\":false}"}\n',
+        '\n',
+        'data: [DONE]\n',
+        '\n',
+    ])
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="openai",
+        base_url="http://localhost:8080/v1",
+        headers={},
+        payload={"stream": True},
+        timeout=120,
+    ))
+
+    assert result.text == '{"correct":false}'
+    assert result.retryable is False
+
+
+def test_streaming_chat_completion_error_event_is_retryable():
+    response = _DummyResponse(lines=[
+        'data: {"error":{"type":"upstream_error","message":"broken"}}\n',
+        '\n',
+    ])
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="openai",
+        base_url="http://localhost:8080/v1",
+        headers={},
+        payload={"stream": True},
+        timeout=120,
+    ))
+
+    assert result.text is None
+    assert result.retryable is True
+    assert result.failure_kind == "service_unavailable"
 
 
 def test_streaming_chat_completion_eof_without_done_is_retryable():


### PR DESCRIPTION
## Summary
- add a per-provider `stream` config flag for OpenAI-compatible LLM providers
- keep DashScope streaming auto-enabled, and enable streaming in the OpenAI/sub2api example config
- make the streaming parser tolerant of metadata/lifecycle SSE events, Responses API `response.output_text.delta` events, and explicit error events
- ignore reasoning-only chunks such as DashScope `reasoning_content` until answer `content` arrives

## Why
OpenAI requests routed through sub2api can fail after long buffered non-streaming waits with upstream read errors such as `unexpected EOF`. Opting that provider into SSE streaming avoids waiting for one fully buffered response. The parser also needed to treat provider-specific SSE lifecycle/reasoning events as part of the stream protocol rather than as malformed responses.

## Validation
- `uv run pytest tests/test_config.py tests/test_shared.py`
- `git diff --check`
- bot LLM component e2e with Wang Chengjun's `178C3` request against DashScope Qwen: returned valid JSON
- bot LLM component e2e with Wang Chengjun's `178C3` request against DashScope GLM 5.2 with 30m timeout: returned valid JSON
- bot LLM component e2e with Wang Chengjun's `178C3` request against sub2api/OpenAI stream path: parser handled SSE correctly, but upstream still returned explicit `Upstream request failed` from sub2api after `stream usage incomplete: unexpected EOF`
