### PR TITLE
[codex] split llm smart and general provider queues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,20 +40,20 @@ NapCat (QQ) ──WS──> worker.py
   by `CURFEW_START_HOUR` and `CURFEW_DURATION_HOURS`. Other commands (clarify, review,
   scoreboard, etc.) are unaffected. Curfew wraps past midnight correctly (e.g. start=22,
   duration=6 → 22:00–04:00).
-- **LLM fallback**: `llm.py` — providers are tried in list order defined by
-  `llm.providers` in `config.yaml`. Each provider is retried internally
-  (`llm.max_retries`) before moving to the next. All providers use the
-  OpenAI-compatible `/chat/completions` format. DashScope/阿里云百炼 providers
-  are called with HTTP+SSE streaming to avoid the 10-minute synchronous HTTP
-  limit; providers with `stream: true` do the same; other providers use the
-  normal JSON response path. Each provider defines `smart_model` for judge/review
-  and `general_model` for clarify/summary/editorial and other tasks.
+- **LLM fallback**: `llm.py` — providers are tried in list order from one of two
+  independent queues in `config.yaml`: `llm.smart_model` for judge/review and
+  `llm.general_model` for clarify/summary/editorial and other tasks. Each
+  provider is retried internally (`llm.max_retries`) before moving to the next.
+  All providers use the OpenAI-compatible `/chat/completions` format.
+  DashScope/阿里云百炼 providers are called with HTTP+SSE streaming to avoid the
+  10-minute synchronous HTTP limit; providers with `stream: true` do the same;
+  other providers use the normal JSON response path.
   `thinking` and `reasoning_effort` are sent unconditionally; unsupported
   fields are silently ignored by upstream APIs.
 - **Official CF tutorials**: Scraped editorials live under `{data_dir}/tutorials/{pid}.json`
   (see `tools/cf_tutorial_agent.py`; low-level CF HTML helpers live in `tools/scrape_cf_tutorial.py`). Runtime extraction is in `tutorials.py`. On the
   On **new problem** (`do_daily_post` / `/newproblem`), `schedule_prefetch_editorial(pid)`
-  starts background translation (using `general_model`) into `tutorial_translations/` so first AC
+  starts background translation (using the `llm.general_model` queue) into `tutorial_translations/` so first AC
   can deliver without waiting. On **first AC**, congrats is sent in `_finalize_submit`, then
   `schedule_post_solve_editorial_followup()` only **delivers** (awaits in-flight prefetch if
   needed). Neither path uses the state scheduler. Tutorial scraping depends on Playwright
@@ -95,17 +95,17 @@ All providers use the OpenAI-compatible `/chat/completions` endpoint.
 | `llm.clarify_timeout_sec` | int | 600 | Clarify LLM timeout |
 | `llm.review_timeout_sec` | int | 600 | Review LLM timeout |
 | `llm.summary_timeout_sec` | int | 120 | Summary + editorial translation timeout |
-| `llm.providers` | list | — | **Ordered** fallback provider list (**required, min 1**) |
+| `llm.smart_model` | list | — | Ordered fallback provider list for `/submit` judge and `/review` (**required, min 1**) |
+| `llm.general_model` | list | — | Ordered fallback provider list for `/clarify`, summaries, editorial translation, sample-note translation, and other LLM tasks (**required, min 1**) |
 
-Each provider in `llm.providers`:
+Each provider in `llm.smart_model` or `llm.general_model`:
 
 | Key | Default | Description |
 |-----|---------|-------------|
 | `name` | — | Provider identifier for logging (**required**) |
 | `api_key` | — | API key (**required**) |
 | `base_url` | `https://api.openai.com/v1` | Base URL for chat completions |
-| `smart_model` | — | Model for `/submit` judge and `/review` (**required**) |
-| `general_model` | — | Model for `/clarify`, summaries, editorial translation, sample-note translation, and other LLM tasks (**required**) |
+| `model` | — | Model name for this provider entry (**required**) |
 | `reasoning_effort` | — | OpenAI reasoning effort: `minimal`/`low`/`medium`/`high`/`xhigh` |
 | `stream` | `false` | Send `stream=true` and read SSE chunks for this provider; DashScope/阿里云百炼 streams automatically |
 | `model_tag` | `""` | Short string appended to every LLM-generated user message (judge/clarify/review/summary/editorial); empty means no tag |
@@ -259,21 +259,26 @@ Healthy state:
 
 ### LLM fallback
 
