### PR TITLE
[codex] add fable provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ cp config.example.yaml config.yaml
 
 > 在我们的测试中，gpt-5.5 high 基本胜任，qwen-3.7-max 也相当不错，Deepseek v4 pro 可用，但由于其 CoT 较长，响应慢，推理能力也确实不及前者，建议只作为 API 连接不稳时的 fallback
 
+ZenMux/Fable 也可以作为 OpenAI-compatible provider 配置。示例见 `config.example.yaml`，推荐放在 fallback 列表靠前位置，使用 `reasoning_effort: "max"` 打开高强度 thinking，并设置 `model_tag: "『Fable』"` 方便在群内识别。Fable 的网关在启用 reasoning 时要求 temperature 为 1，bot 会在检测到 Fable provider 时自动处理这个参数，不需要在配置里额外设置。
+
 #### 公式识别
 
 ```

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -28,6 +28,14 @@ llm:
 
   # Fallback provider list — order matters!
   providers:
+    # ── Optional primary: ZenMux/Fable (OpenAI-compatible) ──
+    # - name: fable
+    #   api_key: "..."
+    #   base_url: "https://zenmux.ai/api/v1"
+    #   model: "anthropic/claude-fable-5-free"
+    #   reasoning_effort: "max"
+    #   model_tag: "『Fable』"
+
     # ── Primary: OpenAI-compatible ──
     - name: openai
       api_key: "..."

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -95,6 +95,17 @@ def _provider_is_dashscope(provider_name: str, base_url: str) -> bool:
     )
 
 
+def _provider_is_fable(provider_name: str, base_url: str) -> bool:
+    name = (provider_name or "").strip().lower()
+    parsed = urlparse((base_url or "").strip())
+    host = (parsed.hostname or "").lower()
+    return name == "fable" or host == "zenmux.ai"
+
+
+def _provider_accepts_generic_thinking(provider_name: str, base_url: str) -> bool:
+    return not _provider_is_fable(provider_name, base_url)
+
+
 def _should_retry_status(status: int) -> bool:
     return status in {408, 409, 429} or status >= 500
 
@@ -459,13 +470,15 @@ async def chat_completion(
             }
             if response_format:
                 payload["response_format"] = response_format
-            if thinking:
+            if thinking and _provider_accepts_generic_thinking(provider.name, provider.base_url):
                 payload["thinking"] = thinking
                 if _provider_is_dashscope(provider.name, provider.base_url):
                     payload["enable_thinking"] = True
             reasoning_effort = provider.reasoning_effort.strip().lower()
             if reasoning_effort and send_reasoning_effort:
                 payload["reasoning_effort"] = reasoning_effort
+                if _provider_is_fable(provider.name, provider.base_url):
+                    payload["temperature"] = 1
             if _provider_uses_stream(
                 provider.name,
                 provider.base_url,

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -307,6 +307,45 @@ def test_dashscope_provider_payload_enables_stream():
     assert calls[0]["enable_thinking"] is True
 
 
+def test_zenmux_fable_payload_uses_reasoning_effort_without_generic_thinking():
+    provider = LlmProviderConfig(
+        name="fable",
+        api_key="sk-test",
+        base_url="https://zenmux.ai/api/v1",
+        model="anthropic/claude-fable-5-free",
+        reasoning_effort="max",
+    )
+    cfg = _openai_cfg(llm_providers=[provider])
+    calls = []
+
+    async def fake_once(session, **kwargs):
+        calls.append(kwargs["payload"].copy())
+        return _ChatCompletionAttempt(
+            text="{\"ok\":true}",
+            retryable=False,
+            retry_after_sec=None,
+        )
+
+    with patch("kouhai_bot.llm.get_config", return_value=cfg), \
+            patch("kouhai_bot.llm.aiohttp.ClientSession", _DummySession), \
+            patch("kouhai_bot.llm._post_chat_completion_once", side_effect=fake_once):
+        result = asyncio.run(call_chat_completion_result(
+            [{"role": "user", "content": "Reply with JSON."}],
+            task="judge",
+            response_format={"type": "json_object"},
+            thinking={"type": "enabled"},
+        ))
+
+    assert result.text == "{\"ok\":true}"
+    assert calls[0]["model"] == "anthropic/claude-fable-5-free"
+    assert calls[0]["response_format"] == {"type": "json_object"}
+    assert calls[0]["reasoning_effort"] == "max"
+    assert calls[0]["temperature"] == 1
+    assert "thinking" not in calls[0]
+    assert "enable_thinking" not in calls[0]
+    assert "stream" not in calls[0]
+
+
 def test_non_dashscope_provider_payload_does_not_enable_stream():
     cfg = _openai_cfg()
     calls = []


### PR DESCRIPTION
## Summary

- Add ZenMux/Fable provider handling so `anthropic/claude-fable-5-free` uses `reasoning_effort` instead of the generic `thinking` payload field.
- Force `temperature=1` for Fable when reasoning is enabled, matching the gateway's validation rule.
- Document the optional Fable provider shape in `config.example.yaml`.

## Validation

- `uv run pytest tests/test_shared.py -q` -> 17 passed
- Pinned Fable smoke with JSON output and thinking request -> provider `fable`, model `anthropic/claude-fable-5-free`, tag `『Fable』`, elapsed ~6.9s
- Default provider-order smoke -> provider `fable`, elapsed ~5.8s

## Runtime Config

Local ignored `config.yaml` has Fable configured first with `reasoning_effort: max`, JSON output is still requested per call through `response_format`, and no completion token cap is set.
