### PR TITLE
[codex] support diagram statements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,8 @@ NapCat (QQ) ──WS──> worker.py
   only as fallback.
 - **Scheduler current-group config**: `~/.kouhai-bot/scheduler_config.json` stores job list + time overrides for `CURRENT_GROUP`. Jobs are defined in `scheduler/jobs.py`.
 - **Command event log**: `eventlog.py` writes append-only JSONL command events by real local date. `achievements.py` reads those events for the 04:00-to-04:00 daily report. `eventlog_backfill.py` and `tools/backfill_command_events.py` can reconstruct recent saved submit/clarify/review events from `scoreboard.json`.
-- **Formula VL**: `problems/fetcher.py` handles CF formula images → Qwen-VL → inline LaTeX. Has white-bg preprocessing, hallucination detection, retry.
-- **Stale cache detection**: `picker.py:fetch_statement()` detects caches created before VL pipeline via `_vl_processed` flag. Stale caches with images are re-fetched with Qwen-VL. Problems with non-formula images (tex-graphics / diagrams) are skipped.
+- **Formula/diagram VL**: `problems/fetcher.py` handles CF formula images → Qwen-VL → inline LaTeX, and `tex-graphics` diagrams → concise VL descriptions. Has white-bg preprocessing, hallucination detection, retry. Diagram metadata is cached as `diagrams` and problem cards attach original diagram images as forward nodes.
+- **Stale cache detection**: `picker.py:fetch_statement()` detects caches created before VL pipeline via `_vl_processed` flag. Stale caches with images are re-fetched with Qwen-VL. Formula conversion failures still skip the problem; non-formula images are supported through VL descriptions plus attached image nodes.
 - **No hermes cron involvement**: The bot runs its own scheduler loop (`scheduler/engine.py`), not hermes cron jobs.
 - **Single worker runtime**: `worker.py` keeps the NapCat reverse-WS connection, dispatches commands, and owns the scheduler in one process. There is no SQLite event queue, ingress supervisor, worker hot-swap, or auto-update loop.
 - **Friend request auto-approval**: Normal OneBot `post_type="request"` / `request_type="friend"` events are parsed by `napcat/client.py`, routed by `handlers.process_event()`, and approved via `set_friend_add_request`. QQ/NapCat "doubtful" friend requests are not reliably pushed as request events, so `worker.py` also runs `friend_requests.doubt_friend_request_loop()`, which polls `get_doubt_friends_add_request` every 60 seconds and approves with `set_doubt_friends_add_request`. Both paths approve only after the requester is confirmed to be a member of `CURRENT_GROUP`; lookup failure, malformed events, non-friend requests, and non-members are ignored without approving. Requests that were already consumed by another QQ client may not appear in the doubtful-request poll.
@@ -631,9 +631,9 @@ commands are rejected in private with a friendly message.
   review as available. It sends a private problem card, preferring the current group's
   cached forward-card payload when the pid is the current group problem. Generated
   private cards must not expose the original CF id, title, contest id, or rating in the
-  card title. If an explicit pid/link fails because the statement fetcher detects
-  non-formula images (`tex-graphics` diagrams), tell the user the bot has limited
-  ability on image-dependent statements and suggest choosing another problem.
+  card title. If an explicit pid/link still fails because diagram extraction or
+  statement fetch is unavailable, tell the user the bot has limited ability on that
+  image-dependent statement and suggest choosing another problem.
 - `/problem` in private resends the selected private problem card. `/tag`, `/status`,
   `/clear`, `/submit`, `/clarify`, and `/review` all operate on private state and do
   not emit group @mentions. `/testcd` is private-only and reports the current service-group

