### PR TITLE
[codex] rename llm model config to smart and general models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,14 +46,14 @@ NapCat (QQ) ──WS──> worker.py
   OpenAI-compatible `/chat/completions` format. DashScope/阿里云百炼 providers
   are called with HTTP+SSE streaming to avoid the 10-minute synchronous HTTP
   limit; providers with `stream: true` do the same; other providers use the
-  normal JSON response path. Per-task model
-  overrides (`judge_model`, `clarify_model`, etc.) are defined per provider.
+  normal JSON response path. Each provider defines `smart_model` for judge/review
+  and `general_model` for clarify/summary/editorial and other tasks.
   `thinking` and `reasoning_effort` are sent unconditionally; unsupported
   fields are silently ignored by upstream APIs.
 - **Official CF tutorials**: Scraped editorials live under `{data_dir}/tutorials/{pid}.json`
   (see `tools/cf_tutorial_agent.py`; low-level CF HTML helpers live in `tools/scrape_cf_tutorial.py`). Runtime extraction is in `tutorials.py`. On the
   On **new problem** (`do_daily_post` / `/newproblem`), `schedule_prefetch_editorial(pid)`
-  starts background translation (using `summary_model`) into `tutorial_translations/` so first AC
+  starts background translation (using `general_model`) into `tutorial_translations/` so first AC
   can deliver without waiting. On **first AC**, congrats is sent in `_finalize_submit`, then
   `schedule_post_solve_editorial_followup()` only **delivers** (awaits in-flight prefetch if
   needed). Neither path uses the state scheduler. Tutorial scraping depends on Playwright
@@ -104,11 +104,8 @@ Each provider in `llm.providers`:
 | `name` | — | Provider identifier for logging (**required**) |
 | `api_key` | — | API key (**required**) |
 | `base_url` | `https://api.openai.com/v1` | Base URL for chat completions |
-| `model` | — | Default model (**required**) |
-| `judge_model` | `model` | Per-task override for `/submit` |
-| `clarify_model` | `model` | Per-task override for `/clarify` |
-| `review_model` | `model` | Per-task override for `/review` |
-| `summary_model` | `model` | Per-task override for `/summary` + editorial translation |
+| `smart_model` | — | Model for `/submit` judge and `/review` (**required**) |
+| `general_model` | — | Model for `/clarify`, summaries, editorial translation, sample-note translation, and other LLM tasks (**required**) |
 | `reasoning_effort` | — | OpenAI reasoning effort: `minimal`/`low`/`medium`/`high`/`xhigh` |
 | `stream` | `false` | Send `stream=true` and read SSE chunks for this provider; DashScope/阿里云百炼 streams automatically |
 | `model_tag` | `""` | Short string appended to every LLM-generated user message (judge/clarify/review/summary/editorial); empty means no tag |
