### PR TITLE
[codex] Add editorial-backed second judge

### DIFF
--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -40,6 +40,7 @@ from ..shared import (
     robust_json_parse,
     save_scoreboard,
     save_user_submission,
+    second_judge_submission_result,
 )
 from ...config import get_config
 from ...context import get_display_name, load_group_ctx
@@ -71,7 +72,7 @@ from ...private_judge import (
     send_problem_card_private,
     set_private_current_problem,
 )
-from ...tutorials import format_editorial_for_review, get_official_editorial
+from ...tutorials import format_editorial_for_review, get_official_editorial, has_cached_editorial_zh
 from ...napcat.client import (
     build_at,
     build_private_reaction_message,
@@ -273,6 +274,29 @@ async def _judge_llm_limited(
 ):
     async with _compute_limit():
         return await judge_submission_result(problem_text, submission, history)
+
+
+async def _second_judge_llm_limited(
+    problem_text: str,
+    submission: str,
+    history: list[dict] | None,
+    first_judge_result: dict,
+    editorial_text: str,
+    editorial_source: str = "",
+    provider_name: str = "",
+    model: str = "",
+):
+    async with _compute_limit():
+        return await second_judge_submission_result(
+            problem_text,
+            submission,
+            history,
+            first_judge_result,
+            editorial_text,
+            editorial_source,
+            provider_name=provider_name,
+            model=model,
+        )
 
 
 async def _send_req_plain(req: PendingRequest, text: str, *, mention: bool = True) -> int | None:
@@ -757,7 +781,46 @@ class GroupCoordinator:
         result = await _judge_llm_limited(problem_text, req.payload, history)
         if not result.text:
             return {"kind": result.failure_kind or "error", "pid": pid}
-        return {"kind": "judge", "pid": pid, "result": robust_json_parse(result.text), "model_tag": result.model_tag}
+        parsed = robust_json_parse(result.text)
+        if parsed.get("correct", False) and parsed.get("reaction", "") != "123":
+            editorial = get_official_editorial(pid) if has_cached_editorial_zh(pid) else None
+            first_provider = result.provider_name
+            first_model = result.model
+            if editorial and first_provider and first_model:
+                source = "\n".join(
+                    part for part in [editorial.tutorial_title, editorial.tutorial_url]
+                    if part
+                )
+                second = await _second_judge_llm_limited(
+                    problem_text,
+                    req.payload,
+                    history,
+                    parsed,
+                    editorial.text,
+                    source,
+                    provider_name=first_provider,
+                    model=first_model,
+                )
+                if second.text:
+                    second_parsed = robust_json_parse(second.text)
+                    if "correct" in second_parsed:
+                        return {
+                            "kind": "judge",
+                            "pid": pid,
+                            "result": second_parsed,
+                            "model_tag": second.model_tag,
+                            "first_judge_result": parsed,
+                            "second_judge": True,
+                        }
+                logger.warning(
+                    "[group_%s] second judge unavailable or malformed for %s via provider=%s model=%s; keeping first verdict",
+                    req.group_id,
+                    pid,
+                    first_provider,
+                    first_model,
+                )
+        return {"kind": "judge", "pid": pid, "result": parsed, "model_tag": result.model_tag}
+
 
     async def _compute_clarify(self, req: PendingRequest) -> dict:
         pid = req.target_pid

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -37,6 +37,7 @@ async def call_chat_completion_result(
     timeout: int = 120,
     response_format: dict | None = None,
     thinking: dict | None = None,
+    provider_name: str = "",
 ) -> ChatCompletionResult:
     """Call the configured chat-completions provider and keep terminal failure metadata."""
     return await chat_completion(
@@ -47,6 +48,7 @@ async def call_chat_completion_result(
         timeout=timeout,
         response_format=response_format,
         thinking=thinking,
+        provider_name=provider_name,
     )
 
 
@@ -58,6 +60,7 @@ async def call_chat_completion(
     timeout: int = 120,
     response_format: dict | None = None,
     thinking: dict | None = None,
+    provider_name: str = "",
 ) -> str | None:
     """Call the configured chat-completions provider. Returns response text or None."""
     result = await call_chat_completion_result(
@@ -68,6 +71,7 @@ async def call_chat_completion(
         timeout=timeout,
         response_format=response_format,
         thinking=thinking,
+        provider_name=provider_name,
     )
     return result.text
 
@@ -713,6 +717,50 @@ def build_judge_messages(
     ]
 
 
+def build_second_judge_messages(
+    problem_text: str,
+    submission: str,
+    history: list[dict] | None,
+    first_judge_result: dict,
+    editorial_text: str,
+    editorial_source: str = "",
+) -> list[dict]:
+    editorial_body = (editorial_text or "").strip()
+    if len(editorial_body) > 18000:
+        editorial_body = editorial_body[:18000] + "\n...(官方题解已截断)"
+    user_msg = json.dumps({
+        "problem": problem_text,
+        "submission": submission,
+        "history": history,
+        "first_judge_result": first_judge_result,
+        "official_editorial": editorial_body,
+        "official_editorial_source": editorial_source,
+    }, ensure_ascii=False)
+    return [
+        {"role": "system", "content": (
+            "你是算法竞赛做法判定的二审 bot。你会收到题面、用户做法、用户在本题的历史上下文、"
+            "一审 bot 的完整 JSON 判定，以及爬取到的 Codeforces 官方题解。"
+            "一审 bot 做出判定时看不到官方题解，只能基于题面、用户做法和历史上下文独立推理；"
+            "因此一审判为正确并不代表它已被题解验证过。"
+            "你的任务是复核一审判为正确的做法是否真的正确且足够完整。\n\n"
+            "判定原则：\n"
+            "1) 只输出 JSON 对象，字段为 correct、reason、reply、reaction。\n"
+            "2) 如果用户做法正确且完整，即使和官方题解不同，也必须判 correct=true。"
+            "算法题可能有多种完全不同的正确解法，不要把题解做法当成唯一标准。\n"
+            "3) 如果用户做法存在关键漏洞、复杂度不满足、遗漏必要证明或处理不了边界，判 correct=false，"
+            "reason 写清楚技术原因，reply 写给用户看的简短纠错提示。\n"
+            "4) 爬取到的题解可能与本题不对应，或只是不完整片段。若题解和题面明显冲突、题解中的变量/目标/结论"
+            "对不上本题，请忽略题解，改为基于题面、用户做法和历史上下文独立复核。\n"
+            "5) 不要因为用户没有贴代码、没有展开所有实现细节就判错；只要算法思路、关键不变量、复杂度和边界处理"
+            "足以支持 AC，就应判 correct=true。\n"
+            "6) 一审可能被用户错误说法带偏。你必须独立判断，不要默认赞同一审。\n\n"
+            "输出示例："
+            "{\"correct\": true, \"reason\": \"...\", \"reply\": \"\", \"reaction\": \"\"}"
+        )},
+        {"role": "user", "content": user_msg},
+    ]
+
+
 async def judge_submission_result(
     problem_text: str,
     submission: str,
@@ -727,6 +775,37 @@ async def judge_submission_result(
         timeout=cfg.judge_timeout_sec,
         response_format={"type": "json_object"},
         thinking={"type": "enabled"},
+    )
+
+
+async def second_judge_submission_result(
+    problem_text: str,
+    submission: str,
+    history: list[dict] | None,
+    first_judge_result: dict,
+    editorial_text: str,
+    editorial_source: str = "",
+    provider_name: str = "",
+    model: str = "",
+) -> ChatCompletionResult:
+    """Re-check a first-pass correct verdict with official editorial context."""
+    cfg = get_config()
+    return await call_chat_completion_result(
+        build_second_judge_messages(
+            problem_text,
+            submission,
+            history,
+            first_judge_result,
+            editorial_text,
+            editorial_source,
+        ),
+        model=model,
+        task="judge",
+        temperature=0.2,
+        timeout=cfg.judge_timeout_sec,
+        response_format={"type": "json_object"},
+        thinking={"type": "enabled"},
+        provider_name=provider_name,
     )
 
 
@@ -817,31 +896,45 @@ async def translate_sample_notes(notes_text: str) -> tuple[str | None, str]:
     return result.text, result.model_tag
 
 
-async def translate_editorial_to_zh(editorial_text: str, pid: str = "") -> tuple[str | None, str]:
-    """Translate a Codeforces editorial to Chinese for group delivery.
+async def translate_editorial_to_zh(
+    editorial_text: str,
+    pid: str = "",
+    problem_text: str = "",
+) -> tuple[str | None, str, bool | None]:
+    """Validate and translate a Codeforces editorial to Chinese for group delivery.
 
-    Returns (translated_text, model_tag). model_tag is empty if the LLM call failed.
+    Returns (translated_text, model_tag, matched). matched is False only for explicit mismatches.
     """
     body = (editorial_text or "").strip()
     if not body:
-        return None, ""
+        return None, "", None
     if len(body) > 24000:
         body = body[:24000] + "\n...(题解原文已截断)"
+    problem_body = (problem_text or "").strip()
+    if len(problem_body) > 12000:
+        problem_body = problem_body[:12000] + "\n...(题面已截断)"
 
-    prompt = (
-        f"题目编号：{pid or '未知'}\n\n"
-        f"待翻译的官方 Editorial（英文为主，可能含 LaTeX/公式与代码）：\n\n"
-        f"{body}\n\n"
-        "请输出可在 QQ 群直接阅读的中文题解译文（仅思路与算法说明，不要贴代码）。"
-        "公式与符号尽量用中文和简单字符表达，避免 LaTeX。"
-    )
+    prompt_payload = {
+        "pid": pid or "未知",
+        "problem": problem_body,
+        "official_editorial": body,
+    }
     result = await call_chat_completion_result(
         [
             {
                 "role": "system",
                 "content": (
-                    "你是算法竞赛选手，要把 Codeforces 官方 Editorial 忠实译成中文题解，"
-                    "供 QQ 群友阅读。"
+                    "你是算法竞赛选手，要先判断爬取到的 Codeforces 官方 Editorial 是否对应给定题目，"
+                    "再把匹配的题解忠实译成中文，供 QQ 群友阅读。"
+                    "你必须输出 JSON 对象，格式严格为："
+                    "{\"matched\":\"yes\",\"result\":\"中文题解译文\"} 或 "
+                    "{\"matched\":\"no\"}。"
+                    "matched 只能是 yes 或 no。"
+                    "判断匹配时比较题面目标、输入输出、关键变量/约束、核心算法对象和题解讨论的问题；"
+                    "如果题解明显在讲另一道题，或题解内容与题面目标/变量/结论对不上，输出 matched=no，"
+                    "不要翻译、不要解释。"
+                    "如果只是题解使用了不同记号、只覆盖核心思路、或题面与题解能合理对应，输出 matched=yes。"
+                    "matched=yes 时，result 是可在 QQ 群直接阅读的中文题解译文（仅思路与算法说明，不要贴代码）。"
                     "只翻译思路、做法、复杂度等文字说明；原文中的代码、伪代码、"
                     "以反引号或代码块形式出现的程序片段一律不要输出，可用一句「实现见官方代码」带过。"
                     "不要增删关键算法步骤，不要添加原文没有的内容。"
@@ -850,16 +943,29 @@ async def translate_editorial_to_zh(editorial_text: str, pid: str = "") -> tuple
                     "\\{a,b\\} 写成集合 {a,b}；"
                     "O(n^2) 写成 O(n²) 或 O(n^2)；\\le \\lt 写成 ≤ <。"
                     "仅当不用 LaTeX 会产生歧义、且无法用中文说清楚时，才保留最少量的 LaTeX 片段。"
-                    "输出连贯纯文本，不要 Markdown 标题、列表语法。"
-                    "不要写「以下是翻译」等套话，直接输出译文。"
+                    "result 输出连贯纯文本，不要 Markdown 标题、列表语法。"
+                    "不要写「以下是翻译」等套话。"
                 ),
             },
-            {"role": "user", "content": prompt},
+            {"role": "user", "content": json.dumps(prompt_payload, ensure_ascii=False)},
         ],
         task="summary",
         timeout=600,
+        response_format={"type": "json_object"},
+        thinking={"type": "enabled"},
     )
-    return result.text, result.model_tag
+    if not result.text:
+        return None, "", None
+    parsed = robust_json_parse(result.text)
+    matched = str(parsed.get("matched", "")).strip().lower()
+    if matched == "no":
+        return None, "", False
+    if matched != "yes":
+        return None, "", None
+    translated = str(parsed.get("result", "") or "").strip()
+    if not translated:
+        return None, "", None
+    return translated, result.model_tag, True
 
 
 # ── Contest checking ────────────────────────────────────────────────────

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -20,6 +20,8 @@ class ChatCompletionResult:
     text: str | None
     failure_kind: str | None = None
     model_tag: str = ""
+    provider_name: str = ""
+    model: str = ""
 
 
 @dataclass(frozen=True)
@@ -363,6 +365,7 @@ async def chat_completion(
     timeout: int = 120,
     response_format: dict | None = None,
     thinking: dict | None = None,
+    provider_name: str = "",
 ) -> ChatCompletionResult:
     """Call providers in fallback order; first success wins.
 
@@ -371,6 +374,8 @@ async def chat_completion(
     """
     cfg = get_config()
     providers = cfg.llm_providers
+    if provider_name:
+        providers = [p for p in providers if p.name == provider_name]
     if not providers:
         return ChatCompletionResult(text=None, failure_kind="error")
 
@@ -429,8 +434,11 @@ async def chat_completion(
                             last_failed_provider,
                         )
                     return ChatCompletionResult(
-                        text=result.text, failure_kind=None,
+                        text=result.text,
+                        failure_kind=None,
                         model_tag=provider.model_tag,
+                        provider_name=provider.name,
+                        model=model_name,
                     )
 
                 last_failure_kind = result.failure_kind
@@ -451,11 +459,18 @@ async def chat_completion(
                 await asyncio.sleep(delay)
 
             last_failed_provider = provider.name
-            logger.warning(
-                "LLM provider '%s' exhausted (max_retries=%s), "
-                "moving to next fallback",
-                provider.name,
-                max_retries,
-            )
+            if provider_name:
+                logger.warning(
+                    "Pinned LLM provider '%s' exhausted (max_retries=%s)",
+                    provider.name,
+                    max_retries,
+                )
+            else:
+                logger.warning(
+                    "LLM provider '%s' exhausted (max_retries=%s), "
+                    "moving to next fallback",
+                    provider.name,
+                    max_retries,
+                )
 
     return ChatCompletionResult(text=None, failure_kind=last_failure_kind)

--- a/src/kouhai_bot/tutorials.py
+++ b/src/kouhai_bot/tutorials.py
@@ -107,8 +107,6 @@ def load_tutorial(pid: str) -> dict | None:
 
 
 def get_official_editorial(pid: str) -> OfficialEditorial | None:
-    if pid and os.path.isfile(_no_editorial_marker_path(pid)):
-        return None
     bundle = load_tutorial(pid)
     if not bundle:
         return None
@@ -218,9 +216,8 @@ async def get_editorial_zh_for_group(editorial: OfficialEditorial, pid: str) -> 
 
     Returns (translated_text, model_tag). model_tag is empty for cache hits.
     """
-    cached = _load_cached_translation(pid)
-    if len(cached) >= MIN_EDITORIAL_LEN:
-        return cached, ""
+    if has_cached_editorial_zh(pid):
+        return _load_cached_translation(pid), ""
 
     problem_text = load_problem_statement(pid)
     translated, model_tag, matched = await translate_editorial_to_zh(

--- a/src/kouhai_bot/tutorials.py
+++ b/src/kouhai_bot/tutorials.py
@@ -11,7 +11,7 @@ import re
 from dataclasses import dataclass
 
 from .config import get_config
-from .handlers.shared import translate_editorial_to_zh
+from .handlers.shared import load_problem_statement, translate_editorial_to_zh
 
 MIN_EDITORIAL_LEN = 80
 _REVIEW_EDITORIAL_MAX_LEN = 12000
@@ -107,6 +107,8 @@ def load_tutorial(pid: str) -> dict | None:
 
 
 def get_official_editorial(pid: str) -> OfficialEditorial | None:
+    if pid and os.path.isfile(_no_editorial_marker_path(pid)):
+        return None
     bundle = load_tutorial(pid)
     if not bundle:
         return None
@@ -137,6 +139,10 @@ def _no_editorial_marker_path(pid: str) -> str:
     return os.path.join(_translation_cache_dir(), f"{pid}.no_editorial")
 
 
+def _verified_editorial_marker_path(pid: str) -> str:
+    return os.path.join(_translation_cache_dir(), f"{pid}.verified")
+
+
 def _load_cached_translation(pid: str) -> str:
     path = _translation_cache_path(pid)
     if not os.path.isfile(path):
@@ -152,6 +158,9 @@ def _save_cached_translation(pid: str, text: str) -> None:
     path = _translation_cache_path(pid)
     with open(path, "w", encoding="utf-8") as f:
         f.write(text)
+    verified = _verified_editorial_marker_path(pid)
+    with open(verified, "w", encoding="utf-8"):
+        pass
     marker = _no_editorial_marker_path(pid)
     if os.path.isfile(marker):
         os.remove(marker)
@@ -168,6 +177,9 @@ def mark_no_official_editorial(pid: str) -> None:
     path = _translation_cache_path(pid)
     if os.path.isfile(path):
         os.remove(path)
+    verified = _verified_editorial_marker_path(pid)
+    if os.path.isfile(verified):
+        os.remove(verified)
 
 
 def clear_no_official_editorial_marker(pid: str) -> None:
@@ -177,6 +189,8 @@ def clear_no_official_editorial_marker(pid: str) -> None:
 
 
 def has_cached_editorial_zh(pid: str) -> bool:
+    if not os.path.isfile(_verified_editorial_marker_path(pid)):
+        return False
     return len(_load_cached_translation(pid)) >= MIN_EDITORIAL_LEN
 
 
@@ -208,7 +222,15 @@ async def get_editorial_zh_for_group(editorial: OfficialEditorial, pid: str) -> 
     if len(cached) >= MIN_EDITORIAL_LEN:
         return cached, ""
 
-    translated, model_tag = await translate_editorial_to_zh(editorial.text, pid=pid)
+    problem_text = load_problem_statement(pid)
+    translated, model_tag, matched = await translate_editorial_to_zh(
+        editorial.text,
+        pid=pid,
+        problem_text=problem_text,
+    )
+    if matched is False:
+        mark_no_official_editorial(pid)
+        return None, ""
     if not translated:
         return None, ""
     translated = translated.strip()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -33,13 +33,16 @@ _forwarded: list[dict] = []
 _private_forwarded: list[dict] = []
 _deleted: list[str] = []
 _deepseek_response: dict | None = None
+_SECOND_JUDGE_USE_FIRST = object()
+_second_judge_response = _SECOND_JUDGE_USE_FIRST
+_second_judge_calls: list[dict] = []
 _group_members: dict[int, list[dict]] = {}
 _deepseek_calls: list[dict] = []
 _temp_dir = None
 
 
 def _reset_state():
-    global _sent, _reacted, _private_sent, _forwarded, _private_forwarded, _deleted, _deepseek_response, _group_members, _deepseek_calls, _temp_dir
+    global _sent, _reacted, _private_sent, _forwarded, _private_forwarded, _deleted, _deepseek_response, _second_judge_response, _group_members, _deepseek_calls, _temp_dir
     _sent.clear()
     _reacted.clear()
     _private_sent.clear()
@@ -47,6 +50,8 @@ def _reset_state():
     _private_forwarded.clear()
     _deleted.clear()
     _deepseek_response = None
+    _second_judge_response = _SECOND_JUDGE_USE_FIRST
+    _second_judge_calls.clear()
     _group_members = {
         GID: [
             {"user_id": UID, "nickname": "Alice", "card": ""},
@@ -122,6 +127,15 @@ def _write_tutorial(pid: str, data: dict):
         json.dump(data, f, ensure_ascii=False, indent=2)
 
 
+def _write_editorial_translation(pid: str, text: str = "已验证中文题解。"):
+    d = os.path.join(_data_dir(), "tutorial_translations")
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, f"{pid}.txt"), "w", encoding="utf-8") as f:
+        f.write(text * 20)
+    with open(os.path.join(d, f"{pid}.verified"), "w", encoding="utf-8"):
+        pass
+
+
 def _has_sent(substring: str) -> bool:
     for s in _sent:
         msg = s.get("message", [])
@@ -194,6 +208,8 @@ async def _mock_deepseek(messages, model="", task="", temperature=0.7, timeout=1
         "model": model,
     })
     if task == "summary":
+        if response_format == {"type": "json_object"}:
+            return json.dumps({"matched": "yes", "result": "官方题解中文翻译。" * 20})
         return "官方题解中文翻译。" * 20
     return json.dumps(_deepseek_response) if isinstance(_deepseek_response, dict) else _deepseek_response
 
@@ -211,7 +227,12 @@ async def _mock_chat_completion_result(messages, model="", task="", temperature=
     )
     if result is None:
         return ChatCompletionResult(text=None, failure_kind="service_unavailable")
-    return ChatCompletionResult(text=result, failure_kind=None)
+    return ChatCompletionResult(
+        text=result,
+        failure_kind=None,
+        provider_name="deepseek",
+        model="deepseek-v4-pro",
+    )
 
 
 async def _mock_judge_result(problem_text, submission, history=None):
@@ -226,6 +247,38 @@ async def _mock_judge_result(problem_text, submission, history=None):
         thinking={"type": "enabled"},
     )
     return result
+
+
+async def _mock_second_judge_result(
+    problem_text,
+    submission,
+    history,
+    first_judge_result,
+    editorial_text,
+    editorial_source="",
+    provider_name="",
+    model="",
+):
+    _second_judge_calls.append({
+        "problem_text": problem_text,
+        "submission": submission,
+        "history": history,
+        "first_judge_result": first_judge_result,
+        "editorial_text": editorial_text,
+        "editorial_source": editorial_source,
+        "provider_name": provider_name,
+        "model": model,
+    })
+    response = _deepseek_response if _second_judge_response is _SECOND_JUDGE_USE_FIRST else _second_judge_response
+    if response is None:
+        return ChatCompletionResult(text=None, failure_kind="service_unavailable")
+    text = json.dumps(response) if isinstance(response, dict) else response
+    return ChatCompletionResult(
+        text=text,
+        failure_kind=None,
+        provider_name=provider_name,
+        model=model,
+    )
 
 
 def _wrap_llm_result(fn, failure_kind="service_unavailable"):
@@ -443,8 +496,10 @@ def _all_patches():
     stack.enter_context(patch("kouhai_bot.private_judge.send_private_forward_msg", _mock_send_private_forward))
     stack.enter_context(patch("kouhai_bot.handlers.shared.call_chat_completion_result", _mock_chat_completion_result))
     stack.enter_context(patch("kouhai_bot.handlers.shared.judge_submission_result", _mock_judge_result))
+    stack.enter_context(patch("kouhai_bot.handlers.shared.second_judge_submission_result", _mock_second_judge_result))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.submit.call_chat_completion_result", _mock_chat_completion_result))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.submit.judge_submission_result", _mock_judge_result))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.submit.second_judge_submission_result", _mock_second_judge_result))
     return stack
 
 
@@ -517,6 +572,7 @@ def test_submit_correct():
 
     asyncio.run(_run_submit())
 
+    assert len(_second_judge_calls) == 0
     assert _has_sent("恭喜") or _has_sent("通过") or _has_sent("solved"), \
         f"No congrats. Messages: {[_last_text()]}"
     assert _forwarded, f"Expected official tutorial forward, got: {_forwarded}"
@@ -538,6 +594,108 @@ def test_submit_correct():
     assert records[-1]["result"] == "correct"
     _cleanup()
     print("✅ submit: correct")
+
+def test_submit_correct_without_editorial_skips_second_judge():
+    _reset_state()
+    _setup_problem()
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
+    global _deepseek_response
+    _deepseek_response = {"correct": True, "reason": "ok", "reply": ""}
+
+    with _all_patches(), patch("kouhai_bot.handlers.cmd.submit._reveal_problem_source", AsyncMock(return_value="")):
+        from kouhai_bot.handlers.cmd.submit import handle
+        asyncio.run(handle(**_kwargs(_make_event("/submit valid but different idea"))))
+
+    with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
+        saved = json.load(f)
+    assert len(_second_judge_calls) == 0
+    assert len(saved["solves"]) == 1
+    assert saved["user_submissions"][str(UID)][-1]["result"] == "correct"
+    _cleanup()
+    print("✅ submit: correct skips second judge without editorial")
+
+
+def test_submit_second_judge_overturns_correct_verdict():
+    _reset_state()
+    _setup_problem()
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
+    _write_tutorial(PID, {
+        "problem_id": PID,
+        "tutorial_url": "https://codeforces.com/blog/entry/1",
+        "tutorial_title": "Editorial",
+        "sections": [{
+            "label": "D",
+            "title": "Superhero's Job",
+            "hint": "",
+            "solution": "Use multiplicativity and enumerate squarefree divisor partitions correctly." * 3,
+            "code_blocks": [],
+            "raw_text": "Use multiplicativity and enumerate squarefree divisor partitions correctly." * 3,
+        }],
+    })
+    _write_editorial_translation(PID)
+    global _deepseek_response, _second_judge_response
+    _deepseek_response = {"correct": True, "reason": "first pass accepted", "reply": ""}
+    _second_judge_response = {
+        "correct": False,
+        "reason": "misses coprime divisor condition",
+        "reply": "这个做法漏掉了 gcd(k, x/k)=1 的限制，再检查一下 divisor 枚举条件～",
+        "reaction": "",
+    }
+
+    with _all_patches(), patch("kouhai_bot.handlers.cmd.submit._reveal_problem_source", AsyncMock(return_value="")):
+        from kouhai_bot.handlers.cmd.submit import handle
+        asyncio.run(handle(**_kwargs(_make_event("/submit enumerate all divisors without coprime check"))))
+
+    with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
+        saved = json.load(f)
+    assert len(_second_judge_calls) == 1
+    assert _second_judge_calls[0]["provider_name"] == "deepseek"
+    assert _second_judge_calls[0]["model"] == "deepseek-v4-pro"
+    assert saved["solves"] == []
+    records = saved["user_submissions"][str(UID)]
+    assert records[-1]["result"] == "incorrect"
+    assert "coprime" in records[-1]["reason"]
+    assert "gcd" in _last_text()
+    _cleanup()
+    print("✅ submit: second judge can overturn correct verdict")
+
+
+def test_submit_second_judge_failure_keeps_first_correct_verdict():
+    _reset_state()
+    _setup_problem()
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
+    _write_tutorial(PID, {
+        "problem_id": PID,
+        "tutorial_url": "https://codeforces.com/blog/entry/1",
+        "tutorial_title": "Editorial",
+        "sections": [{
+            "label": "D",
+            "title": "Superhero's Job",
+            "hint": "",
+            "solution": "Valid official editorial text. " * 8,
+            "code_blocks": [],
+            "raw_text": "Valid official editorial text. " * 8,
+        }],
+    })
+    _write_editorial_translation(PID)
+    global _deepseek_response, _second_judge_response
+    _deepseek_response = {"correct": True, "reason": "first pass accepted", "reply": ""}
+    _second_judge_response = None
+
+    with _all_patches(), patch("kouhai_bot.handlers.cmd.submit._reveal_problem_source", AsyncMock(return_value="")):
+        from kouhai_bot.handlers.cmd.submit import handle
+        asyncio.run(handle(**_kwargs(_make_event("/submit valid idea"))))
+
+    with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
+        saved = json.load(f)
+    assert len(_second_judge_calls) == 1
+    assert len(saved["solves"]) == 1
+    records = saved["user_submissions"][str(UID)]
+    assert records[-1]["result"] == "correct"
+    assert "模型服务" not in _last_text()
+    _cleanup()
+    print("✅ submit: second judge failure keeps first correct verdict")
+
 
 def test_submit_correct_uses_fresh_top5_nicknames_and_points():
     _reset_state()

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import sys
 from unittest.mock import AsyncMock, patch
@@ -7,8 +8,62 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from kouhai_bot.config import BotConfig
 from kouhai_bot.llm_config import LlmProviderConfig
-from kouhai_bot.handlers.shared import call_chat_completion, summarize_problem
-from kouhai_bot.llm import _ChatCompletionAttempt, _post_chat_completion_once
+from kouhai_bot.handlers.shared import build_second_judge_messages, call_chat_completion, call_chat_completion_result, summarize_problem, translate_editorial_to_zh
+from kouhai_bot.llm import ChatCompletionResult, _ChatCompletionAttempt, _post_chat_completion_once
+
+
+def test_translate_editorial_to_zh_uses_structured_match_output():
+    calls = []
+
+    async def fake_call(messages, **kwargs):
+        calls.append({"messages": messages, **kwargs})
+        return ChatCompletionResult(
+            text=json.dumps({"matched": "yes", "result": "中文题解译文"}),
+            model_tag="🐳",
+        )
+
+    with patch("kouhai_bot.handlers.shared.call_chat_completion_result", fake_call):
+        translated, tag, matched = asyncio.run(translate_editorial_to_zh(
+            "Official editorial",
+            pid="542D",
+            problem_text="Problem statement",
+        ))
+
+    assert translated == "中文题解译文"
+    assert tag == "🐳"
+    assert matched is True
+    call = calls[0]
+    assert call["task"] == "summary"
+    assert call["response_format"] == {"type": "json_object"}
+    assert call["thinking"] == {"type": "enabled"}
+    assert "matched" in call["messages"][0]["content"]
+    payload = json.loads(call["messages"][1]["content"])
+    assert payload["pid"] == "542D"
+    assert payload["problem"] == "Problem statement"
+    assert payload["official_editorial"] == "Official editorial"
+
+
+def test_build_second_judge_messages_contains_review_contract():
+    messages = build_second_judge_messages(
+        "Problem statement",
+        "User solution",
+        [{"type": "clarify", "content": "history"}],
+        {"correct": True, "reason": "first pass"},
+        "Official editorial text",
+        "https://codeforces.com/blog/entry/1",
+    )
+
+    system_text = messages[0]["content"]
+    payload = json.loads(messages[1]["content"])
+    assert "一审 bot 做出判定时看不到官方题解" in system_text
+    assert "即使和官方题解不同" in system_text
+    assert "题解可能与本题不对应" in system_text
+    assert payload["problem"] == "Problem statement"
+    assert payload["submission"] == "User solution"
+    assert payload["history"][0]["content"] == "history"
+    assert payload["first_judge_result"]["reason"] == "first pass"
+    assert payload["official_editorial"] == "Official editorial text"
+    assert payload["official_editorial_source"] == "https://codeforces.com/blog/entry/1"
 
 
 class _DummySession:
@@ -110,6 +165,50 @@ def test_call_chat_completion_retries_transient_failures_then_succeeds():
     assert calls == ["gpt-5.5", "gpt-5.5"]
     assert once_mock.call_count == 2
     sleep_mock.assert_awaited_once_with(0.25)
+
+
+def test_call_chat_completion_pinned_provider_does_not_fallback():
+    openai = LlmProviderConfig(
+        name="openai",
+        api_key="sk-openai",
+        base_url="http://openai.local/v1",
+        model="gpt-5.5",
+    )
+    deepseek = LlmProviderConfig(
+        name="deepseek",
+        api_key="sk-deepseek",
+        base_url="http://deepseek.local/v1",
+        model="deepseek-v4-pro",
+    )
+    cfg = BotConfig(
+        llm_providers=[openai, deepseek],
+        llm_max_retries=0,
+        llm_retry_base_delay_sec=0.0,
+        llm_retry_max_delay_sec=0.0,
+    )
+    calls = []
+
+    async def fake_once(session, **kwargs):
+        calls.append(kwargs["provider_name"])
+        return _ChatCompletionAttempt(
+            text=None,
+            retryable=False,
+            retry_after_sec=None,
+            failure_kind="service_unavailable",
+        )
+
+    with patch("kouhai_bot.llm.get_config", return_value=cfg), \
+            patch("kouhai_bot.llm.aiohttp.ClientSession", _DummySession), \
+            patch("kouhai_bot.llm._post_chat_completion_once", side_effect=fake_once):
+        result = asyncio.run(call_chat_completion_result(
+            [{"role": "user", "content": "Reply with exactly OK."}],
+            task="judge",
+            provider_name="openai",
+        ))
+
+    assert result.text is None
+    assert result.failure_kind == "service_unavailable"
+    assert calls == ["openai"]
 
 
 def test_call_chat_completion_stops_on_non_retryable_failure():

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -123,7 +123,7 @@ def test_get_editorial_zh_for_group_uses_translation(tmp_path, monkeypatch):
     async def _run():
         with patch(
             "kouhai_bot.tutorials.translate_editorial_to_zh",
-            AsyncMock(return_value=("中文题解译文。" * 20, "")),
+            AsyncMock(return_value=("中文题解译文。" * 20, "", True)),
         ):
             return await get_editorial_zh_for_group(editorial, "542D")
 
@@ -131,6 +131,53 @@ def test_get_editorial_zh_for_group_uses_translation(tmp_path, monkeypatch):
     assert zh is not None
     assert zh.startswith("中文题解")
     assert (tmp_path / "tutorial_translations" / "542D.txt").is_file()
+    assert (tmp_path / "tutorial_translations" / "542D.verified").is_file()
+
+
+def test_get_editorial_zh_for_group_marks_mismatched_editorial_missing(tmp_path, monkeypatch):
+    import json
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    tutorials_dir = tmp_path / "tutorials"
+    tutorials_dir.mkdir()
+    body = _long_text("wrong-editorial-")
+    (tutorials_dir / "542D.json").write_text(
+        json.dumps({
+            "tutorial_url": "https://example.com/e",
+            "tutorial_title": "Wrong",
+            "sections": [{"hint": "", "solution": body, "raw_text": body, "code_blocks": []}],
+        }),
+        encoding="utf-8",
+    )
+    editorial = OfficialEditorial(text=body, tutorial_url="https://example.com/e", tutorial_title="Wrong")
+
+    async def _run():
+        with patch(
+            "kouhai_bot.tutorials.translate_editorial_to_zh",
+            AsyncMock(return_value=(None, "", False)),
+        ):
+            return await get_editorial_zh_for_group(editorial, "542D")
+
+    zh, tag = asyncio.run(_run())
+    assert zh is None
+    assert tag == ""
+    assert is_no_official_editorial("542D")
+    assert get_official_editorial("542D") is None
+    assert not (tmp_path / "tutorial_translations" / "542D.txt").exists()
+
+
+def test_unverified_editorial_translation_cache_is_not_warm(tmp_path, monkeypatch):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    cache_dir = tmp_path / "tutorial_translations"
+    cache_dir.mkdir()
+    (cache_dir / "317C.txt").write_text("旧缓存译文。" * 20, encoding="utf-8")
+
+    assert not has_cached_editorial_zh("317C")
 
 
 def test_prefetch_editorial_zh_marks_missing(tmp_path, monkeypatch):
@@ -166,7 +213,7 @@ def test_prefetch_editorial_zh_caches_translation(tmp_path, monkeypatch):
     async def _run():
         with patch(
             "kouhai_bot.tutorials.translate_editorial_to_zh",
-            AsyncMock(return_value=("预取译文 \\(x \\le n\\)。" * 15, "")),
+            AsyncMock(return_value=("预取译文 \\(x \\le n\\)。" * 15, "", True)),
         ):
             await prefetch_editorial_zh("542D")
 
@@ -186,6 +233,7 @@ def test_deliver_uses_prefetch_cache_without_translate(tmp_path, monkeypatch):
     cache_dir = tmp_path / "tutorial_translations"
     cache_dir.mkdir()
     (cache_dir / "542D.txt").write_text("预取译文。" * 20, encoding="utf-8")
+    (cache_dir / "542D.verified").write_text("", encoding="utf-8")
 
     async def _fail_translate(*args, **kwargs):
         raise AssertionError("translate should not run when cache is warm")
@@ -212,6 +260,7 @@ def test_run_post_solve_skips_prefetch_wait_when_cache_warm(tmp_path, monkeypatc
     cache_dir = tmp_path / "tutorial_translations"
     cache_dir.mkdir()
     (cache_dir / "542D.txt").write_text("预取译文。" * 20, encoding="utf-8")
+    (cache_dir / "542D.verified").write_text("", encoding="utf-8")
 
     async def _fail_await(pid):
         raise AssertionError("should not wait for prefetch when cache is warm")

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -164,7 +164,9 @@ def test_get_editorial_zh_for_group_marks_mismatched_editorial_missing(tmp_path,
     assert zh is None
     assert tag == ""
     assert is_no_official_editorial("542D")
-    assert get_official_editorial("542D") is None
+    editorial_after_marker = get_official_editorial("542D")
+    assert editorial_after_marker is not None
+    assert editorial_after_marker.text.startswith("wrong-editorial-")
     assert not (tmp_path / "tutorial_translations" / "542D.txt").exists()
 
 
@@ -178,6 +180,64 @@ def test_unverified_editorial_translation_cache_is_not_warm(tmp_path, monkeypatc
     (cache_dir / "317C.txt").write_text("旧缓存译文。" * 20, encoding="utf-8")
 
     assert not has_cached_editorial_zh("317C")
+
+
+def test_get_editorial_zh_for_group_revalidates_unverified_cache(tmp_path, monkeypatch):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    cache_dir = tmp_path / "tutorial_translations"
+    cache_dir.mkdir()
+    (cache_dir / "317C.txt").write_text("旧缓存译文。" * 20, encoding="utf-8")
+    editorial = OfficialEditorial(
+        text=_long_text("english-"),
+        tutorial_url="https://example.com/e",
+        tutorial_title="T",
+    )
+    translate = AsyncMock(return_value=("新缓存译文。" * 20, "", True))
+
+    async def _run():
+        with patch("kouhai_bot.tutorials.translate_editorial_to_zh", translate):
+            return await get_editorial_zh_for_group(editorial, "317C")
+
+    zh, tag = asyncio.run(_run())
+    assert zh is not None
+    assert zh.startswith("新缓存译文")
+    assert tag == ""
+    translate.assert_awaited_once()
+    assert has_cached_editorial_zh("317C")
+    assert (cache_dir / "317C.verified").is_file()
+
+
+def test_prefetch_editorial_zh_recovers_after_rescrape(tmp_path, monkeypatch):
+    import json
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    mark_no_official_editorial("542D")
+    tutorials_dir = tmp_path / "tutorials"
+    tutorials_dir.mkdir()
+    body = _long_text("rescued-")
+    (tutorials_dir / "542D.json").write_text(
+        json.dumps({
+            "tutorial_url": "https://example.com/e",
+            "sections": [{"hint": "", "solution": body, "raw_text": body, "code_blocks": []}],
+        }),
+        encoding="utf-8",
+    )
+
+    async def _run():
+        with patch(
+            "kouhai_bot.tutorials.translate_editorial_to_zh",
+            AsyncMock(return_value=("恢复后的译文。" * 20, "", True)),
+        ):
+            await prefetch_editorial_zh("542D")
+
+    asyncio.run(_run())
+    assert not is_no_official_editorial("542D")
+    assert has_cached_editorial_zh("542D")
 
 
 def test_prefetch_editorial_zh_marks_missing(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- add an internal second-judge pass after a first-pass correct submit verdict when a verified official editorial is already cached
- pin the second judge to the same provider/model that produced the first-pass verdict, and no-op back to the first verdict if that pinned call fails
- validate scraped editorials during translation with structured JSON output, discarding mismatched editorials instead of treating them as usable
- require verified translation cache markers before second-judge editorial context is considered available

## Impact

The external submit flow and concurrency behavior stay the same. Group and private judge submits share the internal second-judge protection, but only group solve follow-ups deliver editorial cards.

## Validation

- uv run pytest: 239 passed
- manually dry-ran known editorial mismatch/match cases
- manually dry-ran second-judge overturn behavior with both configured model paths