--- a/src/kouhai_bot/handlers/cmd/newproblem.py
+++ b/src/kouhai_bot/handlers/cmd/newproblem.py
@@ -235,6 +235,7 @@ def _save_daily_msg(
     post_msg: str,
     sample_messages: list[str],
     notes_message: str,
+    diagram_messages: list[dict] | None,
     snake_enabled: bool,
     node_payload: dict | None = None,
     fwd_message_id: int | None = None,
@@ -245,6 +246,7 @@ def _save_daily_msg(
         "post_msg": post_msg,
         "sample_messages": sample_messages,
         "notes_message": notes_message,
+        "diagram_messages": diagram_messages or [],
         "snake_enabled": snake_enabled,
     }
     if fwd_message_id is not None:
@@ -298,6 +300,36 @@ def _build_sample_messages(stmt: dict) -> list[str]:
     return lines
 
 
+def _build_diagram_messages(stmt: dict) -> list[dict]:
+    diagrams = stmt.get("diagrams")
+    if not isinstance(diagrams, list):
+        return []
+    messages: list[dict] = []
+    for idx, item in enumerate(diagrams, 1):
+        if not isinstance(item, dict):
+            continue
+        src = str(item.get("src", "") or "").strip()
+        description = str(item.get("description", "") or "").strip()
+        label = str(item.get("label", "") or f"图 {idx}").strip()
+        if not src and not description:
+            continue
+        messages.append({"label": label, "src": src, "description": description})
+    return messages
+
+
+def _build_diagram_segments(diagram: dict) -> list[dict]:
+    label = str(diagram.get("label", "示意图") or "示意图").strip()
+    description = str(diagram.get("description", "") or "").strip()
+    src = str(diagram.get("src", "") or "").strip()
+    caption = f"题面示意图：{label}"
+    if description and not description.startswith("("):
+        caption += f"\n{description}"
+    segments = build_plain_message(caption)
+    if src:
+        segments.append({"type": "image", "data": {"file": src}})
+    return segments
+
+
 async def _build_notes_message(stmt: dict) -> str:
     raw_notes = stmt.get("notes")
     normalized_notes = _normalize_sample_block(raw_notes)
@@ -319,6 +351,7 @@ async def _send_problem_forward_card(
     post_msg: str,
     sample_messages: list[str],
     notes_message: str = "",
+    diagram_messages: list[dict] | None = None,
     snake_enabled: bool = True,
 ) -> tuple[int | None, dict]:
     cfg = get_config()
@@ -342,6 +375,14 @@ async def _send_problem_forward_card(
             except Exception as e:
                 logger.warning(f"[group_{group_id}] Snake image self-send failed: {e}")
 
+    diagram_msg_ids: list[int] = []
+    for i, diagram in enumerate(diagram_messages or [], 1):
+        diagram_resp = await send_private_msg(cfg.bot_qq, _build_diagram_segments(diagram))
+        if diagram_resp:
+            diagram_msg_ids.append(diagram_resp)
+        else:
+            logger.warning(f"[group_{group_id}] Diagram {i} self-send failed")
+
     sample_msg_ids: list[int] = []
     for i, sample_msg in enumerate(sample_messages, 1):
         sample_resp = await send_private_msg(cfg.bot_qq, build_plain_message(sample_msg))
@@ -360,6 +401,8 @@ async def _send_problem_forward_card(
 
     await asyncio.sleep(0.5)
     fwd_nodes = [{"type": "node", "data": {"id": str(self_resp)}}]
+    for diagram_msg_id in diagram_msg_ids:
+        fwd_nodes.append({"type": "node", "data": {"id": str(diagram_msg_id)}})
     for sample_msg_id in sample_msg_ids:
         fwd_nodes.append({"type": "node", "data": {"id": str(sample_msg_id)}})
     if note_msg_id:
@@ -369,6 +412,7 @@ async def _send_problem_forward_card(
     fwd_resp = await send_group_forward_msg(group_id, fwd_nodes)
     payload = {
         "msg_id": self_resp,
+        "diagram_msg_ids": diagram_msg_ids,
         "sample_msg_ids": sample_msg_ids,
         "note_msg_id": note_msg_id,
         "snake_msg_id": snake_msg_id,
@@ -467,6 +511,7 @@ async def _do_daily_post_locked(
     pid = str(picked_state.get("today", "") or "")
     sample_messages: list[str] = []
     notes_message = ""
+    diagram_messages: list[dict] = []
     try:
         if pid:
             schedule_prefetch_editorial(pid)
@@ -484,6 +529,7 @@ async def _do_daily_post_locked(
             ml = stmt.get("memory_limit", "?")
             limits_text = f"Time: {tl}, Memory: {ml}"
             sample_messages = _build_sample_messages(stmt)
+            diagram_messages = _build_diagram_messages(stmt)
             notes_message = await _build_notes_message(stmt)
 
         summary, model_tag = await summarize_problem(stmt_text, input_text, limits_text)
@@ -514,6 +560,7 @@ async def _do_daily_post_locked(
         post_msg=post_msg,
         sample_messages=sample_messages,
         notes_message=notes_message,
+        diagram_messages=diagram_messages,
         snake_enabled=True,
     )
     if not fwd_resp:
@@ -529,6 +576,7 @@ async def _do_daily_post_locked(
                     post_msg=post_msg,
                     sample_messages=sample_messages,
                     notes_message=notes_message,
+                    diagram_messages=diagram_messages,
                     snake_enabled=True,
                     node_payload=node_payload,
                 )
@@ -543,7 +591,7 @@ async def _do_daily_post_locked(
     append_group_ctx(group_id, {"role": "assistant", "content": post_msg})
     logger.info(
         f"[group_{group_id}] Daily post forwarded ✓ "
-        f"({1 + len(sample_messages) + (1 if node_payload.get('note_msg_id') else 0) + (1 if node_payload.get('snake_msg_id') else 0)} msgs)"
+        f"({1 + len(diagram_messages) + len(sample_messages) + (1 if node_payload.get('note_msg_id') else 0) + (1 if node_payload.get('snake_msg_id') else 0)} msgs)"
     )
     await _commit_problem_state(group_id, picked_state)
     if pid:
@@ -557,6 +605,7 @@ async def _do_daily_post_locked(
             post_msg=post_msg,
             sample_messages=sample_messages,
             notes_message=notes_message,
+            diagram_messages=diagram_messages,
             snake_enabled=True,
             node_payload=node_payload,
             fwd_message_id=fwd_resp,

--- a/src/kouhai_bot/handlers/cmd/stubs.py
+++ b/src/kouhai_bot/handlers/cmd/stubs.py
@@ -110,6 +110,11 @@ async def handle_problem(group_id: int, user_id: int, sender: dict,
             msg_id = daily_msg.get("msg_id")
             if msg_id:
                 fwd_nodes = [{"type": "node", "data": {"id": str(msg_id)}}]
+                diagram_msg_ids = daily_msg.get("diagram_msg_ids", [])
+                if isinstance(diagram_msg_ids, list):
+                    for diagram_msg_id in diagram_msg_ids:
+                        if diagram_msg_id:
+                            fwd_nodes.append({"type": "node", "data": {"id": str(diagram_msg_id)}})
                 sample_msg_ids = daily_msg.get("sample_msg_ids", [])
                 if isinstance(sample_msg_ids, list):
                     for sample_msg_id in sample_msg_ids:
@@ -131,6 +136,7 @@ async def handle_problem(group_id: int, user_id: int, sender: dict,
             post_msg = daily_msg.get("post_msg")
             sample_messages = daily_msg.get("sample_messages")
             notes_message = daily_msg.get("notes_message")
+            diagram_messages = daily_msg.get("diagram_messages")
             snake_enabled = bool(daily_msg.get("snake_enabled", True))
             if isinstance(post_msg, str) and isinstance(sample_messages, list):
                 fwd_resp, node_payload = await _send_problem_forward_card(
@@ -138,6 +144,7 @@ async def handle_problem(group_id: int, user_id: int, sender: dict,
                     post_msg=post_msg,
                     sample_messages=[str(item) for item in sample_messages],
                     notes_message=str(notes_message) if isinstance(notes_message, str) else "",
+                    diagram_messages=diagram_messages if isinstance(diagram_messages, list) else [],
                     snake_enabled=snake_enabled,
                 )
                 if fwd_resp:

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -162,6 +162,19 @@ def load_problem_statement(pid: str) -> str:
     if desc:
         parts.append(f"\nDescription:\n{desc}")
 
+    diagrams = stmt.get("diagrams", [])
+    if isinstance(diagrams, list) and diagrams:
+        lines = []
+        for idx, item in enumerate(diagrams, 1):
+            if not isinstance(item, dict):
+                continue
+            label = str(item.get("label", "") or f"Diagram {idx}").strip()
+            description = str(item.get("description", "") or "").strip()
+            if description:
+                lines.append(f"{label}: {description}")
+        if lines:
+            parts.append("\nDiagrams:\n" + "\n".join(lines))
+
     inp = stmt.get("input", "")
     if inp:
         parts.append(f"\nInput:\n{inp}")

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -528,6 +528,36 @@ def _build_sample_messages(stmt: dict) -> list[str]:
     return messages
 
 
+def _build_diagram_messages(stmt: dict) -> list[dict]:
+    diagrams = stmt.get("diagrams")
+    if not isinstance(diagrams, list):
+        return []
+    messages: list[dict] = []
+    for idx, item in enumerate(diagrams, 1):
+        if not isinstance(item, dict):
+            continue
+        src = str(item.get("src", "") or "").strip()
+        description = str(item.get("description", "") or "").strip()
+        label = str(item.get("label", "") or f"图 {idx}").strip()
+        if not src and not description:
+            continue
+        messages.append({"label": label, "src": src, "description": description})
+    return messages
+
+
+def _build_diagram_segments(diagram: dict) -> list[dict]:
+    label = str(diagram.get("label", "示意图") or "示意图").strip()
+    description = str(diagram.get("description", "") or "").strip()
+    src = str(diagram.get("src", "") or "").strip()
+    caption = f"题面示意图：{label}"
+    if description and not description.startswith("("):
+        caption += f"\n{description}"
+    segments = build_plain_message(caption)
+    if src:
+        segments.append({"type": "image", "data": {"file": src}})
+    return segments
+
+
 async def _build_notes_message(stmt: dict) -> str:
     raw_notes = _normalize_sample_block(stmt.get("notes", ""))
     if not raw_notes:
@@ -569,6 +599,7 @@ async def build_problem_card_payload(group_id: int, problem: dict, *, greeting: 
         "post_msg": post_msg,
         "sample_messages": _build_sample_messages(stmt),
         "notes_message": await _build_notes_message(stmt),
+        "diagram_messages": _build_diagram_messages(stmt),
         "snake_enabled": False,
     }
 
@@ -648,6 +679,9 @@ async def send_problem_card_private(user_id: int, group_id: int, problem: dict, 
     msg_id = payload.get("msg_id")
     if msg_id:
         node_ids.append(str(msg_id))
+        for diagram_id in payload.get("diagram_msg_ids", []) if isinstance(payload.get("diagram_msg_ids"), list) else []:
+            if diagram_id:
+                node_ids.append(str(diagram_id))
         for sample_id in payload.get("sample_msg_ids", []) if isinstance(payload.get("sample_msg_ids"), list) else []:
             if sample_id:
                 node_ids.append(str(sample_id))
@@ -664,16 +698,25 @@ async def send_problem_card_private(user_id: int, group_id: int, problem: dict, 
     post_msg = payload.get("post_msg")
     sample_messages = payload.get("sample_messages")
     notes_message = payload.get("notes_message")
+    diagram_messages = payload.get("diagram_messages")
     if not isinstance(post_msg, str):
         post_msg = "当前题目"
     if not isinstance(sample_messages, list):
         sample_messages = []
     if not isinstance(notes_message, str):
         notes_message = ""
+    if not isinstance(diagram_messages, list):
+        diagram_messages = []
 
     main_node_id = await send_private_msg(cfg.bot_qq, build_plain_message(post_msg))
     node_ids = [str(main_node_id)] if main_node_id else []
     if main_node_id:
+        for diagram in diagram_messages:
+            if not isinstance(diagram, dict):
+                continue
+            resp = await send_private_msg(cfg.bot_qq, _build_diagram_segments(diagram))
+            if resp:
+                node_ids.append(str(resp))
         for text in [*[str(item) for item in sample_messages], notes_message]:
             if not text:
                 continue
@@ -689,6 +732,11 @@ async def send_problem_card_private(user_id: int, group_id: int, problem: dict, 
 
     direct_id = await send_private_msg(user_id, build_plain_message(post_msg))
     _save_private_problem_card_ref(group_id, direct_id, pid)
+    for diagram in diagram_messages:
+        if not isinstance(diagram, dict):
+            continue
+        diagram_id = await send_private_msg(user_id, _build_diagram_segments(diagram))
+        _save_private_problem_card_ref(group_id, diagram_id, pid)
     for sample in sample_messages:
         sample_id = await send_private_msg(user_id, build_plain_message(str(sample)))
         _save_private_problem_card_ref(group_id, sample_id, pid)

--- a/src/kouhai_bot/problems/fetcher.py
+++ b/src/kouhai_bot/problems/fetcher.py
@@ -13,7 +13,8 @@ VL backends (set via --vl-backend or CF_VL_BACKEND env):
   - none     Dry-run only
 
 Returns:
-  - has_non_formula_images: True if problem contains tex-graphics diagrams → filter out
+  - has_non_formula_images: True if problem contains tex-graphics diagrams
+  - graphics_details: VL descriptions for tex-graphics diagrams when available
 """
 
 import argparse
@@ -22,6 +23,7 @@ import json
 import os
 import re
 import sys
+import urllib.parse
 import urllib.request
 from io import BytesIO
 
@@ -111,7 +113,7 @@ def find_all_tex_images(ps_html: str) -> tuple[list[dict], list[dict]]:
     """Find all tex-formula and tex-graphics images.
     Returns (formulas, graphics) — each a list of {tag, src, class, start, end}.
     tex-formula = math formula images (should convert to LaTeX)
-    tex-graphics = diagrams/charts/drawings (should filter out the problem)
+    tex-graphics = diagrams/charts/drawings (should describe and attach)
     """
     formulas = []
     graphics = []
@@ -125,7 +127,7 @@ def find_all_tex_images(ps_html: str) -> tuple[list[dict], list[dict]]:
         cls = cls_m.group(1) if cls_m else ""
         entry = {
             "tag": tag,
-            "src": src_m.group(1) if src_m else "",
+            "src": normalize_image_url(src_m.group(1) if src_m else ""),
             "class": cls,
             "start": m.start(),
             "end": m.end(),
@@ -142,6 +144,16 @@ def find_all_tex_images(ps_html: str) -> tuple[list[dict], list[dict]]:
 def image_to_base64_url(image_bytes: bytes, mime: str = "image/png") -> str:
     b64 = base64.b64encode(image_bytes).decode()
     return f"data:{mime};base64,{b64}"
+
+
+def normalize_image_url(url: str) -> str:
+    """Normalize CF image URLs so urllib and OneBot can consume them."""
+    url = str(url or "").strip()
+    if url.startswith("//"):
+        return "https:" + url
+    if url.startswith("/"):
+        return urllib.parse.urljoin("https://codeforces.com", url)
+    return url
 
 
 def download_image(url: str) -> bytes:
@@ -329,6 +341,34 @@ def call_vl_with_retry(
     return "(VL hallucination after retries)"
 
 
+def call_vl_for_graphic(
+    vl_fn,
+    b64_url: str,
+    context: str,
+    pid: str,
+    graphic_idx: int,
+) -> str:
+    """Ask VL for a faithful text rendering of a diagram."""
+    prompt = (
+        "This image is a diagram from a competitive programming problem statement. "
+        "Describe only visible, task-relevant facts so a solver and a judging model can "
+        "understand the statement without seeing the image. Include labels, numbers, "
+        "nodes, edges, arrows, axes, coordinates, colors, shapes, examples, and order "
+        "relationships if present. Do not infer a solution or add unstated facts. "
+        "If the image contains no useful problem information, say: no task-relevant "
+        "details visible.\n\n"
+        f"Surrounding statement text: {context}"
+    )
+    result = vl_fn(prompt, [b64_url])
+    result = re.sub(r"\s+", " ", result or "").strip()
+    if not result:
+        return "(VL failed)"
+    if len(result) > 1000:
+        result = result[:1000].rstrip() + "..."
+    print(f"  [{pid}] Graphic {graphic_idx}: {result[:120]}", file=sys.stderr)
+    return result
+
+
 # ── HTML to text ────────────────────────────────────────────────────────
 
 def html_to_text(ps_html: str) -> str:
@@ -352,7 +392,8 @@ def process_problem(
       - pid, url, text, text_length
       - formulas_found, formulas_processed
       - formula_details: list of {src, latex}
-      - has_non_formula_images: True if tex-graphics (diagrams) found → filter out
+      - has_non_formula_images: True if tex-graphics (diagrams) found
+      - graphics_details: list of {src, label, description}
       - formulas_failed: number of formulas that couldn't be converted after retries
     """
     html, pid = fetch_problem_html(contest_id, index)
@@ -367,12 +408,14 @@ def process_problem(
           file=sys.stderr)
 
     if has_non_formula_images:
-        print(f"  [{pid}] ⚠ contains tex-graphics (diagrams) — will be filtered",
+        print(f"  [{pid}] contains tex-graphics (diagrams) — describing with VL",
               file=sys.stderr)
 
     # Process formula images
     formula_results = []
     formulas_failed = 0
+    graphic_results = []
+    graphics_failed = 0
 
     if formulas and vl_backend in VL_BACKENDS:
         vl_fn = VL_BACKENDS[vl_backend]
@@ -414,12 +457,38 @@ def process_problem(
         for fm in formulas:
             formula_results.append({"src": fm["src"], "latex": "[FORMULA IMAGE]"})
 
-    # Also mark graphics images in results (for reporting)
-    for gm in graphics:
-        formula_results.append({
-            "src": gm["src"],
-            "latex": "[DIAGRAM — non-formula image]",
-        })
+    # Describe non-formula graphics instead of rejecting the whole problem.
+    if graphics and vl_backend in VL_BACKENDS:
+        vl_fn = VL_BACKENDS[vl_backend]
+        for i, gm in enumerate(graphics, 1):
+            label = f"Diagram {i}"
+            try:
+                img_bytes = download_image(gm["src"])
+                b64_url = image_to_base64_url(preprocess_formula_png(img_bytes, upscale=1))
+                context = extract_context(ps_html, gm["start"], gm["end"])
+                description = call_vl_for_graphic(vl_fn, b64_url, context, pid, i)
+                if description.startswith("(VL"):
+                    graphics_failed += 1
+                graphic_results.append({
+                    "src": gm["src"],
+                    "label": label,
+                    "description": description,
+                })
+            except Exception as e:
+                graphics_failed += 1
+                graphic_results.append({
+                    "src": gm["src"],
+                    "label": label,
+                    "description": f"(error: {e})",
+                })
+                print(f"    → graphic error: {e}", file=sys.stderr)
+    elif graphics:
+        for i, gm in enumerate(graphics, 1):
+            graphic_results.append({
+                "src": gm["src"],
+                "label": f"Diagram {i}",
+                "description": "[DIAGRAM IMAGE]",
+            })
 
     # Replace all image tags with their text representation (reverse order)
     result_html = ps_html
@@ -432,9 +501,17 @@ def process_problem(
 
     for img_entry in all_images:
         # Find matching result by src URL
-        matching = [r for r in formula_results if r["src"] == img_entry["src"]]
-        latex = matching[0]["latex"] if matching else "[IMAGE]"
-        replacement = f'<span class="tex-formula-text">({latex})</span>'
+        if "tex-graphics" in img_entry.get("class", ""):
+            matching_graphics = [r for r in graphic_results if r["src"] == img_entry["src"]]
+            graphic = matching_graphics[0] if matching_graphics else {}
+            label = graphic.get("label", "Diagram")
+            description = graphic.get("description", "[DIAGRAM IMAGE]")
+            replacement_text = f"[{label}: {description}]"
+        else:
+            matching = [r for r in formula_results if r["src"] == img_entry["src"]]
+            latex = matching[0]["latex"] if matching else "[IMAGE]"
+            replacement_text = f"({latex})"
+        replacement = f'<span class="tex-formula-text">{replacement_text}</span>'
         result_html = (
             result_html[:img_entry["start"]] + replacement + result_html[img_entry["end"]:]
         )
@@ -447,6 +524,9 @@ def process_problem(
         "formulas_found": len(formulas),
         "graphics_found": len(graphics),
         "has_non_formula_images": has_non_formula_images,
+        "graphics_processed": len(graphics) - graphics_failed,
+        "graphics_failed": graphics_failed,
+        "graphics_details": graphic_results,
         "formulas_processed": len(formulas) - formulas_failed,
         "formulas_failed": formulas_failed,
         "formula_details": formula_results,
@@ -520,13 +600,22 @@ def main():
         print(f"URL: {result['url']}")
         print(f"Formulas: {result['formulas_found']} found, {result['formulas_processed']} processed")
         if result["has_non_formula_images"]:
-            print("⚠ Contains non-formula images (diagrams) — recommend filtering")
+            print(
+                f"Diagrams: {result['graphics_found']} found, "
+                f"{result.get('graphics_processed', 0)} described"
+            )
         if result["formulas_failed"]:
             print(f"⚠ {result['formulas_failed']} formula(s) failed")
+        if result.get("graphics_failed"):
+            print(f"⚠ {result['graphics_failed']} diagram(s) failed")
         for fr in result.get("formula_details", []):
             src_short = fr["src"][:60]
             print(f"  {src_short}")
             print(f"    → {fr.get('latex', '?')[:120]}")
+        for gr in result.get("graphics_details", []):
+            src_short = gr["src"][:60]
+            print(f"  {src_short}")
+            print(f"    → {gr.get('description', '?')[:120]}")
         print(f"\n--- Problem text ({result['text_length']} chars) ---")
         print(result["text"][:2000])
 

--- a/src/kouhai_bot/problems/picker.py
+++ b/src/kouhai_bot/problems/picker.py
@@ -238,12 +238,32 @@ def _normalize_samples(samples: list[dict]) -> tuple[list[dict], bool]:
     return normalized, changed
 
 
+def _diagram_details_for_cache(details: object) -> list[dict]:
+    if not isinstance(details, list):
+        return []
+    diagrams: list[dict] = []
+    for idx, item in enumerate(details, 1):
+        if not isinstance(item, dict):
+            continue
+        src = str(item.get("src", "") or "").strip()
+        description = str(item.get("description", "") or "").strip()
+        if not src and not description:
+            continue
+        label = str(item.get("label", "") or f"Diagram {idx}").strip()
+        diagrams.append({
+            "label": label,
+            "src": src,
+            "description": description,
+        })
+    return diagrams
+
+
 def fetch_statement(problem: dict) -> object:
     """
     Fetch full problem statement from Codeforces using cf_statement with Qwen-VL.
-    Formula images are converted to LaTeX text via VL; non-formula diagrams are filtered.
+    Formula images are converted to LaTeX text via VL; non-formula diagrams are described and attached.
     Returns dict with keys: name, time_limit, memory_limit, description,
-    input, samples, notes. Or None on failure / diagram problem.
+    input, samples, notes, diagrams. Or None on failure.
     Caches locally so we only process each problem once.
     """
     contest_id = problem.get("contestId")
@@ -299,10 +319,8 @@ def fetch_statement(problem: dict) -> object:
         print(f"Warning: {pid} cf_statement error: {cf_result['error']}", file=sys.stderr)
         return None
 
-    # Filter: skip problems with non-formula images (diagrams)
     if cf_result.get("has_non_formula_images"):
-        print(f"Warning: {pid} has non-formula images (diagrams), skipping", file=sys.stderr)
-        return None
+        print(f"Info: {pid} has non-formula images (diagrams), using VL descriptions", file=sys.stderr)
 
     # Filter: skip if any formula failed after retries
     if cf_result.get("formulas_failed", 0) > 0:
@@ -339,6 +357,9 @@ def fetch_statement(problem: dict) -> object:
     # Description: use VL-processed text (formulas converted to LaTeX inline)
     desc = cf_result.get("text", "")
     result["description"] = desc
+    diagrams = _diagram_details_for_cache(cf_result.get("graphics_details", []))
+    if diagrams:
+        result["diagrams"] = diagrams
 
     # Extract Input spec from raw HTML
     inp_m = re.search(

--- a/tests/test_picker_samples.py
+++ b/tests/test_picker_samples.py
@@ -19,3 +19,54 @@ def test_normalize_sample_block_div_lines():
 def test_normalize_sample_block_br_lines():
     raw = "5 3 5<br />5 -5 5 1 -4<br />2 1 2<br />"
     assert _normalize_sample_block(raw) == "5 3 5\n5 -5 5 1 -4\n2 1 2"
+
+
+def test_process_problem_describes_tex_graphics(monkeypatch):
+    import base64
+    from kouhai_bot.problems import fetcher
+
+    png = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+    )
+    html = (
+        '<div class="problem-statement">'
+        '<p>Consider the graph <img class="tex-graphics" src="//img.example/graph.png" /></p>'
+        '</div><script></script>'
+    )
+
+    monkeypatch.setattr(
+        fetcher,
+        "fetch_problem_html",
+        lambda contest_id, index: (html, f"{contest_id}{index}"),
+    )
+    monkeypatch.setattr(fetcher, "download_image", lambda url: png)
+    fetcher.VL_BACKENDS["fake"] = (
+        lambda prompt, image_urls: "three nodes labeled 1, 2, 3 with edges 1-2 and 2-3"
+    )
+    try:
+        result = fetcher.process_problem(100, "A", vl_backend="fake")
+    finally:
+        fetcher.VL_BACKENDS.pop("fake", None)
+
+    assert result["has_non_formula_images"] is True
+    assert result["graphics_found"] == 1
+    assert result["graphics_failed"] == 0
+    assert result["graphics_details"][0]["src"] == "https://img.example/graph.png"
+    assert "Diagram 1" in result["text"]
+    assert "three nodes labeled 1, 2, 3" in result["text"]
+
+
+def test_diagram_details_for_cache_keeps_description_and_src():
+    from kouhai_bot.problems.picker import _diagram_details_for_cache
+
+    diagrams = _diagram_details_for_cache([
+        {"src": "https://img.example/a.png", "label": "Diagram 2", "description": "two arrows"},
+        {"src": "", "description": ""},
+        "bad",
+    ])
+
+    assert diagrams == [{
+        "src": "https://img.example/a.png",
+        "label": "Diagram 2",
+        "description": "two arrows",
+    }]


### PR DESCRIPTION
## Summary
- describe Codeforces tex-graphics diagrams with VL instead of rejecting those problems outright
- cache diagram metadata and include diagram descriptions in LLM statement context
- attach original diagram image nodes in group and private problem cards, including /problem resends

## Validation
- uv run pytest -q