@@ -271,10 +268,12 @@ Common fallback pattern: OpenAI (better quality, less stable) → DeepSeek (stab
 llm:
   providers:
     - name: openai
-      model: "gpt-5.5"
+      smart_model: "gpt-5.5"
+      general_model: "gpt-5.5-mini"
       reasoning_effort: "high"
     - name: deepseek
-      model: "deepseek-v4-pro"
+      smart_model: "deepseek-v4-pro"
+      general_model: "deepseek-v4-chat"
 ```
 
 All providers receive the same base request payload. Non-applicable fields (e.g.
@@ -344,15 +343,15 @@ No repository-local runtime queue is used.
 
 | Command | File | Handler | Lock | Model | Notes |
 |---------|------|---------|------|-------|-------|
-| `/submit` (`/sbm`) | submit.py | `handle` | ✅ state scheduler | per-provider `judge_model` | Judge solution, save history, serialize only first-blood/scoreboard; configured dynamic-wait group submits redirect to private judge; private AC does not score until synced |
-| `/clarify` (`/clrf`) | clarify.py | `handle` | ✅ state scheduler | per-provider `clarify_model` | Clarify problem details (JSON output, anti-spoiler, no original problem identity), using admission-time pid; private uses pid-specific summary |
+| `/submit` (`/sbm`) | submit.py | `handle` | ✅ state scheduler | per-provider `smart_model` | Judge solution, save history, serialize only first-blood/scoreboard; configured dynamic-wait group submits redirect to private judge; private AC does not score until synced |
+| `/clarify` (`/clrf`) | clarify.py | `handle` | ✅ state scheduler | per-provider `general_model` | Clarify problem details (JSON output, anti-spoiler, no original problem identity), using admission-time pid; private uses pid-specific summary |
 | `/clear` | clear.py | `handle` | ✅ state scheduler | — | Clear the current user's stored submit/clarify/review history for the admission-time current problem or current private problem |
-| `/newproblem` (`/np`) | newproblem.py | `handle` | ✅ post lock | per-provider `summary_model` | Force new problem when solved (or none); unsolved needs exact `/newproblem --force`; samples are forwarded as separate nodes; if statement has `notes`, translate+symbol-normalize and append as a dedicated notes node; commits state only after card delivery succeeds and keeps `daily_msg.json` in sync even on direct-text fallback |
+| `/newproblem` (`/np`) | newproblem.py | `handle` | ✅ post lock | per-provider `general_model` | Force new problem when solved (or none); unsolved needs exact `/newproblem --force`; samples are forwarded as separate nodes; if statement has `notes`, translate+symbol-normalize and append as a dedicated notes node; commits state only after card delivery succeeds and keeps `daily_msg.json` in sync even on direct-text fallback |
 | `/problem` (`/pb`) | stubs.py | `handle_problem` | ❌ | — | Resend current group/private problem via forward card; group path only uses `daily_msg.json` when pid matches `state.json.today`; if solved, add a friendly `/newproblem` hint |
 | `/tag` | stubs.py | `handle_tag` | ❌ | — | Show current group/private problem CF tags |
 | `/scoreboard` | stubs.py | `handle_scoreboard` | ❌ | — | Cumulative weighted leaderboard; shows the formula at the top, then refreshes latest group nicknames at display time |
 | `/help` | help.py | `handle` | ❌ | — | Auto-generated help (forward card) |
-| `/review` (`/rv`) | review.py | `handle` | ✅ state scheduler | per-provider `review_model` | Discuss the latest solved group/private problem by default; quoted group problem cards can target older problems |
+| `/review` (`/rv`) | review.py | `handle` | ✅ state scheduler | per-provider `smart_model` | Discuss the latest solved group/private problem by default; quoted group problem cards can target older problems |
 | `/status` | stubs.py | `handle_status` | ❌ | — | Check whether this group or private judge has active stateful work |
 | `/setproblem` (`/sp`) | setproblem.py | `handle` | ❌ | — | Private-only; set current private problem from current group problem, CF pid/link, `random`, or a quoted problem card |
 | `/sync` | sync.py | `handle` | ✅ short group state lock for group writes | — | Sync current group problem history between group and private judge; empty source aborts without overwrite |
@@ -593,7 +592,7 @@ scheduler lock, but final reply is not ordered behind unrelated same-group reque
   inputs. Ignore @all, the bot itself, the requester, and duplicate mentions. Do not
   persist anything to mentioned users' histories; only the requester receives the
   saved review record.
-- Uses per-provider `review_model` (free text, no JSON format). Timeout from
+- Uses per-provider `smart_model` (free text, no JSON format). Timeout from
   `llm.review_timeout_sec`. `thinking: enabled` and `reasoning_effort` are sent
   unconditionally; unsupported fields are silently ignored.
 - Long replies (>400 chars) → merged-forward card; short replies → @mention inline
@@ -690,7 +689,7 @@ lock and wraps the same locked implementation:
 1. Reveal yesterday's problem via `picker.py reveal`
 2. Pick a candidate problem via `picker.py pick-json --with-statement`; this marks used
    problems and caches statements but does **not** write `state.json`
-3. Generate Chinese summary via `summarize_problem()` → per-provider `summary_model`,
+3. Generate Chinese summary via `summarize_problem()` → per-provider `general_model`,
    timeout from `llm.summary_timeout_sec`
 4. Self-send summary text; self-send each sample as an independent node; if statement has
    `notes`, translate it to Chinese and append a dedicated `样例解释` node (with LaTeX/Markdown

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -32,7 +32,8 @@ llm:
     # - name: fable
     #   api_key: "..."
     #   base_url: "https://zenmux.ai/api/v1"
-    #   model: "anthropic/claude-fable-5-free"
+    #   smart_model: "anthropic/claude-fable-5-free"
+    #   general_model: "anthropic/claude-fable-5-free"
     #   reasoning_effort: "max"
     #   model_tag: "『Fable』"
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -40,7 +40,8 @@ llm:
     - name: openai
       api_key: "..."
       base_url: "..."
-      model: "gpt-5.5"
+      smart_model: "gpt-5.5"      # judge/review
+      general_model: "gpt-5.5-mini" # clarify/summary/editorial and other tasks
       stream: true               # use SSE streaming; recommended for sub2api/OpenAI
       reasoning_effort: "high"  # minimal/low/medium/high/xhigh
       model_tag: "『֎AI』"        # appended to LLM output; empty to disable
@@ -49,14 +50,16 @@ llm:
     - name: qwen
       api_key: "..."
       base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1"
-      model: "qwen3.7-max"
+      smart_model: "qwen3.7-max"
+      general_model: "qwen3.7-plus"
       model_tag: "『Qwen』"
 
     # ── Fallback: DeepSeek (supports OpenAI-compatible format) ──
     - name: deepseek
       api_key: "..."
       base_url: "https://api.deepseek.com"
-      model: "deepseek-v4-pro"
+      smart_model: "deepseek-v4-pro"
+      general_model: "deepseek-v4-chat"
       model_tag: "『🐳』"
 
 # ── Qwen-VL (formula image recognition) ──

--- a/src/kouhai_bot/llm_config.py
+++ b/src/kouhai_bot/llm_config.py
@@ -32,11 +32,8 @@ class LlmProviderConfig:
     name: str
     api_key: str
     base_url: str
-    model: str
-    judge_model: str = ""
-    clarify_model: str = ""
-    review_model: str = ""
-    summary_model: str = ""
+    smart_model: str
+    general_model: str
     reasoning_effort: str = ""
     model_tag: str = ""
     stream: bool = False
@@ -44,20 +41,14 @@ class LlmProviderConfig:
     def model_for(self, task: str = "", explicit_model: str = "") -> str:
         """Resolve the model name for a given task.
 
-        Priority: explicit_model > per-task override > default model.
+        Priority: explicit_model > smart/general task default.
         """
         if explicit_model:
             return explicit_model
         task_name = (task or "").strip().lower()
-        if task_name == "judge":
-            return self.judge_model or self.model
-        if task_name == "clarify":
-            return self.clarify_model or self.model
-        if task_name == "review":
-            return self.review_model or self.model
-        if task_name == "summary":
-            return self.summary_model or self.model
-        return self.model
+        if task_name in {"judge", "review"}:
+            return self.smart_model
+        return self.general_model
 
 
 def build_providers_from_yaml(llm_section: dict[str, Any]) -> list[LlmProviderConfig]:
@@ -94,9 +85,13 @@ def build_providers_from_yaml(llm_section: dict[str, Any]) -> list[LlmProviderCo
         if not api_key:
             raise RuntimeError(f"LLM provider '{name}' requires 'api_key'")
 
-        model = str(p.get("model", "")).strip()
-        if not model:
-            raise RuntimeError(f"LLM provider '{name}' requires 'model'")
+        smart_model = str(p.get("smart_model", "")).strip()
+        if not smart_model:
+            raise RuntimeError(f"LLM provider '{name}' requires 'smart_model'")
+
+        general_model = str(p.get("general_model", "")).strip()
+        if not general_model:
+            raise RuntimeError(f"LLM provider '{name}' requires 'general_model'")
 
         base_url = str(p.get("base_url", "https://api.openai.com/v1")).strip()
         if not base_url:
@@ -110,11 +105,8 @@ def build_providers_from_yaml(llm_section: dict[str, Any]) -> list[LlmProviderCo
                 name=name,
                 api_key=api_key,
                 base_url=base_url,
-                model=model,
-                judge_model=str(p.get("judge_model", "")).strip(),
-                clarify_model=str(p.get("clarify_model", "")).strip(),
-                review_model=str(p.get("review_model", "")).strip(),
-                summary_model=str(p.get("summary_model", "")).strip(),
+                smart_model=smart_model,
+                general_model=general_model,
                 reasoning_effort=str(p.get("reasoning_effort", "")).strip(),
                 model_tag=str(p.get("model_tag", "")).strip(),
                 stream=_parse_bool(p.get("stream", False)),

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -86,10 +86,8 @@ class _LazyConfig:
         "llm_openai_base_url": "https://api.openai.com/v1",
         "llm_openai_model": "gpt-5",
         "llm_reasoning_effort": "",
-        "judge_model": "",
-        "clarify_model": "",
-        "review_model": "",
-        "summary_model": "",
+        "smart_model": "deepseek-v4-pro",
+        "general_model": "deepseek-v4-flash",
         "qwen_api_key": "",
         "qwen_model": "qwen-vl-max",
         "current_group": GID,
@@ -122,15 +120,9 @@ class _LazyConfig:
         if explicit_model:
             return explicit_model
         task_name = (task or "").strip().lower()
-        if task_name == "judge":
-            return self._config.get("judge_model") or "deepseek-v4-pro"
-        if task_name == "clarify":
-            return self._config.get("clarify_model") or "deepseek-v4-flash"
-        if task_name == "review":
-            return self._config.get("review_model") or "deepseek-v4-pro"
-        if task_name == "summary":
-            return self._config.get("summary_model") or "deepseek-v4-pro"
-        return self.llm_default_model()
+        if task_name in {"judge", "review"}:
+            return self._config.get("smart_model") or "deepseek-v4-pro"
+        return self._config.get("general_model") or "deepseek-v4-flash"
 
     def __getattr__(self, name):
         if name == "data_dir":

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -395,10 +395,8 @@ def _config_dict():
         "llm_openai_base_url": "https://api.openai.com/v1",
         "llm_openai_model": "gpt-5",
         "llm_reasoning_effort": "",
-        "judge_model": "",
-        "clarify_model": "",
-        "review_model": "",
-        "summary_model": "",
+        "smart_model": "deepseek-v4-pro",
+        "general_model": "deepseek-v4-flash",
         "judge_timeout_sec": 1200,
         "clarify_timeout_sec": 600,
         "review_timeout_sec": 600,
@@ -440,15 +438,9 @@ class _LazyConfig:
         if explicit_model:
             return explicit_model
         task_name = (task or "").strip().lower()
-        if task_name == "judge":
-            return self._config.get("judge_model") or "deepseek-v4-pro"
-        if task_name == "clarify":
-            return self._config.get("clarify_model") or "deepseek-v4-flash"
-        if task_name == "review":
-            return self._config.get("review_model") or "deepseek-v4-pro"
-        if task_name == "summary":
-            return self._config.get("summary_model") or "deepseek-v4-pro"
-        return self.llm_default_model()
+        if task_name in {"judge", "review"}:
+            return self._config.get("smart_model") or "deepseek-v4-pro"
+        return self._config.get("general_model") or "deepseek-v4-flash"
 
     def __getattr__(self, name):
         if name == "data_dir":
@@ -3505,29 +3497,31 @@ def test_user_submission_history_is_unbounded_and_upserts_by_request_id():
     _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
     from kouhai_bot.handlers.shared import load_user_submissions, save_user_submission
 
-    for i in range(25):
+    with _all_patches():
+        for i in range(25):
+            save_user_submission(GID, UID, {
+                "timestamp": f"2026-05-14T00:00:{i:02d}+08:00",
+                "type": "submit",
+                "content": f"idea {i}",
+                "result": "incorrect",
+                "reason": "",
+                "reply": "",
+                "problem": PID,
+                "request_id": f"req-{i}",
+            })
         save_user_submission(GID, UID, {
-            "timestamp": f"2026-05-14T00:00:{i:02d}+08:00",
+            "timestamp": "2026-05-14T00:00:03+08:00",
             "type": "submit",
-            "content": f"idea {i}",
-            "result": "incorrect",
+            "content": "idea 3 updated",
+            "result": "superseded",
             "reason": "",
             "reply": "",
             "problem": PID,
-            "request_id": f"req-{i}",
+            "request_id": "req-3",
         })
-    save_user_submission(GID, UID, {
-        "timestamp": "2026-05-14T00:00:03+08:00",
-        "type": "submit",
-        "content": "idea 3 updated",
-        "result": "superseded",
-        "reason": "",
-        "reply": "",
-        "problem": PID,
-        "request_id": "req-3",
-    })
 
-    records = load_user_submissions(GID, UID)
+        records = load_user_submissions(GID, UID)
+
     assert len(records) == 25, records
     assert records[0]["content"] == "idea 0", records
     assert records[3]["content"] == "idea 3 updated", records

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,7 +21,8 @@ def _make_yaml(**overrides) -> str:
                     "name": "test",
                     "api_key": "sk-test",
                     "base_url": "http://localhost:8080/v1",
-                    "model": "test-model",
+                    "smart_model": "test-smart-model",
+                    "general_model": "test-general-model",
                 }
             ]
         },
@@ -79,17 +80,42 @@ def test_config_requires_provider_name(monkeypatch, tmp_path):
         _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
 
 
-def test_config_requires_provider_model(monkeypatch, tmp_path):
+def test_config_requires_provider_smart_model(monkeypatch, tmp_path):
     data = yaml.safe_load(_make_yaml())
-    data["llm"]["providers"][0]["model"] = ""
-    with pytest.raises(RuntimeError, match="model"):
+    data["llm"]["providers"][0]["smart_model"] = ""
+    with pytest.raises(RuntimeError, match="smart_model"):
+        _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
+
+
+def test_config_requires_provider_general_model(monkeypatch, tmp_path):
+    data = yaml.safe_load(_make_yaml())
+    data["llm"]["providers"][0]["general_model"] = ""
+    with pytest.raises(RuntimeError, match="general_model"):
+        _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
+
+
+def test_legacy_provider_model_does_not_satisfy_required_models(monkeypatch, tmp_path):
+    data = yaml.safe_load(_make_yaml())
+    provider = data["llm"]["providers"][0]
+    provider["model"] = "legacy-model"
+    del provider["smart_model"]
+    del provider["general_model"]
+    with pytest.raises(RuntimeError, match="smart_model"):
         _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
 
 
 def test_llm_timeouts_load_from_yaml(monkeypatch, tmp_path):
     yaml_str = _make_yaml(
         llm={
-            "providers": [{"name": "t", "api_key": "k", "base_url": "http://x/v1", "model": "m"}],
+            "providers": [
+                {
+                    "name": "t",
+                    "api_key": "k",
+                    "base_url": "http://x/v1",
+                    "smart_model": "smart",
+                    "general_model": "general",
+                }
+            ],
             "judge_timeout_sec": 1500,
             "clarify_timeout_sec": 700,
             "review_timeout_sec": 800,

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -438,7 +438,8 @@ def test_zenmux_fable_payload_uses_reasoning_effort_without_generic_thinking():
         name="fable",
         api_key="sk-test",
         base_url="https://zenmux.ai/api/v1",
-        model="anthropic/claude-fable-5-free",
+        smart_model="anthropic/claude-fable-5-free",
+        general_model="anthropic/claude-fable-5-free",
         reasoning_effort="max",
     )
     cfg = _openai_cfg(llm_providers=[provider])

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -8,7 +8,16 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from kouhai_bot.config import BotConfig
 from kouhai_bot.llm_config import LlmProviderConfig
-from kouhai_bot.handlers.shared import build_second_judge_messages, call_chat_completion, call_chat_completion_result, summarize_problem, translate_editorial_to_zh
+from kouhai_bot.handlers.shared import (
+    build_second_judge_messages,
+    call_chat_completion,
+    call_chat_completion_result,
+    judge_submission_result,
+    robust_json_parse,
+    summarize_problem,
+    translate_editorial_to_zh,
+    translate_sample_notes,
+)
 from kouhai_bot.llm import ChatCompletionResult, _ChatCompletionAttempt, _post_chat_completion_once
 
 
@@ -185,6 +194,72 @@ def test_general_model_tasks_preserve_provider_model_tag():
     assert result.model == "general"
     assert result.model_tag == "『G』"
     assert calls[0]["model"] == "general"
+
+
+def test_task_entrypoints_are_blackbox_except_model_class_and_tag():
+    provider = LlmProviderConfig(
+        name="deepseek",
+        api_key="sk-test",
+        base_url="http://localhost:8080/v1",
+        smart_model="deepseek-v4-pro",
+        general_model="deepseek-v4-flash",
+        model_tag="『T』",
+    )
+    cfg = _openai_cfg(llm_providers=[provider])
+    calls = []
+
+    async def fake_once(session, **kwargs):
+        payload = kwargs["payload"].copy()
+        calls.append(payload)
+        text = "OK"
+        if payload.get("response_format") == {"type": "json_object"}:
+            user_content = payload["messages"][-1]["content"]
+            if "official_editorial" in user_content:
+                text = json.dumps({"matched": "yes", "result": "中文题解"})
+            else:
+                text = json.dumps({
+                    "correct": False,
+                    "reason": "missing proof",
+                    "reply": "再检查一下证明。",
+                    "reaction": "",
+                })
+        return _ChatCompletionAttempt(text=text, retryable=False, retry_after_sec=None)
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.llm.get_config", return_value=cfg), \
+            patch("kouhai_bot.llm.aiohttp.ClientSession", _DummySession), \
+            patch("kouhai_bot.llm._post_chat_completion_once", side_effect=fake_once):
+        judge = asyncio.run(judge_submission_result("problem", "solution", []))
+        review = asyncio.run(call_chat_completion_result(
+            [{"role": "user", "content": "review this"}],
+            task="review",
+        ))
+        summary, summary_tag = asyncio.run(summarize_problem("stmt", "input", "limits"))
+        notes, notes_tag = asyncio.run(translate_sample_notes("1 goes to 2"))
+        editorial, editorial_tag, matched = asyncio.run(translate_editorial_to_zh(
+            "official editorial",
+            pid="1A",
+            problem_text="problem",
+        ))
+
+    assert robust_json_parse(judge.text)["correct"] is False
+    assert judge.model_tag == "『T』"
+    assert review.text == "OK"
+    assert review.model_tag == "『T』"
+    assert summary == "OK"
+    assert summary_tag == "『T』"
+    assert notes == "OK"
+    assert notes_tag == "『T』"
+    assert editorial == "中文题解"
+    assert editorial_tag == "『T』"
+    assert matched is True
+    assert [call["model"] for call in calls] == [
+        "deepseek-v4-pro",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "deepseek-v4-flash",
+        "deepseek-v4-flash",
+    ]
 
 
 def test_call_chat_completion_retries_transient_failures_then_succeeds():

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -126,7 +126,8 @@ def _openai_cfg(**overrides):
         name="openai",
         api_key="sk-test",
         base_url="http://localhost:8080/v1",
-        model="gpt-5.5",
+        smart_model="gpt-5.5",
+        general_model="gpt-5.5-mini",
     )
     cfg = BotConfig(
         llm_providers=[provider],
@@ -137,6 +138,23 @@ def _openai_cfg(**overrides):
     for key, value in overrides.items():
         setattr(cfg, key, value)
     return cfg
+
+
+def test_provider_model_for_uses_smart_and_general_models():
+    provider = LlmProviderConfig(
+        name="openai",
+        api_key="sk-test",
+        base_url="http://localhost:8080/v1",
+        smart_model="smart",
+        general_model="general",
+    )
+
+    assert provider.model_for(task="judge") == "smart"
+    assert provider.model_for(task="review") == "smart"
+    assert provider.model_for(task="clarify") == "general"
+    assert provider.model_for(task="summary") == "general"
+    assert provider.model_for(task="unknown") == "general"
+    assert provider.model_for(task="judge", explicit_model="override") == "override"
 
 
 def test_call_chat_completion_retries_transient_failures_then_succeeds():
@@ -172,13 +190,15 @@ def test_call_chat_completion_pinned_provider_does_not_fallback():
         name="openai",
         api_key="sk-openai",
         base_url="http://openai.local/v1",
-        model="gpt-5.5",
+        smart_model="gpt-5.5",
+        general_model="gpt-5.5-mini",
     )
     deepseek = LlmProviderConfig(
         name="deepseek",
         api_key="sk-deepseek",
         base_url="http://deepseek.local/v1",
-        model="deepseek-v4-pro",
+        smart_model="deepseek-v4-pro",
+        general_model="deepseek-v4-chat",
     )
     cfg = BotConfig(
         llm_providers=[openai, deepseek],
@@ -283,7 +303,8 @@ def test_dashscope_provider_payload_enables_stream():
         name="qwen",
         api_key="sk-test",
         base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
-        model="qwen-test",
+        smart_model="qwen-test",
+        general_model="qwen-test-lite",
     )
     cfg = _openai_cfg(llm_providers=[provider])
     calls = []
@@ -371,7 +392,8 @@ def test_explicit_stream_provider_payload_enables_stream():
         name="openai",
         api_key="sk-test",
         base_url="http://localhost:8080/v1",
-        model="gpt-5.5",
+        smart_model="gpt-5.5",
+        general_model="gpt-5.5-mini",
         stream=True,
     )
     cfg = _openai_cfg(llm_providers=[provider])

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -157,6 +157,36 @@ def test_provider_model_for_uses_smart_and_general_models():
     assert provider.model_for(task="judge", explicit_model="override") == "override"
 
 
+def test_general_model_tasks_preserve_provider_model_tag():
+    provider = LlmProviderConfig(
+        name="openai",
+        api_key="sk-test",
+        base_url="http://localhost:8080/v1",
+        smart_model="smart",
+        general_model="general",
+        model_tag="『G』",
+    )
+    cfg = _openai_cfg(llm_providers=[provider])
+    calls = []
+
+    async def fake_once(session, **kwargs):
+        calls.append(kwargs["payload"].copy())
+        return _ChatCompletionAttempt(text="OK", retryable=False, retry_after_sec=None)
+
+    with patch("kouhai_bot.llm.get_config", return_value=cfg), \
+            patch("kouhai_bot.llm.aiohttp.ClientSession", _DummySession), \
+            patch("kouhai_bot.llm._post_chat_completion_once", side_effect=fake_once):
+        result = asyncio.run(call_chat_completion_result(
+            [{"role": "user", "content": "Reply with exactly OK."}],
+            task="summary",
+        ))
+
+    assert result.text == "OK"
+    assert result.model == "general"
+    assert result.model_tag == "『G』"
+    assert calls[0]["model"] == "general"
+
+
 def test_call_chat_completion_retries_transient_failures_then_succeeds():
     cfg = _openai_cfg(llm_max_retries=2, llm_retry_base_delay_sec=0.25)
     sleep_mock = AsyncMock()

--- a/tests/test_user_groups.py
+++ b/tests/test_user_groups.py
@@ -27,7 +27,13 @@ def _make_yaml(**overrides) -> str:
         "current_group": 123,
         "llm": {
             "providers": [
-                {"name": "t", "api_key": "k", "base_url": "http://x/v1", "model": "m"}
+                {
+                    "name": "t",
+                    "api_key": "k",
+                    "base_url": "http://x/v1",
+                    "smart_model": "smart",
+                    "general_model": "general",
+                }
             ]
         },
         "qwen": {"api_key": "k", "model": "qwen-vl-max"},


### PR DESCRIPTION
## Summary
- replace provider `model`/per-task override fields with required `smart_model` and `general_model`
- route judge/review to `smart_model` and all other LLM tasks to `general_model`
- update config example, agent docs, and tests for the breaking config schema change

## Notes
This intentionally removes compatibility for `model`, `judge_model`, `review_model`, `clarify_model`, and `summary_model` in `llm.providers`.

## Tests
- `uv run pytest tests/test_config.py tests/test_shared.py`
- `uv run pytest tests/test_commands.py::test_user_submission_history_is_unbounded_and_upserts_by_request_id tests/test_user_groups.py`
- `uv run pytest tests/test_config.py tests/test_shared.py tests/test_user_groups.py`
- `uv run pytest`