### PR TITLE
[codex] Auto-crawl CF tutorials on problem set

### DIFF
--- a/src/kouhai_bot/editorial_followup.py
+++ b/src/kouhai_bot/editorial_followup.py
@@ -49,25 +49,29 @@ def _chunk_text(text: str, chunk_size: int) -> list[str]:
     return [text[i:i + chunk_size] for i in range(0, len(text), chunk_size)] or [""]
 
 
-def _prefetch_needed(pid: str) -> bool:
+def _prefetch_needed(pid: str, *, run_agent: bool) -> bool:
     if has_cached_editorial_zh(pid):
         return False
-    if is_no_official_editorial(pid) and get_official_editorial(pid) is None:
+    if (
+        is_no_official_editorial(pid)
+        and not run_agent
+        and get_official_editorial(pid) is None
+    ):
         return False
     return True
 
 
-def schedule_prefetch_editorial(pid: str) -> None:
+def schedule_prefetch_editorial(pid: str, *, run_agent: bool = True) -> None:
     """Start translating editorial when today's problem is set (/newproblem, daily_post)."""
     pid = (pid or "").strip()
-    if not pid or not _prefetch_needed(pid):
+    if not pid or not _prefetch_needed(pid, run_agent=run_agent):
         return
     existing = _prefetch_tasks.get(pid)
     if existing is not None and not existing.done():
         return
     logger.info("editorial prefetch scheduled for %s", pid)
     task = asyncio.create_task(
-        _run_prefetch_editorial(pid),
+        _run_prefetch_editorial(pid, run_agent=run_agent),
         name=f"editorial_prefetch_{pid}",
     )
     _prefetch_tasks[pid] = task
@@ -92,7 +96,7 @@ def schedule_prefetch_for_group_today(group_id: int) -> None:
         return
     pid = str(state.get("today", "") or "").strip()
     if pid:
-        schedule_prefetch_editorial(pid)
+        schedule_prefetch_editorial(pid, run_agent=False)
 
 
 def schedule_prefetch_for_current_group() -> None:
@@ -101,10 +105,10 @@ def schedule_prefetch_for_current_group() -> None:
         schedule_prefetch_for_group_today(cfg.current_group)
 
 
-async def _run_prefetch_editorial(pid: str) -> None:
+async def _run_prefetch_editorial(pid: str, *, run_agent: bool) -> None:
     started = time.monotonic()
     try:
-        await prefetch_editorial_zh(pid)
+        await prefetch_editorial_zh(pid, run_agent=run_agent)
         elapsed = time.monotonic() - started
         if has_cached_editorial_zh(pid):
             logger.info("editorial prefetch ready for %s in %.1fs (cached)", pid, elapsed)

--- a/src/kouhai_bot/handlers/cmd/setproblem.py
+++ b/src/kouhai_bot/handlers/cmd/setproblem.py
@@ -8,6 +8,7 @@ import asyncio
 
 from .. import registry
 from ..registry import CommandDef
+from ...editorial_followup import schedule_prefetch_editorial
 from ...napcat.client import build_plain_message, send_group_msg, send_private_msg
 from ...private_judge import (
     NonFormulaImageProblem,
@@ -171,6 +172,8 @@ async def handle(group_id: int, user_id: int, sender: dict,
             copied=copied,
         )
     ))
+    if pid:
+        schedule_prefetch_editorial(pid)
 
 
 def register() -> None:

--- a/src/kouhai_bot/tutorials.py
+++ b/src/kouhai_bot/tutorials.py
@@ -6,15 +6,21 @@ Extraction rules align with tools/scrape_cf_tutorial.py normalization (hint/solu
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
+import sys
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
 
 from .config import get_config
 from .handlers.shared import translate_editorial_to_zh
 
 MIN_EDITORIAL_LEN = 80
 _REVIEW_EDITORIAL_MAX_LEN = 12000
+
+logger = logging.getLogger("kouhai-bot.tutorials")
 
 _PLACEHOLDER_RE = re.compile(
     r"Tutorial is loading|Will be added soon",
@@ -144,6 +150,88 @@ def load_tutorial(pid: str) -> dict | None:
         return None
 
 
+def _tools_dir() -> Path:
+    return Path(__file__).resolve().parents[2] / "tools"
+
+
+def _load_tutorial_agent() -> tuple[type[Exception], type[Exception], Any]:
+    tools_dir = _tools_dir()
+    if tools_dir.is_dir():
+        tools_dir_str = str(tools_dir)
+        if tools_dir_str not in sys.path:
+            sys.path.insert(0, tools_dir_str)
+
+    from cf_tutorial_agent import AgentNoMatch, run_agent_for_pid
+    from scrape_cf_tutorial import ScrapeError
+
+    return AgentNoMatch, ScrapeError, run_agent_for_pid
+
+
+def _write_tutorial_bundle(pid: str, bundle: dict) -> None:
+    tutorials_dir = Path(get_config().data_dir) / "tutorials"
+    tutorials_dir.mkdir(parents=True, exist_ok=True)
+    out_path = tutorials_dir / f"{pid}.json"
+    tmp_path = out_path.with_suffix(".json.tmp")
+    tmp_path.write_text(json.dumps(bundle, ensure_ascii=False, indent=2), encoding="utf-8")
+    os.replace(tmp_path, out_path)
+
+
+async def ensure_tutorial_json(pid: str) -> bool:
+    """Run the CF tutorial agent if no usable tutorial JSON is cached."""
+    pid = (pid or "").strip()
+    if not pid:
+        return False
+    if get_official_editorial(pid) is not None:
+        clear_no_official_editorial_marker(pid)
+        return True
+
+    cfg = get_config()
+    statements_dir = Path(cfg.data_dir) / "statements"
+    statement_path = statements_dir / f"{pid}.json"
+    if not statement_path.is_file():
+        logger.info("tutorial agent skipped for %s: statement cache missing", pid)
+        return False
+
+    try:
+        AgentNoMatch, ScrapeError, run_agent_for_pid = _load_tutorial_agent()
+    except Exception as e:
+        logger.warning("tutorial agent unavailable for %s: %s", pid, e, exc_info=True)
+        return False
+
+    try:
+        result = await run_agent_for_pid(pid=pid, statements_dir=statements_dir)
+    except AgentNoMatch as e:
+        logger.info("tutorial agent found no official editorial for %s: %s", pid, e)
+        return False
+    except ScrapeError as e:
+        logger.warning("tutorial agent scrape failed for %s: %s", pid, e)
+        return False
+    except Exception as e:
+        logger.warning("tutorial agent failed for %s: %s", pid, e, exc_info=True)
+        return False
+
+    try:
+        _write_tutorial_bundle(pid, result.bundle)
+    except OSError as e:
+        logger.warning("failed to write tutorial JSON for %s: %s", pid, e, exc_info=True)
+        return False
+
+    if get_official_editorial(pid) is None:
+        logger.warning("tutorial agent wrote unusable tutorial JSON for %s", pid)
+        return False
+
+    clear_no_official_editorial_marker(pid)
+    logger.info(
+        "tutorial agent cached official editorial for %s "
+        "candidate=%s confidence=%.2f elapsed=%.1fs",
+        pid,
+        result.selected_candidate_id,
+        result.confidence,
+        result.elapsed_sec,
+    )
+    return True
+
+
 def get_official_editorial(pid: str) -> OfficialEditorial | None:
     bundle = load_tutorial(pid)
     if not bundle:
@@ -234,10 +322,16 @@ def load_cached_editorial_zh(pid: str) -> str:
     return _load_cached_translation(pid)
 
 
-async def prefetch_editorial_zh(pid: str) -> None:
+async def prefetch_editorial_zh(pid: str, *, run_agent: bool = True) -> None:
     """Translate editorial ahead of first AC; does not send to the group."""
     if not pid or has_cached_editorial_zh(pid):
         return
+    if is_no_official_editorial(pid) and not run_agent:
+        if get_official_editorial(pid) is None:
+            return
+        clear_no_official_editorial_marker(pid)
+    if run_agent and get_official_editorial(pid) is None:
+        await ensure_tutorial_json(pid)
     if is_no_official_editorial(pid):
         if get_official_editorial(pid) is None:
             return

--- a/src/kouhai_bot/tutorials.py
+++ b/src/kouhai_bot/tutorials.py
@@ -326,17 +326,20 @@ async def prefetch_editorial_zh(pid: str, *, run_agent: bool = True) -> None:
     """Translate editorial ahead of first AC; does not send to the group."""
     if not pid or has_cached_editorial_zh(pid):
         return
-    if is_no_official_editorial(pid) and not run_agent:
-        if get_official_editorial(pid) is None:
-            return
-        clear_no_official_editorial_marker(pid)
-    if run_agent and get_official_editorial(pid) is None:
-        await ensure_tutorial_json(pid)
-    if is_no_official_editorial(pid):
-        if get_official_editorial(pid) is None:
-            return
-        clear_no_official_editorial_marker(pid)
     editorial = get_official_editorial(pid)
+    if is_no_official_editorial(pid) and not run_agent:
+        if editorial is None:
+            return
+        clear_no_official_editorial_marker(pid)
+    if not run_agent and editorial is None:
+        return
+    if run_agent and editorial is None:
+        await ensure_tutorial_json(pid)
+        editorial = get_official_editorial(pid)
+    if is_no_official_editorial(pid):
+        if editorial is None:
+            return
+        clear_no_official_editorial_marker(pid)
     if not editorial:
         mark_no_official_editorial(pid)
         return

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -256,6 +256,27 @@ def test_prefetch_editorial_zh_marks_missing(tmp_path, monkeypatch):
     assert is_no_official_editorial("999Z")
 
 
+def test_prefetch_editorial_zh_no_agent_leaves_missing_unknown(tmp_path, monkeypatch):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+
+    async def _run():
+        with patch(
+            "kouhai_bot.tutorials.ensure_tutorial_json",
+            AsyncMock(side_effect=AssertionError("agent should not run")),
+        ), patch(
+            "kouhai_bot.tutorials.translate_editorial_to_zh",
+            AsyncMock(side_effect=AssertionError("translate should not run")),
+        ):
+            await prefetch_editorial_zh("999Z", run_agent=False)
+
+    asyncio.run(_run())
+    assert not is_no_official_editorial("999Z")
+    assert not (tmp_path / "tutorial_translations" / "999Z.no_editorial").exists()
+
+
 def test_tutorial_agent_importable_from_runtime():
     from kouhai_bot.tutorials import _load_tutorial_agent
 

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -1,8 +1,10 @@
 """Tests for official tutorial extraction."""
 
 import asyncio
+import json
 import os
 import sys
+from types import SimpleNamespace
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
@@ -15,6 +17,7 @@ from kouhai_bot.tutorials import (
     get_editorial_zh_for_group,
     get_official_editorial,
     has_cached_editorial_zh,
+    ensure_tutorial_json,
     is_no_official_editorial,
     mark_no_official_editorial,
     prefetch_editorial_zh,
@@ -253,6 +256,79 @@ def test_prefetch_editorial_zh_marks_missing(tmp_path, monkeypatch):
     assert is_no_official_editorial("999Z")
 
 
+def test_tutorial_agent_importable_from_runtime():
+    from kouhai_bot.tutorials import _load_tutorial_agent
+
+    AgentNoMatch, ScrapeError, run_agent_for_pid = _load_tutorial_agent()
+    assert issubclass(AgentNoMatch, Exception)
+    assert issubclass(ScrapeError, Exception)
+    assert run_agent_for_pid.__name__ == "run_agent_for_pid"
+
+
+def test_prefetch_editorial_zh_runs_agent_before_translate(tmp_path, monkeypatch):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    statements_dir = tmp_path / "statements"
+    statements_dir.mkdir()
+    (statements_dir / "542D.json").write_text(
+        json.dumps({"name": "P", "description": "D", "input": "I", "output": "O"}),
+        encoding="utf-8",
+    )
+    mark_no_official_editorial("542D")
+
+    class FakeAgentNoMatch(Exception):
+        pass
+
+    class FakeScrapeError(Exception):
+        pass
+
+    async def _fake_run_agent_for_pid(*, pid, statements_dir):
+        assert pid == "542D"
+        assert (statements_dir / "542D.json").is_file()
+        body = _long_text("agent editorial ")
+        return SimpleNamespace(
+            bundle={
+                "tutorial_url": "https://codeforces.com/blog/entry/1",
+                "tutorial_title": "Editorial",
+                "sections": [
+                    {"hint": "", "solution": body, "raw_text": body, "code_blocks": []}
+                ],
+            },
+            selected_candidate_id="c1",
+            confidence=0.91,
+            elapsed_sec=1.2,
+        )
+
+    async def _run():
+        with patch(
+            "kouhai_bot.tutorials._load_tutorial_agent",
+            return_value=(FakeAgentNoMatch, FakeScrapeError, _fake_run_agent_for_pid),
+        ), patch(
+            "kouhai_bot.tutorials.translate_editorial_to_zh",
+            AsyncMock(return_value=("自动抓取后的译文。" * 12, "", True)),
+        ):
+            await prefetch_editorial_zh("542D")
+
+    asyncio.run(_run())
+    assert not is_no_official_editorial("542D")
+    assert get_official_editorial("542D") is not None
+    assert has_cached_editorial_zh("542D")
+
+
+def test_ensure_tutorial_json_returns_false_without_statement(tmp_path, monkeypatch):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+
+    async def _run():
+        assert await ensure_tutorial_json("999Z") is False
+
+    asyncio.run(_run())
+
+
 def test_prefetch_editorial_zh_caches_translation(tmp_path, monkeypatch):
     from kouhai_bot.config import BotConfig
 
@@ -261,7 +337,6 @@ def test_prefetch_editorial_zh_caches_translation(tmp_path, monkeypatch):
     tutorials_dir = tmp_path / "tutorials"
     tutorials_dir.mkdir()
     body = _long_text("prefetch-")
-    import json
     (tutorials_dir / "542D.json").write_text(
         json.dumps({
             "tutorial_url": "https://example.com/e",


### PR DESCRIPTION
## Summary

- Run the CF tutorial discovery agent from runtime prefetch before translating editorials.
- Let explicit `/newproblem` and `/setproblem` selections start that crawl/translate task in the background.
- Keep startup warmup from re-crawling old `no_editorial` misses, while first AC still waits for any in-flight prefetch task.
- Add tests for runtime agent import and the crawl-before-translate path.

## Root Cause

Tutorial JSON files were only produced by CLI tooling, so runtime prefetch usually saw no `tutorials/{pid}.json`, marked the problem as `no_editorial`, and never produced Chinese editorial translations.

## Validation

- `uv run pytest tests/test_tutorials.py tests/test_cf_tutorial_agent.py`
- `python -m py_compile src/kouhai_bot/tutorials.py src/kouhai_bot/editorial_followup.py src/kouhai_bot/handlers/cmd/setproblem.py`
- `uv run pytest`