-Providers in `llm.providers` are tried **in list order**. Each provider is retried
-up to `llm.max_retries` times internally (exponential backoff). On exhaustion, the
-next provider is tried. The first successful response wins.
+Providers in the selected queue are tried **in list order**. Each provider is
+retried up to `llm.max_retries` times internally (exponential backoff). On
+exhaustion, the next provider in that same queue is tried. The first successful
+response wins.
 
-Common fallback pattern: OpenAI (better quality, less stable) → DeepSeek (stable backup):
+Common fallback pattern: OpenAI (better quality, less stable) → DeepSeek (stable backup)
+for smart tasks, with a separate cheaper/faster general queue:
 ```yaml
 llm:
-  providers:
+  smart_model:
     - name: openai
-      smart_model: "gpt-5.5"
-      general_model: "gpt-5.5-mini"
+      model: "gpt-5.5"
       reasoning_effort: "high"
     - name: deepseek
-      smart_model: "deepseek-v4-pro"
-      general_model: "deepseek-v4-chat"
+      model: "deepseek-v4-pro"
+  general_model:
+    - name: qwen
+      model: "qwen3.7-plus"
+    - name: deepseek
+      model: "deepseek-v4-chat"
 ```
 
 All providers receive the same base request payload. Non-applicable fields (e.g.
@@ -343,15 +348,15 @@ No repository-local runtime queue is used.
 
 | Command | File | Handler | Lock | Model | Notes |
 |---------|------|---------|------|-------|-------|
-| `/submit` (`/sbm`) | submit.py | `handle` | ✅ state scheduler | per-provider `smart_model` | Judge solution, save history, serialize only first-blood/scoreboard; configured dynamic-wait group submits redirect to private judge; private AC does not score until synced |
-| `/clarify` (`/clrf`) | clarify.py | `handle` | ✅ state scheduler | per-provider `general_model` | Clarify problem details (JSON output, anti-spoiler, no original problem identity), using admission-time pid; private uses pid-specific summary |
+| `/submit` (`/sbm`) | submit.py | `handle` | ✅ state scheduler | `llm.smart_model` queue | Judge solution, save history, serialize only first-blood/scoreboard; configured dynamic-wait group submits redirect to private judge; private AC does not score until synced |
+| `/clarify` (`/clrf`) | clarify.py | `handle` | ✅ state scheduler | `llm.general_model` queue | Clarify problem details (JSON output, anti-spoiler, no original problem identity), using admission-time pid; private uses pid-specific summary |
 | `/clear` | clear.py | `handle` | ✅ state scheduler | — | Clear the current user's stored submit/clarify/review history for the admission-time current problem or current private problem |
-| `/newproblem` (`/np`) | newproblem.py | `handle` | ✅ post lock | per-provider `general_model` | Force new problem when solved (or none); unsolved needs exact `/newproblem --force`; samples are forwarded as separate nodes; if statement has `notes`, translate+symbol-normalize and append as a dedicated notes node; commits state only after card delivery succeeds and keeps `daily_msg.json` in sync even on direct-text fallback |
+| `/newproblem` (`/np`) | newproblem.py | `handle` | ✅ post lock | `llm.general_model` queue | Force new problem when solved (or none); unsolved needs exact `/newproblem --force`; samples are forwarded as separate nodes; if statement has `notes`, translate+symbol-normalize and append as a dedicated notes node; commits state only after card delivery succeeds and keeps `daily_msg.json` in sync even on direct-text fallback |
 | `/problem` (`/pb`) | stubs.py | `handle_problem` | ❌ | — | Resend current group/private problem via forward card; group path only uses `daily_msg.json` when pid matches `state.json.today`; if solved, add a friendly `/newproblem` hint |
 | `/tag` | stubs.py | `handle_tag` | ❌ | — | Show current group/private problem CF tags |
 | `/scoreboard` | stubs.py | `handle_scoreboard` | ❌ | — | Cumulative weighted leaderboard; shows the formula at the top, then refreshes latest group nicknames at display time |
 | `/help` | help.py | `handle` | ❌ | — | Auto-generated help (forward card) |
-| `/review` (`/rv`) | review.py | `handle` | ✅ state scheduler | per-provider `smart_model` | Discuss the latest solved group/private problem by default; quoted group problem cards can target older problems |
+| `/review` (`/rv`) | review.py | `handle` | ✅ state scheduler | `llm.smart_model` queue | Discuss the latest solved group/private problem by default; quoted group problem cards can target older problems |
 | `/status` | stubs.py | `handle_status` | ❌ | — | Check whether this group or private judge has active stateful work |
 | `/setproblem` (`/sp`) | setproblem.py | `handle` | ❌ | — | Private-only; set current private problem from current group problem, CF pid/link, `random`, or a quoted problem card |
 | `/sync` | sync.py | `handle` | ✅ short group state lock for group writes | — | Sync current group problem history between group and private judge; empty source aborts without overwrite |
@@ -592,7 +597,7 @@ scheduler lock, but final reply is not ordered behind unrelated same-group reque
   inputs. Ignore @all, the bot itself, the requester, and duplicate mentions. Do not
   persist anything to mentioned users' histories; only the requester receives the
   saved review record.
-- Uses per-provider `smart_model` (free text, no JSON format). Timeout from
+- Uses `llm.smart_model` queue (free text, no JSON format). Timeout from
   `llm.review_timeout_sec`. `thinking: enabled` and `reasoning_effort` are sent
   unconditionally; unsupported fields are silently ignored.
 - Long replies (>400 chars) → merged-forward card; short replies → @mention inline
@@ -689,7 +694,7 @@ lock and wraps the same locked implementation:
 1. Reveal yesterday's problem via `picker.py reveal`
 2. Pick a candidate problem via `picker.py pick-json --with-statement`; this marks used
    problems and caches statements but does **not** write `state.json`
-3. Generate Chinese summary via `summarize_problem()` → per-provider `general_model`,
+3. Generate Chinese summary via `summarize_problem()` → `llm.general_model` queue,
    timeout from `llm.summary_timeout_sec`
 4. Self-send summary text; self-send each sample as an independent node; if statement has
    `notes`, translate it to Chinese and append a dedicated `样例解释` node (with LaTeX/Markdown

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -26,14 +26,13 @@ llm:
   review_timeout_sec: 600
   summary_timeout_sec: 120
 
-  # Fallback provider list — order matters!
-  providers:
+  # Smart-model fallback queue — judge/review use this list. Order matters.
+  smart_model:
     # ── Optional primary: ZenMux/Fable (OpenAI-compatible) ──
     # - name: fable
     #   api_key: "..."
     #   base_url: "https://zenmux.ai/api/v1"
-    #   smart_model: "anthropic/claude-fable-5-free"
-    #   general_model: "anthropic/claude-fable-5-free"
+    #   model: "anthropic/claude-fable-5-free"
     #   reasoning_effort: "max"
     #   model_tag: "『Fable』"
 
@@ -41,8 +40,7 @@ llm:
     - name: openai
       api_key: "..."
       base_url: "..."
-      smart_model: "gpt-5.5"      # judge/review
-      general_model: "gpt-5.5-mini" # clarify/summary/editorial and other tasks
+      model: "gpt-5.5"
       stream: true               # use SSE streaming; recommended for sub2api/OpenAI
       reasoning_effort: "high"  # minimal/low/medium/high/xhigh
       model_tag: "『֎AI』"        # appended to LLM output; empty to disable
@@ -51,16 +49,29 @@ llm:
     - name: qwen
       api_key: "..."
       base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1"
-      smart_model: "qwen3.7-max"
-      general_model: "qwen3.7-plus"
+      model: "qwen3.7-max"
       model_tag: "『Qwen』"
 
     # ── Fallback: DeepSeek (supports OpenAI-compatible format) ──
     - name: deepseek
       api_key: "..."
       base_url: "https://api.deepseek.com"
-      smart_model: "deepseek-v4-pro"
-      general_model: "deepseek-v4-chat"
+      model: "deepseek-v4-pro"
+      model_tag: "『🐳』"
+
+  # General-model fallback queue — clarify/summary/editorial and other tasks use this list.
+  # This queue can use completely different providers/models from smart_model.
+  general_model:
+    - name: qwen
+      api_key: "..."
+      base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1"
+      model: "qwen3.7-plus"
+      model_tag: "『Qwen』"
+
+    - name: deepseek
+      api_key: "..."
+      base_url: "https://api.deepseek.com"
+      model: "deepseek-v4-chat"
       model_tag: "『🐳』"
 
 # ── Qwen-VL (formula image recognition) ──

--- a/src/kouhai_bot/config.py
+++ b/src/kouhai_bot/config.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import yaml
 
-from .llm_config import LlmProviderConfig, build_providers_from_yaml
+from .llm_config import LlmProviderConfig, build_provider_queues_from_yaml
 
 
 def _repo_root() -> Path:
@@ -107,7 +107,8 @@ class BotConfig:
     napcat_http_port: int = 3000
 
     # --- LLM fallback ---
-    llm_providers: list[LlmProviderConfig] = field(default_factory=list)
+    llm_smart_providers: list[LlmProviderConfig] = field(default_factory=list)
+    llm_general_providers: list[LlmProviderConfig] = field(default_factory=list)
     llm_max_retries: int = 2
     llm_retry_base_delay_sec: float = 1.0
     llm_retry_max_delay_sec: float = 8.0
@@ -171,7 +172,10 @@ class BotConfig:
         llm = data.get("llm", {})
         if not isinstance(llm, dict):
             raise RuntimeError("config.yaml: 'llm' must be a mapping")
-        c.llm_providers = build_providers_from_yaml(llm)
+        (
+            c.llm_smart_providers,
+            c.llm_general_providers,
+        ) = build_provider_queues_from_yaml(llm)
         c.llm_max_retries = int(llm.get("max_retries", c.llm_max_retries))
         c.llm_retry_base_delay_sec = float(
             llm.get("retry_base_delay_sec", c.llm_retry_base_delay_sec)

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -438,7 +438,11 @@ async def chat_completion(
     On exhaustion, the next provider in the fallback list is tried.
     """
     cfg = get_config()
-    providers = cfg.llm_providers
+    task_name = (task or "").strip().lower()
+    if task_name in {"judge", "review"}:
+        providers = cfg.llm_smart_providers
+    else:
+        providers = cfg.llm_general_providers
     if provider_name:
         providers = [p for p in providers if p.name == provider_name]
     if not providers:
@@ -458,7 +462,7 @@ async def chat_completion(
 
     async with aiohttp.ClientSession() as session:
         for provider in providers:
-            model_name = provider.model_for(task=task, explicit_model=model)
+            model_name = provider.model_for(explicit_model=model)
             headers = {
                 "Authorization": f"Bearer {provider.api_key}",
                 "Content-Type": "application/json",

--- a/src/kouhai_bot/llm_config.py
+++ b/src/kouhai_bot/llm_config.py
@@ -24,7 +24,7 @@ def _parse_bool(value: Any, *, default: bool = False) -> bool:
 
 @dataclass(frozen=True)
 class LlmProviderConfig:
-    """A single LLM provider with its own credentials and per-task model mapping.
+    """A single LLM provider entry in one fallback queue.
 
     Fallback order is defined by list position in the YAML config.
     """
@@ -32,71 +32,64 @@ class LlmProviderConfig:
     name: str
     api_key: str
     base_url: str
-    smart_model: str
-    general_model: str
+    model: str
     reasoning_effort: str = ""
     model_tag: str = ""
     stream: bool = False
 
-    def model_for(self, task: str = "", explicit_model: str = "") -> str:
-        """Resolve the model name for a given task.
+    def model_for(self, explicit_model: str = "") -> str:
+        """Resolve the model name for this provider.
 
-        Priority: explicit_model > smart/general task default.
+        Priority: explicit_model > provider model.
         """
-        if explicit_model:
-            return explicit_model
-        task_name = (task or "").strip().lower()
-        if task_name in {"judge", "review"}:
-            return self.smart_model
-        return self.general_model
+        return explicit_model or self.model
 
 
-def build_providers_from_yaml(llm_section: dict[str, Any]) -> list[LlmProviderConfig]:
-    """Build ordered provider list from the YAML ``llm.providers`` list.
-
-    Raises RuntimeError if the list is empty or required fields are missing.
-    """
-    providers_raw = llm_section.get("providers", [])
-    if not isinstance(providers_raw, list):
+def _build_provider_list(raw: Any, *, section_name: str) -> list[LlmProviderConfig]:
+    if not isinstance(raw, list):
         raise RuntimeError(
-            "config.yaml: llm.providers must be a list of provider mappings"
+            f"config.yaml: llm.{section_name} must be a list of provider mappings"
         )
-    if not providers_raw:
+    if not raw:
         raise RuntimeError(
-            "No LLM providers configured in config.yaml: llm.providers is empty"
+            f"No LLM providers configured in config.yaml: llm.{section_name} is empty"
         )
 
     providers: list[LlmProviderConfig] = []
     seen: set[str] = set()
-    for p in providers_raw:
+    for p in raw:
         if not isinstance(p, dict):
             raise RuntimeError(
-                f"config.yaml: each entry in llm.providers must be a mapping, "
+                f"config.yaml: each entry in llm.{section_name} must be a mapping, "
                 f"got {type(p).__name__}: {p!r}"
             )
         name = str(p.get("name", "")).strip()
         if not name:
-            raise RuntimeError("Each LLM provider must have a 'name' field")
+            raise RuntimeError(
+                f"Each LLM provider in llm.{section_name} must have a 'name' field"
+            )
         if name in seen:
-            raise RuntimeError(f"Duplicate LLM provider name: {name}")
+            raise RuntimeError(
+                f"Duplicate LLM provider name in llm.{section_name}: {name}"
+            )
         seen.add(name)
 
         api_key = str(p.get("api_key", "")).strip()
         if not api_key:
-            raise RuntimeError(f"LLM provider '{name}' requires 'api_key'")
+            raise RuntimeError(
+                f"LLM provider '{name}' in llm.{section_name} requires 'api_key'"
+            )
 
-        smart_model = str(p.get("smart_model", "")).strip()
-        if not smart_model:
-            raise RuntimeError(f"LLM provider '{name}' requires 'smart_model'")
-
-        general_model = str(p.get("general_model", "")).strip()
-        if not general_model:
-            raise RuntimeError(f"LLM provider '{name}' requires 'general_model'")
+        model = str(p.get("model", "")).strip()
+        if not model:
+            raise RuntimeError(
+                f"LLM provider '{name}' in llm.{section_name} requires 'model'"
+            )
 
         base_url = str(p.get("base_url", "https://api.openai.com/v1")).strip()
         if not base_url:
             raise RuntimeError(
-                f"LLM provider '{name}' has empty base_url; "
+                f"LLM provider '{name}' in llm.{section_name} has empty base_url; "
                 f"set base_url (e.g. https://api.deepseek.com) or omit for OpenAI default"
             )
 
@@ -105,11 +98,29 @@ def build_providers_from_yaml(llm_section: dict[str, Any]) -> list[LlmProviderCo
                 name=name,
                 api_key=api_key,
                 base_url=base_url,
-                smart_model=smart_model,
-                general_model=general_model,
+                model=model,
                 reasoning_effort=str(p.get("reasoning_effort", "")).strip(),
                 model_tag=str(p.get("model_tag", "")).strip(),
                 stream=_parse_bool(p.get("stream", False)),
             )
         )
     return providers
+
+
+def build_provider_queues_from_yaml(
+    llm_section: dict[str, Any],
+) -> tuple[list[LlmProviderConfig], list[LlmProviderConfig]]:
+    """Build smart/general provider fallback queues from the YAML ``llm`` section.
+
+    Raises RuntimeError if either queue is empty or required fields are missing.
+    """
+    return (
+        _build_provider_list(
+            llm_section.get("smart_model", []),
+            section_name="smart_model",
+        ),
+        _build_provider_list(
+            llm_section.get("general_model", []),
+            section_name="general_model",
+        ),
+    )

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -86,8 +86,8 @@ class _LazyConfig:
         "llm_openai_base_url": "https://api.openai.com/v1",
         "llm_openai_model": "gpt-5",
         "llm_reasoning_effort": "",
-        "smart_model": "deepseek-v4-pro",
-        "general_model": "deepseek-v4-flash",
+        "smart_queue_model": "deepseek-v4-pro",
+        "general_queue_model": "deepseek-v4-flash",
         "qwen_api_key": "",
         "qwen_model": "qwen-vl-max",
         "current_group": GID,
@@ -121,8 +121,8 @@ class _LazyConfig:
             return explicit_model
         task_name = (task or "").strip().lower()
         if task_name in {"judge", "review"}:
-            return self._config.get("smart_model") or "deepseek-v4-pro"
-        return self._config.get("general_model") or "deepseek-v4-flash"
+            return self._config.get("smart_queue_model") or "deepseek-v4-pro"
+        return self._config.get("general_queue_model") or "deepseek-v4-flash"
 
     def __getattr__(self, name):
         if name == "data_dir":

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -395,8 +395,8 @@ def _config_dict():
         "llm_openai_base_url": "https://api.openai.com/v1",
         "llm_openai_model": "gpt-5",
         "llm_reasoning_effort": "",
-        "smart_model": "deepseek-v4-pro",
-        "general_model": "deepseek-v4-flash",
+        "smart_queue_model": "deepseek-v4-pro",
+        "general_queue_model": "deepseek-v4-flash",
         "judge_timeout_sec": 1200,
         "clarify_timeout_sec": 600,
         "review_timeout_sec": 600,
@@ -439,8 +439,8 @@ class _LazyConfig:
             return explicit_model
         task_name = (task or "").strip().lower()
         if task_name in {"judge", "review"}:
-            return self._config.get("smart_model") or "deepseek-v4-pro"
-        return self._config.get("general_model") or "deepseek-v4-flash"
+            return self._config.get("smart_queue_model") or "deepseek-v4-pro"
+        return self._config.get("general_queue_model") or "deepseek-v4-flash"
 
     def __getattr__(self, name):
         if name == "data_dir":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,15 +16,22 @@ def _make_yaml(**overrides) -> str:
         "bot_qq": 1234567890,
         "current_group": 999999,
         "llm": {
-            "providers": [
+            "smart_model": [
                 {
-                    "name": "test",
+                    "name": "smart-test",
                     "api_key": "sk-test",
                     "base_url": "http://localhost:8080/v1",
-                    "smart_model": "test-smart-model",
-                    "general_model": "test-general-model",
+                    "model": "test-smart-model",
                 }
-            ]
+            ],
+            "general_model": [
+                {
+                    "name": "general-test",
+                    "api_key": "sk-test",
+                    "base_url": "http://localhost:8080/v1",
+                    "model": "test-general-model",
+                }
+            ],
         },
         "qwen": {
             "api_key": "sk-qwen",
@@ -59,10 +66,17 @@ def test_config_requires_bot_qq(monkeypatch, tmp_path):
         _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
 
 
-def test_config_requires_providers(monkeypatch, tmp_path):
+def test_config_requires_smart_model_queue(monkeypatch, tmp_path):
     data = yaml.safe_load(_make_yaml())
-    data["llm"]["providers"] = []
-    with pytest.raises(RuntimeError, match="providers"):
+    data["llm"]["smart_model"] = []
+    with pytest.raises(RuntimeError, match="smart_model"):
+        _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
+
+
+def test_config_requires_general_model_queue(monkeypatch, tmp_path):
+    data = yaml.safe_load(_make_yaml())
+    data["llm"]["general_model"] = []
+    with pytest.raises(RuntimeError, match="general_model"):
         _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
 
 
@@ -75,31 +89,25 @@ def test_config_requires_qwen_model(monkeypatch, tmp_path):
 
 def test_config_requires_provider_name(monkeypatch, tmp_path):
     data = yaml.safe_load(_make_yaml())
-    data["llm"]["providers"][0]["name"] = ""
+    data["llm"]["smart_model"][0]["name"] = ""
     with pytest.raises(RuntimeError, match="name"):
         _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
 
 
-def test_config_requires_provider_smart_model(monkeypatch, tmp_path):
+def test_config_requires_provider_model(monkeypatch, tmp_path):
     data = yaml.safe_load(_make_yaml())
-    data["llm"]["providers"][0]["smart_model"] = ""
-    with pytest.raises(RuntimeError, match="smart_model"):
+    data["llm"]["general_model"][0]["model"] = ""
+    with pytest.raises(RuntimeError, match="model"):
         _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
 
 
-def test_config_requires_provider_general_model(monkeypatch, tmp_path):
+def test_legacy_single_provider_queue_does_not_satisfy_required_queues(monkeypatch, tmp_path):
     data = yaml.safe_load(_make_yaml())
-    data["llm"]["providers"][0]["general_model"] = ""
-    with pytest.raises(RuntimeError, match="general_model"):
-        _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
-
-
-def test_legacy_provider_model_does_not_satisfy_required_models(monkeypatch, tmp_path):
-    data = yaml.safe_load(_make_yaml())
-    provider = data["llm"]["providers"][0]
-    provider["model"] = "legacy-model"
-    del provider["smart_model"]
-    del provider["general_model"]
+    data["llm"] = {
+        "providers": [
+            {"name": "legacy", "api_key": "k", "base_url": "http://x/v1", "model": "m"}
+        ]
+    }
     with pytest.raises(RuntimeError, match="smart_model"):
         _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
 
@@ -107,14 +115,11 @@ def test_legacy_provider_model_does_not_satisfy_required_models(monkeypatch, tmp
 def test_llm_timeouts_load_from_yaml(monkeypatch, tmp_path):
     yaml_str = _make_yaml(
         llm={
-            "providers": [
-                {
-                    "name": "t",
-                    "api_key": "k",
-                    "base_url": "http://x/v1",
-                    "smart_model": "smart",
-                    "general_model": "general",
-                }
+            "smart_model": [
+                {"name": "smart", "api_key": "k", "base_url": "http://x/v1", "model": "smart"}
+            ],
+            "general_model": [
+                {"name": "general", "api_key": "k", "base_url": "http://x/v1", "model": "general"}
             ],
             "judge_timeout_sec": 1500,
             "clarify_timeout_sec": 700,
@@ -131,10 +136,10 @@ def test_llm_timeouts_load_from_yaml(monkeypatch, tmp_path):
 
 def test_provider_stream_loads_from_yaml(monkeypatch, tmp_path):
     data = yaml.safe_load(_make_yaml())
-    data["llm"]["providers"][0]["stream"] = True
+    data["llm"]["smart_model"][0]["stream"] = True
     cfg = _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
 
-    assert cfg.llm_providers[0].stream is True
+    assert cfg.llm_smart_providers[0].stream is True
 
 
 def test_current_group_loaded(monkeypatch, tmp_path):
@@ -147,15 +152,15 @@ def test_submit_ac_backdoor_loaded(monkeypatch, tmp_path):
     assert cfg.submit_ac_backdoor == "open-sesame"
 
 
-def test_providers_not_list_raises(monkeypatch, tmp_path):
+def test_provider_queue_not_list_raises(monkeypatch, tmp_path):
     data = yaml.safe_load(_make_yaml())
-    data["llm"]["providers"] = "not-a-list"
+    data["llm"]["smart_model"] = "not-a-list"
     with pytest.raises(RuntimeError, match="must be a list"):
         _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
 
 
 def test_provider_entry_not_dict_raises(monkeypatch, tmp_path):
     data = yaml.safe_load(_make_yaml())
-    data["llm"]["providers"] = ["not-a-dict"]
+    data["llm"]["general_model"] = ["not-a-dict"]
     with pytest.raises(RuntimeError, match="must be a mapping"):
         _from_yaml(yaml.dump(data), monkeypatch, tmp_path)

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -131,15 +131,21 @@ class _PostSession:
 
 
 def _openai_cfg(**overrides):
-    provider = LlmProviderConfig(
+    smart_provider = LlmProviderConfig(
         name="openai",
         api_key="sk-test",
         base_url="http://localhost:8080/v1",
-        smart_model="gpt-5.5",
-        general_model="gpt-5.5-mini",
+        model="gpt-5.5",
+    )
+    general_provider = LlmProviderConfig(
+        name="openai",
+        api_key="sk-test",
+        base_url="http://localhost:8080/v1",
+        model="gpt-5.5-mini",
     )
     cfg = BotConfig(
-        llm_providers=[provider],
+        llm_smart_providers=[smart_provider],
+        llm_general_providers=[general_provider],
         llm_max_retries=2,
         llm_retry_base_delay_sec=1.0,
         llm_retry_max_delay_sec=8.0,
@@ -149,21 +155,16 @@ def _openai_cfg(**overrides):
     return cfg
 
 
-def test_provider_model_for_uses_smart_and_general_models():
+def test_provider_model_for_uses_provider_model_and_explicit_override():
     provider = LlmProviderConfig(
         name="openai",
         api_key="sk-test",
         base_url="http://localhost:8080/v1",
-        smart_model="smart",
-        general_model="general",
+        model="configured",
     )
 
-    assert provider.model_for(task="judge") == "smart"
-    assert provider.model_for(task="review") == "smart"
-    assert provider.model_for(task="clarify") == "general"
-    assert provider.model_for(task="summary") == "general"
-    assert provider.model_for(task="unknown") == "general"
-    assert provider.model_for(task="judge", explicit_model="override") == "override"
+    assert provider.model_for() == "configured"
+    assert provider.model_for(explicit_model="override") == "override"
 
 
 def test_general_model_tasks_preserve_provider_model_tag():
@@ -171,11 +172,10 @@ def test_general_model_tasks_preserve_provider_model_tag():
         name="openai",
         api_key="sk-test",
         base_url="http://localhost:8080/v1",
-        smart_model="smart",
-        general_model="general",
+        model="general",
         model_tag="『G』",
     )
-    cfg = _openai_cfg(llm_providers=[provider])
+    cfg = _openai_cfg(llm_general_providers=[provider])
     calls = []
 
     async def fake_once(session, **kwargs):
@@ -197,15 +197,24 @@ def test_general_model_tasks_preserve_provider_model_tag():
 
 
 def test_task_entrypoints_are_blackbox_except_model_class_and_tag():
-    provider = LlmProviderConfig(
-        name="deepseek",
+    smart_provider = LlmProviderConfig(
+        name="deepseek-smart",
         api_key="sk-test",
         base_url="http://localhost:8080/v1",
-        smart_model="deepseek-v4-pro",
-        general_model="deepseek-v4-flash",
+        model="deepseek-v4-pro",
         model_tag="『T』",
     )
-    cfg = _openai_cfg(llm_providers=[provider])
+    general_provider = LlmProviderConfig(
+        name="deepseek-general",
+        api_key="sk-test",
+        base_url="http://localhost:8080/v1",
+        model="deepseek-v4-flash",
+        model_tag="『T』",
+    )
+    cfg = _openai_cfg(
+        llm_smart_providers=[smart_provider],
+        llm_general_providers=[general_provider],
+    )
     calls = []
 
     async def fake_once(session, **kwargs):
@@ -295,18 +304,17 @@ def test_call_chat_completion_pinned_provider_does_not_fallback():
         name="openai",
         api_key="sk-openai",
         base_url="http://openai.local/v1",
-        smart_model="gpt-5.5",
-        general_model="gpt-5.5-mini",
+        model="gpt-5.5",
     )
     deepseek = LlmProviderConfig(
         name="deepseek",
         api_key="sk-deepseek",
         base_url="http://deepseek.local/v1",
-        smart_model="deepseek-v4-pro",
-        general_model="deepseek-v4-chat",
+        model="deepseek-v4-pro",
     )
     cfg = BotConfig(
-        llm_providers=[openai, deepseek],
+        llm_smart_providers=[openai, deepseek],
+        llm_general_providers=[deepseek],
         llm_max_retries=0,
         llm_retry_base_delay_sec=0.0,
         llm_retry_max_delay_sec=0.0,
@@ -408,10 +416,9 @@ def test_dashscope_provider_payload_enables_stream():
         name="qwen",
         api_key="sk-test",
         base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
-        smart_model="qwen-test",
-        general_model="qwen-test-lite",
+        model="qwen-test",
     )
-    cfg = _openai_cfg(llm_providers=[provider])
+    cfg = _openai_cfg(llm_smart_providers=[provider])
     calls = []
 
     async def fake_once(session, **kwargs):
@@ -438,11 +445,10 @@ def test_zenmux_fable_payload_uses_reasoning_effort_without_generic_thinking():
         name="fable",
         api_key="sk-test",
         base_url="https://zenmux.ai/api/v1",
-        smart_model="anthropic/claude-fable-5-free",
-        general_model="anthropic/claude-fable-5-free",
+        model="anthropic/claude-fable-5-free",
         reasoning_effort="max",
     )
-    cfg = _openai_cfg(llm_providers=[provider])
+    cfg = _openai_cfg(llm_smart_providers=[provider])
     calls = []
 
     async def fake_once(session, **kwargs):
@@ -498,11 +504,10 @@ def test_explicit_stream_provider_payload_enables_stream():
         name="openai",
         api_key="sk-test",
         base_url="http://localhost:8080/v1",
-        smart_model="gpt-5.5",
-        general_model="gpt-5.5-mini",
+        model="gpt-5.5",
         stream=True,
     )
-    cfg = _openai_cfg(llm_providers=[provider])
+    cfg = _openai_cfg(llm_smart_providers=[provider])
     calls = []
 
     async def fake_once(session, **kwargs):

--- a/tests/test_user_groups.py
+++ b/tests/test_user_groups.py
@@ -26,15 +26,12 @@ def _make_yaml(**overrides) -> str:
         "bot_qq": 1,
         "current_group": 123,
         "llm": {
-            "providers": [
-                {
-                    "name": "t",
-                    "api_key": "k",
-                    "base_url": "http://x/v1",
-                    "smart_model": "smart",
-                    "general_model": "general",
-                }
-            ]
+            "smart_model": [
+                {"name": "smart", "api_key": "k", "base_url": "http://x/v1", "model": "smart"}
+            ],
+            "general_model": [
+                {"name": "general", "api_key": "k", "base_url": "http://x/v1", "model": "general"}
+            ],
         },
         "qwen": {"api_key": "k", "model": "qwen-vl-max"},
     }


### PR DESCRIPTION
## Summary
- replace the merged per-provider `smart_model`/`general_model` fields with two independent fallback queues: `llm.smart_model` and `llm.general_model`
- restore each provider entry to a single `model` field, so smart/general queues can use completely different providers and model sets
- route judge/review to the smart queue and all other LLM tasks to the general queue while keeping HTTP payload construction/retry/stream/tag behavior shared
- update config example, AGENTS.md, and tests for the corrected schema

## Validation
- real DeepSeek smoke with temporary config using the new split queue schema:
  - `task=summary` through `llm.general_model`
  - `task=review` through `llm.smart_model`
  - `task=judge` through `llm.smart_model` with `response_format=json_object` and `thinking`
- `uv run pytest tests/test_config.py tests/test_shared.py`
- `uv run pytest tests/test_config.py tests/test_shared.py tests/test_user_groups.py tests/test_annotations.py tests/test_commands.py`
- `uv run pytest`