### PR TITLE
[codex] fix dashscope thinking payload

### DIFF
--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -72,15 +72,27 @@ def _provider_uses_stream(
     if explicit_stream:
         return True
 
+    return _provider_is_dashscope(provider_name, base_url)
+
+
+def _provider_is_dashscope(provider_name: str, base_url: str) -> bool:
     name = (provider_name or "").strip().lower()
-    if name in {"aliyun", "bailian", "dashscope"}:
+    if name in {"aliyun", "bailian", "dashscope"} or "dashscope" in name:
         return True
 
     parsed = urlparse((base_url or "").strip())
     host = (parsed.hostname or "").lower()
     if not host and "://" not in (base_url or ""):
         host = (base_url or "").split("/", 1)[0].lower()
-    return host == "dashscope.aliyuncs.com" or host.endswith(".dashscope.aliyuncs.com")
+    return (
+        host in {
+            "dashscope.aliyuncs.com",
+            "dashscope-intl.aliyuncs.com",
+            "dashscope-us.aliyuncs.com",
+        }
+        or host.endswith(".dashscope.aliyuncs.com")
+        or host.endswith(".maas.aliyuncs.com")
+    )
 
 
 def _should_retry_status(status: int) -> bool:
@@ -137,6 +149,38 @@ def _choice_delta_text(choice: dict) -> str:
     message = choice.get("message", {})
     if isinstance(message, dict):
         return _stream_content_text(message)
+    return ""
+
+
+def _choice_reasoning_text(choice: dict) -> str:
+    for key in ("delta", "message"):
+        value = choice.get(key, {})
+        if not isinstance(value, dict):
+            continue
+        reasoning_content = value.get("reasoning_content", "")
+        if isinstance(reasoning_content, str):
+            return reasoning_content
+    return ""
+
+
+def _stream_event_reasoning_text(data: dict) -> str:
+    choices = data.get("choices", [])
+    if choices:
+        choice = choices[0]
+        if isinstance(choice, dict):
+            return _choice_reasoning_text(choice)
+
+    output = data.get("output")
+    if isinstance(output, dict):
+        choices = output.get("choices", [])
+        if choices:
+            choice = choices[0]
+            if isinstance(choice, dict):
+                message = choice.get("message", {})
+                if isinstance(message, dict):
+                    reasoning_content = message.get("reasoning_content", "")
+                    if isinstance(reasoning_content, str):
+                        return reasoning_content
     return ""
 
 
@@ -205,10 +249,17 @@ async def _read_streaming_chat_completion(
 ) -> _ChatCompletionAttempt:
     parts: list[str] = []
     event_lines: list[str] = []
+    reasoning_chars = 0
 
     def finish(text: str) -> _ChatCompletionAttempt:
         if not text:
             logger.warning("%s API stream returned no text", provider_name)
+        if reasoning_chars:
+            logger.info(
+                "%s API stream returned reasoning_content chars=%s",
+                provider_name,
+                reasoning_chars,
+            )
         return _ChatCompletionAttempt(
             text=text or None,
             retryable=not bool(text),
@@ -226,6 +277,7 @@ async def _read_streaming_chat_completion(
         )
 
     def handle_event(raw_data: str) -> tuple[bool, _ChatCompletionAttempt | None]:
+        nonlocal reasoning_chars
         data_text = raw_data.strip()
         if not data_text:
             return False, None
@@ -236,6 +288,7 @@ async def _read_streaming_chat_completion(
         except json.JSONDecodeError:
             return False, stream_failure("invalid json")
 
+        reasoning_chars += len(_stream_event_reasoning_text(data))
         text, valid_event, error_message = _stream_event_text(data)
         if error_message:
             return False, stream_failure(error_message)
@@ -408,6 +461,8 @@ async def chat_completion(
                 payload["response_format"] = response_format
             if thinking:
                 payload["thinking"] = thinking
+                if _provider_is_dashscope(provider.name, provider.base_url):
+                    payload["enable_thinking"] = True
             reasoning_effort = provider.reasoning_effort.strip().lower()
             if reasoning_effort and send_reasoning_effort:
                 payload["reasoning_effort"] = reasoning_effort

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -298,10 +298,13 @@ def test_dashscope_provider_payload_enables_stream():
         result = asyncio.run(call_chat_completion(
             [{"role": "user", "content": "Reply with exactly OK."}],
             task="judge",
+            thinking={"type": "enabled"},
         ))
 
     assert result == "OK"
     assert calls[0]["stream"] is True
+    assert calls[0]["thinking"] == {"type": "enabled"}
+    assert calls[0]["enable_thinking"] is True
 
 
 def test_non_dashscope_provider_payload_does_not_enable_stream():
@@ -351,7 +354,8 @@ def test_explicit_stream_provider_payload_enables_stream():
     assert calls[0]["stream"] is True
 
 
-def test_streaming_chat_completion_reads_sse_delta_chunks():
+def test_streaming_chat_completion_reads_sse_delta_chunks(caplog):
+    caplog.set_level("INFO", logger="kouhai-bot.llm")
     response = _DummyResponse(lines=[
         ': keep-alive\n',
         'data: {"choices":[{"delta":{"reasoning_content":"thinking"}}]}\n',
@@ -377,6 +381,7 @@ def test_streaming_chat_completion_reads_sse_delta_chunks():
     assert result.text == "Hello world"
     assert result.retryable is False
     assert session.calls[0][1]["json"] == {"stream": True}
+    assert "reasoning_content chars=8" in caplog.text
 
 
 def test_streaming_chat_completion_ignores_metadata_events():


### PR DESCRIPTION
## What changed

- Send DashScope/Bailian-compatible `enable_thinking: true` whenever Kouhai requests thinking mode.
- Keep streaming `reasoning_content` out of final answer text while logging its character count for diagnostics.
- Broaden DashScope host detection for compatible Alibaba endpoints.
- Extend LLM transport tests for DashScope thinking payloads and reasoning-content stream handling.

## Why

DashScope OpenAI-compatible chat uses `enable_thinking` as the thinking-mode switch and emits thinking text in `reasoning_content`. Kouhai was only sending the generic `thinking` payload, so GLM/Qwen-family DashScope providers could run without explicit thinking even when judge/review code requested it.

## Validation

- `uv run pytest tests/test_shared.py -q` -> 16 passed.
- Re-ran the 914E e2e judge path with current GLM-first config after the fix:
  - first judge: 78.719s, `reasoning_content chars=16446`, correct=true
  - second judge: 241.747s, `reasoning_content chars=41846`, correct=true
  - total: 320.467s
- Ran an additional one-pass diagnostic for the same submit: `enable_thinking=true`, `reasoning_effort=max`, 12,976 reasoning chars over 523 stream chunks, final JSON parsed as correct.
