### PR TITLE
[codex] cf tutorial llm harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ NapCat (QQ) ──WS──> worker.py
   `thinking` and `reasoning_effort` are sent unconditionally; unsupported
   fields are silently ignored by upstream APIs.
 - **Official CF tutorials**: Scraped editorials live under `{data_dir}/tutorials/{pid}.json`
-  (see `tools/scrape_cf_tutorial.py`). Runtime extraction is in `tutorials.py`. On the
+  (see `tools/cf_tutorial_agent.py`; low-level CF HTML helpers live in `tools/scrape_cf_tutorial.py`). Runtime extraction is in `tutorials.py`. On the
   On **new problem** (`do_daily_post` / `/newproblem`), `schedule_prefetch_editorial(pid)`
   starts background translation (using `summary_model`) into `tutorial_translations/` so first AC
   can deliver without waiting. On **first AC**, congrats is sent in `_finalize_submit`, then
@@ -712,15 +712,18 @@ continue using their admission-time problem snapshot while the new card is being
 **Scraping** (offline, not in the bot hot path):
 
 ```bash
-# Batch: statements/*.json → tutorials/<pid>.json (quality check + 1 retry)
-uv run python tools/tutorial_tools.py crawl \
-  --statements-dir statements \
+# Batch: statements/*.json → tutorials/<pid>.json using the LLM harness
+KOUHAI_CONFIG=/path/to/config.yaml uv run python tools/tutorial_tools.py crawl \
+  --statements-dir ~/.kouhai-bot/statements \
   --tutorials-dir ~/.kouhai-bot/tutorials
 
-# Single problem debug
-uv run python tools/scrape_cf_tutorial.py \
-  --problem-url "https://codeforces.com/problemset/problem/542/D" \
-  --output /tmp/542D.json
+# Single-problem LLM harness: bounded blog candidates → selector LLM → existing JSON schema
+KOUHAI_CONFIG=/path/to/config.yaml uv run python tools/tutorial_tools.py agent \
+  --pid 542D \
+  --statements-dir ~/.kouhai-bot/statements \
+  --tutorials-dir ~/.kouhai-bot/tutorials \
+  --translate
+
 
 # Optional audit of existing tutorials/
 uv run python tools/tutorial_tools.py validate --heuristic-only

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -366,6 +366,7 @@ async def chat_completion(
     response_format: dict | None = None,
     thinking: dict | None = None,
     provider_name: str = "",
+    send_reasoning_effort: bool = True,
 ) -> ChatCompletionResult:
     """Call providers in fallback order; first success wins.
 
@@ -408,7 +409,7 @@ async def chat_completion(
             if thinking:
                 payload["thinking"] = thinking
             reasoning_effort = provider.reasoning_effort.strip().lower()
-            if reasoning_effort:
+            if reasoning_effort and send_reasoning_effort:
                 payload["reasoning_effort"] = reasoning_effort
             if _provider_uses_stream(
                 provider.name,

--- a/src/kouhai_bot/tutorials.py
+++ b/src/kouhai_bot/tutorials.py
@@ -11,7 +11,7 @@ import re
 from dataclasses import dataclass
 
 from .config import get_config
-from .handlers.shared import load_problem_statement, translate_editorial_to_zh
+from .handlers.shared import translate_editorial_to_zh
 
 MIN_EDITORIAL_LEN = 80
 _REVIEW_EDITORIAL_MAX_LEN = 12000
@@ -93,6 +93,44 @@ def extract_editorial(section: dict) -> str:
             body = ""
 
     return _append_code_blocks(body, code_blocks)
+
+
+def _load_problem_statement_for_editorial(pid: str) -> str:
+    path = os.path.join(get_config().data_dir, "statements", f"{pid}.json")
+    if not os.path.isfile(path):
+        return ""
+    try:
+        with open(path, encoding="utf-8") as f:
+            stmt = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return ""
+
+    parts: list[str] = []
+    if stmt.get("name"):
+        parts.append(f"Problem: {stmt['name']}")
+    if stmt.get("time_limit"):
+        parts.append(f"Time limit: {stmt['time_limit']}")
+    if stmt.get("memory_limit"):
+        parts.append(f"Memory limit: {stmt['memory_limit']}")
+    for label, key in [
+        ("Description", "description"),
+        ("Input", "input"),
+        ("Output", "output"),
+        ("Note", "notes"),
+    ]:
+        value = (stmt.get(key) or "").strip()
+        if value:
+            parts.append(f"\n{label}:\n{value}")
+    samples = stmt.get("samples") or []
+    if isinstance(samples, list):
+        for sample in samples:
+            if not isinstance(sample, dict):
+                continue
+            parts.append(
+                f"\nInput:\n{sample.get('input', '')}\n"
+                f"Output:\n{sample.get('output', '')}"
+            )
+    return "\n".join(parts)
 
 
 def load_tutorial(pid: str) -> dict | None:
@@ -219,7 +257,7 @@ async def get_editorial_zh_for_group(editorial: OfficialEditorial, pid: str) -> 
     if has_cached_editorial_zh(pid):
         return _load_cached_translation(pid), ""
 
-    problem_text = load_problem_statement(pid)
+    problem_text = _load_problem_statement_for_editorial(pid)
     translated, model_tag, matched = await translate_editorial_to_zh(
         editorial.text,
         pid=pid,

--- a/tests/test_cf_tutorial_agent.py
+++ b/tests/test_cf_tutorial_agent.py
@@ -1,0 +1,269 @@
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import cf_tutorial_agent as agent
+from kouhai_bot.llm import ChatCompletionResult
+
+
+def _write_statement(statements_dir: Path, pid: str = "1000B") -> None:
+    statements_dir.mkdir(parents=True, exist_ok=True)
+    (statements_dir / f"{pid}.json").write_text(
+        json.dumps(
+            {
+                "name": "Target Problem",
+                "description": "Given an array, find the maximum subarray sum.",
+                "input": "n and array a",
+                "output": "maximum sum",
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _problem_page() -> str:
+    return """
+    <html><body>
+      <div class="title">B. Target Problem</div>
+      <a href="/blog/entry/1">Announcement</a>
+      <a href="/blog/entry/2">Tutorial</a>
+    </body></html>
+    """
+
+
+def _blog_page(body: str, title: str = "Editorial") -> str:
+    return f"""
+    <html>
+      <head><title>{title}</title></head>
+      <body><div class="ttypography">{body}</div></body>
+    </html>
+    """
+
+
+def test_extract_blog_links_prefers_tutorial_text():
+    links = agent.extract_blog_links(_problem_page(), "https://codeforces.com/problemset/problem/1000/B", limit=2)
+    assert links == [
+        "https://codeforces.com/blog/entry/2",
+        "https://codeforces.com/blog/entry/1",
+    ]
+
+
+def test_agent_selects_high_confidence_candidate(tmp_path):
+    _write_statement(tmp_path)
+
+    pages = {
+        "https://codeforces.com/problemset/problem/1000/B": _problem_page(),
+        "https://codeforces.com/blog/entry/2": _blog_page(
+            """
+            <h4>A - Other</h4>
+            <p>This solves a graph problem.</p>
+            <h4>B - Target Problem</h4>
+            <p>Use Kadane dynamic programming. Let dp be the best subarray ending here,
+            update it with max(a_i, dp+a_i), and keep the best answer. This matches
+            the maximum subarray objective and runs in linear time.</p>
+            """
+        ),
+        "https://codeforces.com/blog/entry/1": _blog_page(
+            "<h4>B - Target Problem</h4><p>Authors and preparation.</p>",
+            title="Announcement",
+        ),
+    }
+
+    def fake_fetch(url, **_kwargs):
+        return pages[url]
+
+    async def fake_chat_completion(messages, **kwargs):
+        payload = json.loads(messages[1]["content"])
+        ids = [row["id"] for row in payload["candidates"]]
+        assert ids
+        return ChatCompletionResult(
+            text=json.dumps(
+                {
+                    "match": True,
+                    "candidate_id": ids[0],
+                    "confidence": 0.92,
+                    "reason": "candidate discusses maximum subarray DP",
+                }
+            )
+        )
+
+    with patch("cf_tutorial_agent.fetch_html", side_effect=fake_fetch), \
+            patch("cf_tutorial_agent.chat_completion", side_effect=fake_chat_completion):
+        result = asyncio.run(
+            agent.run_agent_for_pid(
+                pid="1000B",
+                statements_dir=tmp_path,
+                fetcher="http",
+                blog_limit=2,
+                deadline_sec=10,
+                selector_timeout_sec=5,
+            )
+        )
+
+    assert result.confidence == 0.92
+    assert result.bundle["tutorial_url"] == "https://codeforces.com/blog/entry/2"
+    assert result.bundle["sections"][0]["label"] == "B"
+    assert "Kadane" in result.bundle["sections"][0]["raw_text"]
+    assert result.bundle["agent_meta"]["source_kind"] == "section"
+
+
+def test_agent_rejects_low_confidence(tmp_path):
+    _write_statement(tmp_path)
+    pages = {
+        "https://codeforces.com/problemset/problem/1000/B": _problem_page(),
+        "https://codeforces.com/blog/entry/2": _blog_page(
+            "<h4>B - Target Problem</h4><p>Some unrelated short text.</p>"
+        ),
+    }
+
+    def fake_fetch(url, **_kwargs):
+        return pages[url]
+
+    async def fake_chat_completion(*_args, **_kwargs):
+        return ChatCompletionResult(
+            text=json.dumps(
+                {
+                    "match": True,
+                    "candidate_id": "c1",
+                    "confidence": 0.4,
+                    "reason": "too little evidence",
+                }
+            )
+        )
+
+    with patch("cf_tutorial_agent.fetch_html", side_effect=fake_fetch), \
+            patch("cf_tutorial_agent.chat_completion", side_effect=fake_chat_completion):
+        try:
+            asyncio.run(
+                agent.run_agent_for_pid(
+                    pid="1000B",
+                    statements_dir=tmp_path,
+                    fetcher="http",
+                    blog_limit=1,
+                    deadline_sec=10,
+                    selector_timeout_sec=5,
+                )
+            )
+        except agent.AgentNoMatch as exc:
+            assert "selector_low_confidence" in str(exc)
+        else:
+            raise AssertionError("expected low confidence rejection")
+
+
+def test_dynamic_candidate_used_when_static_section_is_placeholder(tmp_path):
+    _write_statement(tmp_path)
+    pages = {
+        "https://codeforces.com/problemset/problem/1000/B": _problem_page(),
+        "https://codeforces.com/blog/entry/2": _blog_page(
+            "<h4>B - Target Problem</h4><p>Tutorial is loading...</p>"
+        ),
+    }
+
+    def fake_fetch(url, **_kwargs):
+        return pages[url]
+
+    async def fake_chat_completion(*_args, **_kwargs):
+        return ChatCompletionResult(
+            text=json.dumps(
+                {
+                    "match": True,
+                    "candidate_id": "c1",
+                    "confidence": 0.9,
+                    "reason": "dynamic tutorial matches",
+                }
+            )
+        )
+
+    with patch("cf_tutorial_agent.fetch_html", side_effect=fake_fetch), \
+            patch("cf_tutorial_agent.fetch_dynamic_editorial", return_value=("Target Problem", "Dynamic official explanation " * 8)), \
+            patch("cf_tutorial_agent.chat_completion", side_effect=fake_chat_completion):
+        result = asyncio.run(
+            agent.run_agent_for_pid(
+                pid="1000B",
+                statements_dir=tmp_path,
+                fetcher="http",
+                blog_limit=1,
+                deadline_sec=10,
+                selector_timeout_sec=5,
+            )
+        )
+
+    assert result.bundle["agent_meta"]["source_kind"] == "dynamic"
+    assert "Dynamic official explanation" in result.bundle["sections"][0]["solution"]
+
+
+
+def test_repair_concatenated_heading_from_old_cf_blog():
+    section = agent.Section(
+        label="C",
+        title="Sereja and SubsequencesIt is clear that we need to calculate the sum of products. " * 3,
+        hint="",
+        solution="",
+        code_blocks=[],
+        raw_text="",
+    )
+
+    repaired = agent._repair_concatenated_heading(section, "Sereja and Subsequences")
+
+    assert repaired.title == "Sereja and Subsequences"
+    assert repaired.solution.startswith("It is clear")
+    assert len(repaired.solution) >= agent.MIN_EDITORIAL_LEN
+
+
+def test_parse_old_problem_sections_handles_problem_headings():
+    text = "Problem A\nEasy text.\n\nPorblem B\n" + ("Target explanation. " * 10) + "\n\nProblem C\nOther text."
+    sections = agent.parse_old_problem_sections(text)
+    labels = [section.label for section in sections]
+    assert "A" in labels
+    assert "B" in labels
+    b = [section for section in sections if section.label == "B"][0]
+    assert "Target explanation" in b.solution
+
+
+def test_selector_disables_reasoning_effort(monkeypatch):
+    calls = []
+    candidate = agent.EditorialCandidate(
+        candidate_id="c1",
+        tutorial_url="https://codeforces.com/blog/entry/1",
+        tutorial_title="Editorial",
+        source_kind="old_problem_section",
+        label="G",
+        title="Problem G",
+        section=agent.Section(
+            label="G",
+            title="Problem G",
+            hint="",
+            solution="Detailed official explanation " * 8,
+            code_blocks=[],
+            raw_text="Detailed official explanation " * 8,
+        ),
+    )
+
+    async def fake_chat_completion(*args, **kwargs):
+        calls.append(kwargs)
+        return ChatCompletionResult(
+            text=json.dumps({"match": True, "candidate_id": "c1", "confidence": 0.9, "reason": "ok"})
+        )
+
+    monkeypatch.setattr(agent, "chat_completion", fake_chat_completion)
+    selected, confidence, _reason = asyncio.run(
+        agent.select_candidate(
+            pid="39G",
+            problem_title="Inverse Function",
+            problem_text="statement",
+            candidates=[candidate],
+            timeout=5,
+            llm_text_limit=1000,
+        )
+    )
+
+    assert selected.candidate_id == "c1"
+    assert confidence == 0.9
+    assert calls[0]["send_reasoning_effort"] is False

--- a/tools/cf_tutorial_agent.py
+++ b/tools/cf_tutorial_agent.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python3
+"""Lightweight LLM harness for Codeforces official editorial discovery.
+
+This is intentionally not a general web agent. It fetches a small, bounded set
+of Codeforces pages, asks the configured LLM to choose the matching candidate,
+and writes the existing tutorials/{pid}.json schema only for high-confidence
+matches.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import json
+import re
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urldefrag, urljoin
+
+from kouhai_bot.handlers.shared import robust_json_parse
+from kouhai_bot.llm import chat_completion
+from kouhai_bot.tutorials import MIN_EDITORIAL_LEN, extract_editorial
+
+from scrape_cf_tutorial import ScrapeError
+from scrape_cf_tutorial import Section
+from scrape_cf_tutorial import build_problem_url_from_pid
+from scrape_cf_tutorial import extract_blog_body_html
+from scrape_cf_tutorial import extract_page_title
+from scrape_cf_tutorial import extract_problem_title
+from scrape_cf_tutorial import fetch_dynamic_editorial
+from scrape_cf_tutorial import fetch_html
+from scrape_cf_tutorial import html_to_markdownish
+from scrape_cf_tutorial import parse_legacy_title_sections
+from scrape_cf_tutorial import parse_pid
+from scrape_cf_tutorial import parse_sections
+
+
+DEFAULT_DEADLINE_SEC = 150
+DEFAULT_CANDIDATE_LIMIT = 3
+DEFAULT_CONFIDENCE_THRESHOLD = 0.75
+DEFAULT_SELECTOR_TIMEOUT_SEC = 40
+DEFAULT_LLM_TEXT_LIMIT = 4500
+
+
+class AgentNoMatch(RuntimeError):
+    """Expected no-result outcome. The caller should not write a tutorial JSON."""
+
+
+@dataclass(frozen=True)
+class EditorialCandidate:
+    candidate_id: str
+    tutorial_url: str
+    tutorial_title: str
+    source_kind: str
+    label: str
+    title: str
+    section: Section
+
+    def extracted_text(self) -> str:
+        return extract_editorial(self.section.as_dict())
+
+    def llm_text(self, limit: int) -> str:
+        text = self.extracted_text() or self.section.raw_text
+        text = re.sub(r"```[\s\S]*?```", "\n(代码块略)\n", text).strip()
+        if len(text) <= limit:
+            return text
+        return text[: limit - 20] + "\n...(已截断)"
+
+
+@dataclass(frozen=True)
+class AgentResult:
+    pid: str
+    bundle: dict[str, Any]
+    selected_candidate_id: str
+    confidence: float
+    reason: str
+    elapsed_sec: float
+    candidate_count: int
+
+
+def load_statement(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ScrapeError(f"无法读取题面 JSON: {path} ({exc})", 7) from exc
+    if not isinstance(data, dict):
+        raise ScrapeError(f"题面 JSON 不是对象: {path}", 7)
+    return data
+
+
+def statement_to_text(stmt: dict[str, Any], *, limit: int = 12000) -> str:
+    parts: list[str] = []
+    if stmt.get("name"):
+        parts.append(f"Problem: {stmt['name']}")
+    if stmt.get("time_limit"):
+        parts.append(f"Time limit: {stmt['time_limit']}")
+    if stmt.get("memory_limit"):
+        parts.append(f"Memory limit: {stmt['memory_limit']}")
+    for label, key in [
+        ("Description", "description"),
+        ("Input", "input"),
+        ("Output", "output"),
+        ("Notes", "notes"),
+    ]:
+        value = str(stmt.get(key) or "").strip()
+        if value:
+            parts.append(f"\n{label}:\n{value}")
+    samples = stmt.get("samples") or []
+    if isinstance(samples, list):
+        for sample in samples[:2]:
+            if not isinstance(sample, dict):
+                continue
+            parts.append(
+                "\nSample:\n"
+                f"Input:\n{sample.get('input', '')}\n"
+                f"Output:\n{sample.get('output', '')}"
+            )
+    text = "\n".join(parts).strip()
+    if len(text) > limit:
+        return text[: limit - 20] + "\n...(题面已截断)"
+    return text
+
+
+def extract_blog_links(problem_html: str, base_url: str, *, limit: int) -> list[str]:
+    anchor_re = re.compile(
+        r"<a[^>]+href\s*=\s*['\"](?P<href>[^'\"]+)['\"][^>]*>(?P<text>[\s\S]*?)</a>",
+        re.I,
+    )
+    seen: set[str] = set()
+    scored: list[tuple[int, int, str]] = []
+    for pos, match in enumerate(anchor_re.finditer(problem_html)):
+        href = match.group("href")
+        if "/blog/entry/" not in href.lower():
+            continue
+        text = re.sub(r"<[^>]+>", " ", match.group("text"))
+        text = html.unescape(re.sub(r"\s+", " ", text)).strip().lower()
+        url = urldefrag(urljoin(base_url, href))[0]
+        if url in seen:
+            continue
+        seen.add(url)
+        score = 0
+        if "tutorial" in text or "editorial" in text:
+            score += 100
+        if "announcement" in text or "standings" in text:
+            score -= 20
+        scored.append((-score, pos, url))
+    scored.sort()
+    return [url for _, _, url in scored[: max(1, limit)]]
+
+
+def _section_from_block(label: str, title: str, block: str) -> Section:
+    code_blocks = [
+        code.strip()
+        for code in re.findall(r"```(?:[^\n`]*)\n([\s\S]*?)\n```", block)
+        if code.strip()
+    ]
+    text_without_code = re.sub(
+        r"```(?:[^\n`]*)\n[\s\S]*?\n```", "", block
+    ).strip()
+    return Section(
+        label=label,
+        title=title.strip(),
+        hint="",
+        solution=text_without_code,
+        code_blocks=code_blocks,
+        raw_text=block.strip(),
+    )
+
+
+def parse_old_problem_sections(markdownish: str) -> list[Section]:
+    heading_re = re.compile(
+        r"(?im)(?:^|\n)\s*(?:Problem|Porblem)\s+([A-Z](?:\d+)?)\b\s*"
+    )
+    matches = list(heading_re.finditer(markdownish))
+    sections: list[Section] = []
+    for idx, match in enumerate(matches):
+        label = match.group(1).upper()
+        title_start = match.end()
+        block_end = matches[idx + 1].start() if idx + 1 < len(matches) else len(markdownish)
+        block = markdownish[title_start:block_end].strip()
+        if not block:
+            continue
+        lines = block.splitlines()
+        first = lines[0].strip() if lines else ""
+        if first and len(first) <= 120 and not first.endswith("."):
+            title = first
+            body = "\n".join(lines[1:]).strip()
+        else:
+            title = f"Problem {label}"
+            body = block
+        sections.append(_section_from_block(label, title, body or block))
+    return sections
+
+
+def _candidate_quality_key(candidate: EditorialCandidate) -> tuple[int, int]:
+    text = candidate.extracted_text()
+    preferred_source = 0 if candidate.source_kind == "dynamic" else 1
+    enough_text = 0 if len(text) >= MIN_EDITORIAL_LEN else 1
+    return (enough_text, preferred_source)
+
+
+def _repair_concatenated_heading(section: Section, problem_title: str) -> Section:
+    if section.raw_text.strip() or section.hint.strip() or section.solution.strip():
+        return section
+    expected_title = (problem_title or "").strip()
+    parsed_title = section.title.strip()
+    if not expected_title or not parsed_title.startswith(expected_title):
+        return section
+    body = parsed_title[len(expected_title):].strip()
+    if len(body) < MIN_EDITORIAL_LEN:
+        return section
+    return Section(
+        label=section.label,
+        title=expected_title,
+        hint="",
+        solution=body,
+        code_blocks=section.code_blocks,
+        raw_text=body,
+    )
+
+
+def collect_candidates_for_blog(
+    *,
+    pid: str,
+    problem_title: str,
+    tutorial_url: str,
+    fetcher: str,
+    pw_wait_ms: int,
+    per_blog_limit: int = 4,
+) -> tuple[str, list[EditorialCandidate]]:
+    _, target_index = parse_pid(pid)
+    target_index = target_index.upper()
+    tutorial_html = fetch_html(tutorial_url, fetcher=fetcher, pw_wait_ms=pw_wait_ms)
+    tutorial_title = extract_page_title(tutorial_html)
+
+    candidates: list[EditorialCandidate] = []
+    dynamic_title, dynamic_text = fetch_dynamic_editorial(
+        tutorial_url=tutorial_url,
+        tutorial_html=tutorial_html,
+        problem_code=pid,
+    )
+    if dynamic_text.strip():
+        candidates.append(
+            EditorialCandidate(
+                candidate_id="",
+                tutorial_url=tutorial_url,
+                tutorial_title=tutorial_title,
+                source_kind="dynamic",
+                label=target_index,
+                title=dynamic_title or problem_title,
+                section=Section(
+                    label=target_index,
+                    title=dynamic_title or problem_title,
+                    hint="",
+                    solution=dynamic_text.strip(),
+                    code_blocks=[],
+                    raw_text=dynamic_text.strip(),
+                ),
+            )
+        )
+
+    body_html = extract_blog_body_html(tutorial_html)
+    markdownish = html_to_markdownish(body_html)
+    try:
+        parsed_sections = parse_sections(markdownish)
+    except ScrapeError:
+        parsed_sections = []
+
+    for section in parsed_sections:
+        if section.label.upper() == target_index:
+            section = _repair_concatenated_heading(section, problem_title)
+            candidates.append(
+                EditorialCandidate(
+                    candidate_id="",
+                    tutorial_url=tutorial_url,
+                    tutorial_title=tutorial_title,
+                    source_kind="section",
+                    label=section.label,
+                    title=section.title,
+                    section=section,
+                )
+            )
+
+    if not candidates:
+        for section in parse_old_problem_sections(markdownish):
+            if section.label.upper() != target_index:
+                continue
+            candidates.append(
+                EditorialCandidate(
+                    candidate_id="",
+                    tutorial_url=tutorial_url,
+                    tutorial_title=tutorial_title,
+                    source_kind="old_problem_section",
+                    label=section.label,
+                    title=section.title,
+                    section=section,
+                )
+            )
+            if len(candidates) >= per_blog_limit:
+                break
+
+    if not candidates:
+        for legacy_title, block in parse_legacy_title_sections(markdownish):
+            candidates.append(
+                EditorialCandidate(
+                    candidate_id="",
+                    tutorial_url=tutorial_url,
+                    tutorial_title=tutorial_title,
+                    source_kind="legacy_section",
+                    label=target_index,
+                    title=legacy_title,
+                    section=_section_from_block(target_index, legacy_title, block),
+                )
+            )
+            if len(candidates) >= per_blog_limit:
+                break
+
+    if not candidates and markdownish.strip():
+        candidates.append(
+            EditorialCandidate(
+                candidate_id="",
+                tutorial_url=tutorial_url,
+                tutorial_title=tutorial_title,
+                source_kind="whole_blog",
+                label=target_index,
+                title=tutorial_title or problem_title,
+                section=_section_from_block(target_index, tutorial_title or problem_title, markdownish),
+            )
+        )
+
+    candidates = sorted(candidates, key=_candidate_quality_key)
+    return tutorial_title, candidates[:per_blog_limit]
+
+
+def collect_candidates(
+    *,
+    pid: str,
+    fetcher: str,
+    pw_wait_ms: int,
+    blog_limit: int,
+) -> tuple[str, str, list[EditorialCandidate]]:
+    problem_url = build_problem_url_from_pid(pid)
+    problem_html = fetch_html(problem_url, fetcher=fetcher, pw_wait_ms=pw_wait_ms)
+    problem_title = extract_problem_title(problem_html)
+    blog_urls = extract_blog_links(problem_html, problem_url, limit=blog_limit)
+    if not blog_urls:
+        raise AgentNoMatch("problem_page_has_no_blog_entry_links")
+
+    all_candidates: list[EditorialCandidate] = []
+    for blog_url in blog_urls:
+        try:
+            _, candidates = collect_candidates_for_blog(
+                pid=pid,
+                problem_title=problem_title,
+                tutorial_url=blog_url,
+                fetcher=fetcher,
+                pw_wait_ms=pw_wait_ms,
+            )
+        except ScrapeError:
+            continue
+        all_candidates.extend(candidates)
+
+    if not all_candidates:
+        raise AgentNoMatch("no_parseable_candidates_from_blog_entries")
+
+    numbered: list[EditorialCandidate] = []
+    for idx, candidate in enumerate(all_candidates, start=1):
+        numbered.append(
+            EditorialCandidate(
+                candidate_id=f"c{idx}",
+                tutorial_url=candidate.tutorial_url,
+                tutorial_title=candidate.tutorial_title,
+                source_kind=candidate.source_kind,
+                label=candidate.label,
+                title=candidate.title,
+                section=candidate.section,
+            )
+        )
+    return problem_url, problem_title, numbered
+
+
+def _build_selector_messages(
+    *,
+    pid: str,
+    problem_title: str,
+    problem_text: str,
+    candidates: list[EditorialCandidate],
+    llm_text_limit: int,
+) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for candidate in candidates:
+        rows.append(
+            {
+                "id": candidate.candidate_id,
+                "url": candidate.tutorial_url,
+                "blog_title": candidate.tutorial_title,
+                "source_kind": candidate.source_kind,
+                "section_label": candidate.label,
+                "section_title": candidate.title,
+                "text": candidate.llm_text(llm_text_limit),
+            }
+        )
+
+    payload = {
+        "pid": pid,
+        "problem_title": problem_title,
+        "problem": problem_text,
+        "candidates": rows,
+    }
+    return [
+        {
+            "role": "system",
+            "content": (
+                "你是 Codeforces 官方题解 oncall。你会收到一道题的题面和若干从 "
+                "Codeforces blog 抓到的候选片段。你的任务只是选择哪个候选片段是在讲这道题。"
+                "不要生成题解，不要改写候选内容。"
+                "只输出 JSON 对象："
+                "{\"match\":true,\"candidate_id\":\"c1\",\"confidence\":0.0到1.0,\"reason\":\"...\"} "
+                "或 {\"match\":false,\"reason\":\"...\"}。"
+                "判断时比较题意目标、输入输出、关键变量、算法对象、约束和候选中的结论。"
+                "如果只是同一个题号字母但题意明显不同，必须 match=false。"
+                "如果候选只是代码、作者信息、目录、占位或太短，必须 match=false。"
+                "只有候选足以作为官方题解/教程正文时才 match=true。"
+            ),
+        },
+        {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
+    ]
+
+
+async def select_candidate(
+    *,
+    pid: str,
+    problem_title: str,
+    problem_text: str,
+    candidates: list[EditorialCandidate],
+    timeout: int,
+    llm_text_limit: int,
+) -> tuple[EditorialCandidate, float, str]:
+    result = await chat_completion(
+        _build_selector_messages(
+            pid=pid,
+            problem_title=problem_title,
+            problem_text=problem_text,
+            candidates=candidates,
+            llm_text_limit=llm_text_limit,
+        ),
+        task="summary",
+        temperature=0.0,
+        timeout=timeout,
+        response_format={"type": "json_object"},
+        send_reasoning_effort=False,
+    )
+    if not result.text:
+        raise AgentNoMatch(f"selector_llm_failed:{result.failure_kind}")
+    parsed = robust_json_parse(result.text)
+    if parsed.get("match") is not True:
+        raise AgentNoMatch(str(parsed.get("reason") or "selector_no_match"))
+    candidate_id = str(parsed.get("candidate_id") or "").strip()
+    try:
+        confidence = float(parsed.get("confidence"))
+    except (TypeError, ValueError):
+        confidence = 0.0
+    reason = str(parsed.get("reason") or "").strip()
+    by_id = {candidate.candidate_id: candidate for candidate in candidates}
+    candidate = by_id.get(candidate_id)
+    if not candidate:
+        raise AgentNoMatch(f"selector_unknown_candidate:{candidate_id}")
+    return candidate, confidence, reason
+
+
+def build_bundle(
+    *,
+    pid: str,
+    problem_url: str,
+    selected: EditorialCandidate,
+    confidence: float,
+    reason: str,
+    candidate_count: int,
+    elapsed_sec: float,
+) -> dict[str, Any]:
+    section = selected.section.as_dict()
+    return {
+        "problem_url": problem_url,
+        "problem_id": pid,
+        "tutorial_url": selected.tutorial_url,
+        "tutorial_title": selected.tutorial_title,
+        "sections": [section],
+        "agent_meta": {
+            "tool": "cf_tutorial_agent",
+            "selected_candidate_id": selected.candidate_id,
+            "source_kind": selected.source_kind,
+            "confidence": confidence,
+            "reason": reason,
+            "candidate_count": candidate_count,
+            "elapsed_sec": round(elapsed_sec, 3),
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+        },
+    }
+
+
+async def run_agent_for_pid(
+    *,
+    pid: str,
+    statements_dir: Path,
+    fetcher: str = "auto",
+    pw_wait_ms: int = 7000,
+    blog_limit: int = DEFAULT_CANDIDATE_LIMIT,
+    deadline_sec: int = DEFAULT_DEADLINE_SEC,
+    selector_timeout_sec: int = DEFAULT_SELECTOR_TIMEOUT_SEC,
+    confidence_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD,
+    llm_text_limit: int = DEFAULT_LLM_TEXT_LIMIT,
+) -> AgentResult:
+    started = time.monotonic()
+    stmt = load_statement(statements_dir / f"{pid}.json")
+    problem_text = statement_to_text(stmt)
+
+    async def _run() -> AgentResult:
+        problem_url, problem_title, candidates = await asyncio.to_thread(
+            collect_candidates,
+            pid=pid,
+            fetcher=fetcher,
+            pw_wait_ms=pw_wait_ms,
+            blog_limit=blog_limit,
+        )
+        selected, confidence, reason = await select_candidate(
+            pid=pid,
+            problem_title=problem_title or str(stmt.get("name") or ""),
+            problem_text=problem_text,
+            candidates=candidates,
+            timeout=selector_timeout_sec,
+            llm_text_limit=llm_text_limit,
+        )
+        if confidence < confidence_threshold:
+            raise AgentNoMatch(
+                f"selector_low_confidence:{confidence:.2f}:{reason or selected.candidate_id}"
+            )
+        elapsed = time.monotonic() - started
+        bundle = build_bundle(
+            pid=pid,
+            problem_url=problem_url,
+            selected=selected,
+            confidence=confidence,
+            reason=reason,
+            candidate_count=len(candidates),
+            elapsed_sec=elapsed,
+        )
+        return AgentResult(
+            pid=pid,
+            bundle=bundle,
+            selected_candidate_id=selected.candidate_id,
+            confidence=confidence,
+            reason=reason,
+            elapsed_sec=elapsed,
+            candidate_count=len(candidates),
+        )
+
+    try:
+        return await asyncio.wait_for(_run(), timeout=max(1, deadline_sec))
+    except asyncio.TimeoutError as exc:
+        raise AgentNoMatch(f"deadline_exceeded:{deadline_sec}s") from exc
+

--- a/tools/scrape_cf_tutorial.py
+++ b/tools/scrape_cf_tutorial.py
@@ -1,26 +1,20 @@
 #!/usr/bin/env python3
-"""
-Scrape Codeforces tutorial/editorial by problem URL.
+"""Low-level Codeforces HTML helpers used by cf_tutorial_agent.py.
 
-Current supported tutorial style (v1):
-- Editorial page split by problem sections like:
-  #### A - ...
-  #### B - ...
-- Inside each section, parse Hint / Solution / Code.
+This module intentionally does not choose the final tutorial anymore. The LLM
+harness owns candidate selection; helpers here only fetch pages, normalize HTML,
+load dynamic Codeforces tutorial fragments, and parse common section shapes.
 """
 
 from __future__ import annotations
 
-import argparse
 import html
 import json
 import os
 import random
 import re
 import string
-import sys
 import time
-import traceback
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -46,9 +40,6 @@ except ImportError:
     PlaywrightTimeoutError = TimeoutError
 
 CF_ROOT = "https://codeforces.com"
-DEFAULT_STATE_DIR = os.path.expanduser("./")
-DEFAULT_STATEMENTS_DIR = os.path.join(DEFAULT_STATE_DIR, "statements")
-DEFAULT_TUTORIALS_DIR = os.path.join(DEFAULT_STATE_DIR, "tutorials")
 
 
 class ScrapeError(RuntimeError):
@@ -293,53 +284,6 @@ def fetch_dynamic_editorial(
     return section_title, "\n".join(lines).strip()
 
 
-def parse_problem_id(problem_url: str) -> str:
-    m = re.search(r"/problem(?:set)?/problem/(\d+)/([A-Za-z0-9]+)", problem_url)
-    if m:
-        return f"{m.group(1)}{m.group(2)}"
-    m2 = re.search(r"/contest/(\d+)/problem/([A-Za-z0-9]+)", problem_url)
-    if m2:
-        return f"{m2.group(1)}{m2.group(2)}"
-    return ""
-
-
-def extract_tutorial_url(problem_html: str, base_url: str) -> str:
-    anchor_pattern = re.compile(
-        r"<a[^>]+href\s*=\s*['\"](?P<href>[^'\"]+)['\"][^>]*>(?P<text>[\s\S]*?)</a>",
-        re.I,
-    )
-    candidates: list[tuple[str, str]] = []
-    for m in anchor_pattern.finditer(problem_html):
-        href = m.group("href")
-        text = re.sub(r"<[^>]+>", " ", m.group("text"))
-        text = html.unescape(re.sub(r"\s+", " ", text)).strip().lower()
-        normalized_href = href.lower()
-        # Some problems provide tutorial only as an external PDF.
-        if (
-            ("tutorial" in text or "editorial" in text)
-            and ("pdf" in text or normalized_href.endswith(".pdf") or ".pdf?" in normalized_href)
-        ):
-            raise ScrapeError(f"Tutorial 为 PDF，跳过提取: {urljoin(base_url, href)}", 11)
-        if "/blog/entry/" not in href.lower():
-            continue
-        candidates.append((href, text))
-        if "tutorial" in text or "editorial" in text:
-            return urljoin(base_url, href)
-
-    # Fallback: if multiple blog entries exist on the page, prefer the largest entry id.
-    if candidates:
-        def _entry_id(h: str) -> int:
-            m = re.search(r"/blog/entry/(\d+)", h, re.I)
-            return int(m.group(1)) if m else -1
-        href, _ = max(candidates, key=lambda x: _entry_id(x[0]))
-        return urljoin(base_url, href)
-
-    m2 = re.search(r"/blog/entry/\d+", problem_html, re.I)
-    if m2:
-        return urljoin(base_url, m2.group(0))
-
-    raise ScrapeError("在题目页中未找到 Tutorial 链接", 3)
-
 
 def extract_page_title(html_text: str) -> str:
     m = re.search(r"<title>([\s\S]*?)</title>", html_text, re.I)
@@ -574,142 +518,6 @@ def parse_sections(markdownish: str) -> list[Section]:
     return sections
 
 
-def build_result(problem_url: str, fetcher: str = "auto", pw_wait_ms: int = 7000) -> dict[str, Any]:
-    parsed = urlparse(problem_url)
-    if not parsed.scheme or not parsed.netloc:
-        raise ScrapeError(f"非法题目链接: {problem_url}", 1)
-
-    normalized_problem_url = problem_url.strip()
-    problem_html = fetch_html(normalized_problem_url, fetcher=fetcher, pw_wait_ms=pw_wait_ms)
-    problem_title = extract_problem_title(problem_html)
-    tutorial_url = extract_tutorial_url(problem_html, normalized_problem_url)
-    tutorial_html = fetch_html(tutorial_url, fetcher=fetcher, pw_wait_ms=pw_wait_ms)
-
-    body_html = extract_blog_body_html(tutorial_html)
-    markdownish = html_to_markdownish(body_html)
-    pid = parse_problem_id(normalized_problem_url)
-    dynamic_title = ""
-    dynamic_hint = ""
-    if pid:
-        dynamic_title, dynamic_hint = fetch_dynamic_editorial(
-            tutorial_url=tutorial_url,
-            tutorial_html=tutorial_html,
-            problem_code=pid,
-        )
-
-    try:
-        sections = parse_sections(markdownish)
-    except ScrapeError:
-        sections = []
-        if pid:
-            _, problem_index = parse_pid(pid)
-            if dynamic_hint:
-                sections = [
-                    Section(
-                        label=problem_index.upper(),
-                        title=dynamic_title,
-                        hint=dynamic_hint,
-                        solution="",
-                        code_blocks=[],
-                        raw_text=markdownish.strip(),
-                    )
-                ]
-            elif problem_title:
-                legacy_sections = parse_legacy_title_sections(markdownish)
-                target_key = _normalize_title_key(problem_title)
-                for legacy_title, legacy_block in legacy_sections:
-                    if _normalize_title_key(legacy_title) == target_key:
-                        code_blocks = [
-                            code.strip()
-                            for code in re.findall(
-                                r"```(?:[^\n`]*)\n([\s\S]*?)\n```", legacy_block
-                            )
-                            if code.strip()
-                        ]
-                        text_without_code = re.sub(
-                            r"```(?:[^\n`]*)\n[\s\S]*?\n```", "", legacy_block
-                        ).strip()
-                        sections = [
-                            Section(
-                                label=problem_index.upper(),
-                                title=legacy_title.strip(),
-                                hint="",
-                                solution=text_without_code,
-                                code_blocks=code_blocks,
-                                raw_text=legacy_block,
-                            )
-                        ]
-                        break
-        if not sections:
-            raise
-
-    # Keep only the target problem section (e.g. 1000E -> E).
-    if pid:
-        _, problem_index = parse_pid(pid)
-        target = problem_index.upper()
-        matched = [s for s in sections if s.label.upper() == target]
-        if matched:
-            sections = matched
-
-    # Some tutorial pages load Editorial via AJAX (/data/problemTutorial).
-    # If we only got placeholder text, try fetching the dynamic editorial.
-    if pid:
-        for sec in sections:
-            needs_dynamic = (
-                re.search(r"Tutorial is loading", sec.raw_text, flags=re.I)
-                or re.search(r"Tutorial is loading", sec.hint, flags=re.I)
-                or re.search(r"Tutorial is loading", sec.solution, flags=re.I)
-                or (
-                    not sec.hint.strip()
-                    and not sec.solution.strip()
-                    and len(sec.code_blocks) == 0
-                    and dynamic_hint.strip() != ""
-                )
-            )
-            if needs_dynamic:
-                if dynamic_hint:
-                    if re.search(r"\bTutorial\b", sec.raw_text, flags=re.I):
-                        if not sec.solution.strip() or re.search(
-                            r"Tutorial is loading", sec.solution, flags=re.I
-                        ):
-                            sec.solution = dynamic_hint
-                        if re.search(r"Tutorial is loading", sec.hint, flags=re.I):
-                            sec.hint = ""
-                    elif not sec.hint.strip() and not sec.solution.strip():
-                        # If static section parse produced an empty block, treat dynamic
-                        # payload as the main solution text instead of a hint.
-                        sec.solution = dynamic_hint
-                    else:
-                        sec.hint = dynamic_hint
-                if dynamic_title and not sec.title:
-                    sec.title = dynamic_title
-
-    # Normalize: for tutorial-styled pages, keep explanation in solution field.
-    for sec in sections:
-        if (
-            sec.hint.strip()
-            and (
-                not sec.solution.strip()
-                or re.search(r"Tutorial is loading", sec.solution, flags=re.I)
-            )
-            and re.search(r"\bTutorial\b", sec.raw_text, flags=re.I)
-        ):
-            sec.solution = sec.hint
-            sec.hint = ""
-
-    # Always drop known loading placeholders from final fields.
-    for sec in sections:
-        sec.hint = _strip_loading_placeholder(sec.hint)
-        sec.solution = _strip_loading_placeholder(sec.solution)
-
-    return {
-        "problem_url": normalized_problem_url,
-        "problem_id": pid,
-        "tutorial_url": tutorial_url,
-        "tutorial_title": extract_page_title(tutorial_html),
-        "sections": [s.as_dict() for s in sections],
-    }
-
 
 def parse_pid(pid: str) -> tuple[str, str]:
     m = re.fullmatch(r"(\d+)([A-Za-z0-9]+)", pid.strip())
@@ -736,58 +544,3 @@ def list_statement_pids(statements_dir: str) -> list[str]:
     if not pids:
         raise ScrapeError(f"statements 目录下未找到题号 JSON: {statements_dir}", 8)
     return pids
-
-
-def main():
-    parser = argparse.ArgumentParser(
-        description=(
-            "Scrape one Codeforces tutorial by problem URL (low-level). "
-            "Batch crawl from statements/ → tutorials/ use tools/tutorial_tools.py crawl."
-        )
-    )
-    parser.add_argument("--problem-url", required=True, help="Codeforces problem URL")
-    parser.add_argument("--output", help="Write JSON output to a file")
-    parser.add_argument(
-        "--fetcher",
-        choices=["auto", "http", "playwright"],
-        default="auto",
-        help="Fetch backend. auto=HTTP then Playwright fallback when anti-bot challenged",
-    )
-    parser.add_argument(
-        "--pw-wait-ms",
-        type=int,
-        default=7000,
-        help="Extra wait time in milliseconds when using Playwright",
-    )
-    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
-    args = parser.parse_args()
-
-    try:
-        result = build_result(
-            args.problem_url,
-            fetcher=args.fetcher,
-            pw_wait_ms=max(0, args.pw_wait_ms),
-        )
-    except ScrapeError as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        sys.exit(exc.code)
-
-    payload = json.dumps(
-        result,
-        ensure_ascii=False,
-        indent=2 if args.pretty else None,
-    )
-    if args.output:
-        with open(args.output, "w", encoding="utf-8") as f:
-            f.write(payload)
-            if args.pretty:
-                f.write("\n")
-    else:
-        try:
-            print(payload)
-        except UnicodeEncodeError:
-            sys.stdout.buffer.write((payload + "\n").encode("utf-8"))
-
-
-if __name__ == "__main__":
-    main()

--- a/tools/tutorial_tools.py
+++ b/tools/tutorial_tools.py
@@ -13,8 +13,6 @@ import asyncio
 import json
 import os
 import sys
-import time
-import traceback
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,13 +22,20 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "src"))
 
 from kouhai_bot.config import get_config
-from kouhai_bot.handlers.shared import robust_json_parse
+from kouhai_bot.handlers.shared import robust_json_parse, translate_editorial_to_zh
 from kouhai_bot.llm import chat_completion
 from kouhai_bot.tutorials import MIN_EDITORIAL_LEN, _is_placeholder, extract_editorial
 
+from cf_tutorial_agent import AgentNoMatch
+from cf_tutorial_agent import DEFAULT_CANDIDATE_LIMIT
+from cf_tutorial_agent import DEFAULT_CONFIDENCE_THRESHOLD
+from cf_tutorial_agent import DEFAULT_DEADLINE_SEC
+from cf_tutorial_agent import DEFAULT_LLM_TEXT_LIMIT
+from cf_tutorial_agent import DEFAULT_SELECTOR_TIMEOUT_SEC
+from cf_tutorial_agent import load_statement
+from cf_tutorial_agent import run_agent_for_pid
+from cf_tutorial_agent import statement_to_text
 from scrape_cf_tutorial import ScrapeError
-from scrape_cf_tutorial import build_problem_url_from_pid
-from scrape_cf_tutorial import build_result
 from scrape_cf_tutorial import list_statement_pids
 
 DEFAULT_STATEMENTS_DIR = str(ROOT / "statements")
@@ -114,103 +119,128 @@ def _write_tutorial(path: Path, bundle: dict, *, pretty: bool) -> None:
     path.write_text(payload + ("\n" if pretty else ""), encoding="utf-8")
 
 
-def _crawl_pid(
+async def _translate_agent_bundle(
+    *,
+    pid: str,
+    bundle: dict,
+    statements_dir: Path,
+    tutorials_dir: Path,
+    timeout: int,
+) -> tuple[bool, str]:
+    sections = bundle.get("sections") or []
+    if not sections or not isinstance(sections[0], dict):
+        return False, "no_section"
+    editorial_text = extract_editorial(sections[0])
+    if len(editorial_text) < MIN_EDITORIAL_LEN:
+        return False, "editorial_too_short"
+    stmt = load_statement(statements_dir / f"{pid}.json")
+    problem_text = statement_to_text(stmt)
+    try:
+        translated, model_tag, matched = await asyncio.wait_for(
+            translate_editorial_to_zh(
+                editorial_text,
+                pid=pid,
+                problem_text=problem_text,
+            ),
+            timeout=max(1, timeout),
+        )
+    except asyncio.TimeoutError:
+        return False, "translation_timeout"
+    if matched is False:
+        return False, "translation_mismatch"
+    if not translated or len(translated.strip()) < MIN_EDITORIAL_LEN:
+        return False, "translation_empty"
+
+    cache_dir = tutorials_dir.parent / "tutorial_translations"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    full_text = (translated.strip() + model_tag).strip() if model_tag else translated.strip()
+    (cache_dir / f"{pid}.txt").write_text(full_text, encoding="utf-8")
+    (cache_dir / f"{pid}.verified").write_text("", encoding="utf-8")
+    no_editorial = cache_dir / f"{pid}.no_editorial"
+    if no_editorial.is_file():
+        no_editorial.unlink()
+    return True, "translated"
+
+
+def _run_agent_sync(
     pid: str,
     *,
-    out_path: Path,
+    statements_dir: Path,
+    tutorials_dir: Path,
     fetcher: str,
     pw_wait_ms: int,
     pretty: bool,
-    max_attempts: int,
-    retry_sleep_seconds: float,
+    blog_limit: int,
+    deadline_sec: int,
+    selector_timeout_sec: int,
+    confidence_threshold: float,
+    llm_text_limit: int,
+    translate: bool,
+    translate_timeout_sec: int,
 ) -> CrawlOutcome:
-    last_reason = ""
-    last_error = ""
-
-    for attempt in range(1, max_attempts + 1):
-        problem_url = build_problem_url_from_pid(pid)
-        try:
-            bundle = build_result(
-                problem_url,
+    out_path = tutorials_dir / f"{pid}.json"
+    try:
+        result = asyncio.run(
+            run_agent_for_pid(
+                pid=pid,
+                statements_dir=statements_dir,
                 fetcher=fetcher,
-                pw_wait_ms=pw_wait_ms,
+                pw_wait_ms=max(0, pw_wait_ms),
+                blog_limit=max(1, blog_limit),
+                deadline_sec=max(1, deadline_sec),
+                selector_timeout_sec=max(1, selector_timeout_sec),
+                confidence_threshold=max(0.0, min(1.0, confidence_threshold)),
+                llm_text_limit=max(800, llm_text_limit),
             )
-        except ScrapeError as exc:
-            last_error = str(exc)
-            if exc.code == 11:
-                return CrawlOutcome(
-                    pid=pid,
-                    status="skipped_pdf",
-                    attempts=attempt,
-                    error=last_error,
-                )
-            if attempt < max_attempts:
-                print(f"[RETRY_SCRAPE] {pid} attempt={attempt} error={exc}")
-                if retry_sleep_seconds > 0:
-                    time.sleep(retry_sleep_seconds)
-                continue
-            if out_path.is_file():
-                out_path.unlink()
-            return CrawlOutcome(
-                pid=pid,
-                status="scrape_failed",
-                attempts=attempt,
-                error=last_error,
-            )
-        except Exception as exc:
-            last_error = str(exc)
-            if attempt < max_attempts:
-                print(f"[RETRY_SCRAPE] {pid} attempt={attempt} error={exc}")
-                if retry_sleep_seconds > 0:
-                    time.sleep(retry_sleep_seconds)
-                continue
-            if out_path.is_file():
-                out_path.unlink()
-            return CrawlOutcome(
-                pid=pid,
-                status="scrape_failed",
-                attempts=attempt,
-                error=last_error,
-            )
+        )
+    except AgentNoMatch as exc:
+        if out_path.is_file():
+            out_path.unlink()
+        return CrawlOutcome(pid=pid, status="agent_no_match", attempts=1, error=str(exc))
+    except ScrapeError as exc:
+        if out_path.is_file():
+            out_path.unlink()
+        return CrawlOutcome(pid=pid, status="scrape_failed", attempts=1, error=str(exc))
 
-        reason = tutorial_quality_reason(bundle) or ""
-        if reason:
-            last_reason = reason
-            print(
-                f"[LOW_QUALITY] {pid} attempt={attempt}/{max_attempts} reason={reason}"
-            )
-            if attempt < max_attempts:
-                if retry_sleep_seconds > 0:
-                    time.sleep(retry_sleep_seconds)
-                continue
-            if out_path.is_file():
-                out_path.unlink()
-            return CrawlOutcome(
+    reason = tutorial_quality_reason(result.bundle) or ""
+    if reason:
+        if out_path.is_file():
+            out_path.unlink()
+        return CrawlOutcome(
+            pid=pid,
+            status="quality_failed",
+            attempts=1,
+            quality_reason=reason,
+        )
+
+    _write_tutorial(out_path, result.bundle, pretty=pretty)
+
+    status = "agent_ok"
+    if translate:
+        translated, translate_reason = asyncio.run(
+            _translate_agent_bundle(
                 pid=pid,
-                status="quality_failed",
-                attempts=attempt,
-                quality_reason=last_reason,
+                bundle=result.bundle,
+                statements_dir=statements_dir,
+                tutorials_dir=tutorials_dir,
+                timeout=translate_timeout_sec,
             )
+        )
+        if translated:
+            status = "agent_ok_translated"
+        else:
+            print(f"[TRANSLATE_SKIP] {pid} reason={translate_reason}")
 
-        _write_tutorial(out_path, bundle, pretty=pretty)
-        status = "ok" if attempt == 1 else "ok_after_retry"
-        return CrawlOutcome(pid=pid, status=status, attempts=attempt)
-
-    if out_path.is_file():
-        out_path.unlink()
-    return CrawlOutcome(
-        pid=pid,
-        status="quality_failed",
-        attempts=max_attempts,
-        quality_reason=last_reason or "unknown",
-        error=last_error,
+    print(
+        f"[AGENT_SELECT] {pid} candidate={result.selected_candidate_id} "
+        f"confidence={result.confidence:.2f} candidates={result.candidate_count} "
+        f"elapsed={result.elapsed_sec:.1f}s reason={result.reason}"
     )
+    return CrawlOutcome(pid=pid, status=status, attempts=1)
+
 
 
 def cmd_crawl(args: argparse.Namespace) -> None:
-    if args.max_attempts < 1:
-        raise SystemExit("--max-attempts 至少为 1")
-
     statements_dir = Path(args.statements_dir)
     tutorials_dir = Path(args.tutorials_dir)
     tutorials_dir.mkdir(parents=True, exist_ok=True)
@@ -230,7 +260,7 @@ def cmd_crawl(args: argparse.Namespace) -> None:
 
     print(
         f"[INFO] statements={statements_dir} tutorials={tutorials_dir} "
-        f"total={len(pids)} max_attempts={args.max_attempts} "
+        f"total={len(pids)} mode=agent "
         f"skip_existing={args.skip_existing} force={args.force}"
     )
 
@@ -254,14 +284,20 @@ def cmd_crawl(args: argparse.Namespace) -> None:
                 continue
 
         try:
-            outcome = _crawl_pid(
+            outcome = _run_agent_sync(
                 pid,
-                out_path=out_path,
+                statements_dir=statements_dir,
+                tutorials_dir=tutorials_dir,
                 fetcher=args.fetcher,
                 pw_wait_ms=max(0, args.pw_wait_ms),
                 pretty=args.pretty,
-                max_attempts=args.max_attempts,
-                retry_sleep_seconds=max(0.0, args.retry_sleep_seconds),
+                blog_limit=args.candidate_limit,
+                deadline_sec=args.deadline_sec,
+                selector_timeout_sec=args.selector_timeout_sec,
+                confidence_threshold=args.confidence_threshold,
+                llm_text_limit=args.llm_text_limit,
+                translate=args.translate,
+                translate_timeout_sec=args.translate_timeout_sec,
             )
         except Exception as exc:
             outcome = CrawlOutcome(
@@ -271,13 +307,12 @@ def cmd_crawl(args: argparse.Namespace) -> None:
                 error=str(exc),
             )
             print(f"[FAIL] {pid}: {exc}")
-            traceback.print_exc()
 
         outcomes.append(outcome)
         counts[outcome.status] = counts.get(outcome.status, 0) + 1
 
         tag = outcome.status.upper()
-        if outcome.status.startswith("ok"):
+        if outcome.status.startswith("ok") or outcome.status.startswith("agent_ok"):
             print(f"[{tag}] {pid} -> {out_path} attempts={outcome.attempts}")
         else:
             detail = outcome.quality_reason or outcome.error
@@ -292,8 +327,40 @@ def cmd_crawl(args: argparse.Namespace) -> None:
         "total": len(pids),
         "counts": counts,
         "quality_failed": [o.as_dict() for o in outcomes if o.status == "quality_failed"],
+        "agent_no_match": [o.as_dict() for o in outcomes if o.status == "agent_no_match"],
+        "scrape_failed": [o.as_dict() for o in outcomes if o.status == "scrape_failed"],
     }
     print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+
+def cmd_agent(args: argparse.Namespace) -> None:
+    statements_dir = Path(args.statements_dir)
+    tutorials_dir = Path(args.tutorials_dir)
+    tutorials_dir.mkdir(parents=True, exist_ok=True)
+    os.environ["SCRAPE_REQUEST_WAIT_SECONDS"] = str(max(0.0, args.request_wait_seconds))
+
+    outcome = _run_agent_sync(
+        args.pid,
+        statements_dir=statements_dir,
+        tutorials_dir=tutorials_dir,
+        fetcher=args.fetcher,
+        pw_wait_ms=max(0, args.pw_wait_ms),
+        pretty=args.pretty,
+        blog_limit=args.candidate_limit,
+        deadline_sec=args.deadline_sec,
+        selector_timeout_sec=args.selector_timeout_sec,
+        confidence_threshold=args.confidence_threshold,
+        llm_text_limit=args.llm_text_limit,
+        translate=args.translate,
+        translate_timeout_sec=args.translate_timeout_sec,
+    )
+    out_path = tutorials_dir / f"{args.pid}.json"
+    print(json.dumps({
+        **outcome.as_dict(),
+        "output": str(out_path) if out_path.is_file() else "",
+    }, ensure_ascii=False, indent=2))
+    if not outcome.status.startswith("agent_ok"):
+        raise SystemExit(2)
 
 
 # ---------------------------------------------------------------------------
@@ -530,7 +597,7 @@ def cmd_validate(args: argparse.Namespace) -> None:
 
 
 def _add_crawl_parser(sub: argparse._SubParsersAction) -> None:
-    p = sub.add_parser("crawl", help="根据 statements 题号爬取题解到 tutorials")
+    p = sub.add_parser("crawl", help="根据 statements 题号用 LLM harness 爬取题解到 tutorials")
     p.add_argument("--statements-dir", default=DEFAULT_STATEMENTS_DIR)
     p.add_argument("--tutorials-dir", default=DEFAULT_TUTORIALS_DIR)
     p.add_argument(
@@ -539,15 +606,37 @@ def _add_crawl_parser(sub: argparse._SubParsersAction) -> None:
         help="若 tutorials 中已有题解文件则跳过（不论质量）",
     )
     p.add_argument("--force", action="store_true", help="即使已有文件也重新爬取")
-    p.add_argument("--max-attempts", type=int, default=2)
     p.add_argument("--sleep-seconds", type=float, default=10.0)
-    p.add_argument("--retry-sleep-seconds", type=float, default=3.0)
     p.add_argument("--request-wait-seconds", type=float, default=10.0)
     p.add_argument("--fetcher", choices=["auto", "http", "playwright"], default="auto")
     p.add_argument("--pw-wait-ms", type=int, default=7000)
     p.add_argument("--pretty", action="store_true")
     p.add_argument("--limit", type=int, default=0, help="仅处理前 N 题（0=全部）")
+    _add_agent_options(p)
     p.set_defaults(func=cmd_crawl)
+
+
+def _add_agent_options(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--candidate-limit", type=int, default=DEFAULT_CANDIDATE_LIMIT)
+    p.add_argument("--deadline-sec", type=int, default=DEFAULT_DEADLINE_SEC)
+    p.add_argument("--selector-timeout-sec", type=int, default=DEFAULT_SELECTOR_TIMEOUT_SEC)
+    p.add_argument("--translate-timeout-sec", type=int, default=75)
+    p.add_argument("--confidence-threshold", type=float, default=DEFAULT_CONFIDENCE_THRESHOLD)
+    p.add_argument("--llm-text-limit", type=int, default=DEFAULT_LLM_TEXT_LIMIT)
+    p.add_argument("--translate", action="store_true", help="题解 JSON 成功后额外写中文翻译缓存")
+
+
+def _add_agent_parser(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser("agent", help="单题轻量 LLM harness 爬取官方题解")
+    p.add_argument("--pid", required=True, help="题号，如 542D")
+    p.add_argument("--statements-dir", default=DEFAULT_STATEMENTS_DIR)
+    p.add_argument("--tutorials-dir", default=DEFAULT_TUTORIALS_DIR)
+    p.add_argument("--request-wait-seconds", type=float, default=0.0)
+    p.add_argument("--fetcher", choices=["auto", "http", "playwright"], default="auto")
+    p.add_argument("--pw-wait-ms", type=int, default=7000)
+    p.add_argument("--pretty", action="store_true")
+    _add_agent_options(p)
+    p.set_defaults(func=cmd_agent)
 
 
 def _add_validate_parser(sub: argparse._SubParsersAction) -> None:
@@ -577,6 +666,7 @@ def main() -> None:
     )
     sub = parser.add_subparsers(dest="command", required=True)
     _add_crawl_parser(sub)
+    _add_agent_parser(sub)
     _add_validate_parser(sub)
     args = parser.parse_args()
     args.func(args)


### PR DESCRIPTION
## What changed

- Added a lightweight offline Codeforces editorial harness in `tools/cf_tutorial_agent.py`.
- Extended `tools/tutorial_tools.py` with:
  - `agent --pid ...` for single-problem oncall runs
  - `crawl --agent` for batch runs
  - optional `--translate` cache generation through the existing LLM fallback path
- Kept runtime tutorial consumption schema-compatible with existing `tutorials/{pid}.json`.
- Made tutorial translation load problem statements through `kouhai_bot.tutorials.get_config()` so tests and runtime use one config source.

## Design

The harness is intentionally bounded and fail-closed: it fetches the problem page, collects a small number of `/blog/entry/*` candidates, extracts candidate sections/dynamic tutorial fragments, then asks the configured `summary` LLM provider fallback to choose the matching candidate. It writes JSON only for high-confidence matches and never asks the LLM to invent the English editorial text.

## Live E2E

All outputs were written to `/tmp`, not the real cache.

- `1884D`: success, selected official section in 21.9s.
- `1884D --translate`: success, selected and wrote translation cache in about 36s total.
- `314C`: initially failed `too_short`; investigation showed old CF blog HTML concatenated heading and body. Added a repair path, then success in 29.1s.
- `1010E`: success in 20.1s.
- `240F`: no match. LLM identified only a contest announcement with no tutorial body.
- `1004F`: no match. Candidates were official placeholders (`Will be added soon.`).

## Tests

- `KOUHAI_CONFIG=/home/nerovix/kouhai-bot/config.yaml uv run pytest` -> 246 passed
- `uv run pytest tests/test_cf_tutorial_agent.py tests/test_tutorial_quality.py tests/test_tutorials.py tests/test_shared.py` -> 38 passed
- `python3 -m py_compile tools/cf_tutorial_agent.py tools/tutorial_tools.py src/kouhai_bot/tutorials.py`

Note: full pytest without `KOUHAI_CONFIG` fails in this temporary worktree because it has no local `config.yaml`; rerunning with the existing local config passes.
