### PR TITLE
Add group echo repeat feature

### DIFF
--- a/src/kouhai_bot/echo.py
+++ b/src/kouhai_bot/echo.py
@@ -1,4 +1,4 @@
-"""Group echo/repeat handling for non-command messages."""
+"""Group echo/repeat handling for group messages."""
 
 from __future__ import annotations
 
@@ -41,7 +41,7 @@ class GroupEcho:
         cfg = get_config()
         if group_id != cfg.current_group:
             return False
-        if not raw_text or raw_text.startswith("/"):
+        if not raw_text:
             return False
 
         echo_text: str | None = None
@@ -53,7 +53,7 @@ class GroupEcho:
             streak_len = 0
             streak_users: set[int] = set()
             for entry in reversed(buf):
-                if entry.raw_text != streak_text:
+                if entry.raw_text != streak_text or entry.raw_text.startswith("/"):
                     break
                 streak_len += 1
                 streak_users.add(entry.user_id)

--- a/src/kouhai_bot/echo.py
+++ b/src/kouhai_bot/echo.py
@@ -21,20 +21,13 @@ class EchoEntry:
 
 
 class GroupEcho:
-    """Bounded per-group recent-message buffers for repeat detection."""
+    """Bounded recent-message buffer for repeat detection."""
 
     def __init__(self, *, max_entries: int = 50, trigger_count: int = 3) -> None:
         self.max_entries = max_entries
         self.trigger_count = trigger_count
-        self._buffers: dict[int, deque[EchoEntry]] = {}
+        self._buffer: deque[EchoEntry] = deque(maxlen=max_entries)
         self._lock = asyncio.Lock()
-
-    def _buffer_for(self, group_id: int) -> deque[EchoEntry]:
-        buf = self._buffers.get(group_id)
-        if buf is None:
-            buf = deque(maxlen=self.max_entries)
-            self._buffers[group_id] = buf
-        return buf
 
     async def check_and_echo(
         self,
@@ -53,7 +46,7 @@ class GroupEcho:
 
         echo_text: str | None = None
         async with self._lock:
-            buf = self._buffer_for(group_id)
+            buf = self._buffer
             buf.append(EchoEntry(user_id=user_id, raw_text=raw_text, message_id=message_id))
 
             streak_text = buf[-1].raw_text
@@ -83,9 +76,9 @@ class GroupEcho:
         await send_group_msg(group_id, build_plain_message(echo_text))
         return True
 
-    def buffer_snapshot(self, group_id: int) -> list[EchoEntry]:
-        """Return a copy of a group buffer for tests and diagnostics."""
-        return list(self._buffers.get(group_id, ()))
+    def buffer_snapshot(self) -> list[EchoEntry]:
+        """Return a copy of the buffer for tests and diagnostics."""
+        return list(self._buffer)
 
 
 _echo = GroupEcho()

--- a/src/kouhai_bot/echo.py
+++ b/src/kouhai_bot/echo.py
@@ -17,7 +17,7 @@ logger = logging.getLogger("kouhai-bot.echo")
 class EchoEntry:
     user_id: int
     raw_text: str
-    message_id: str
+    message_id: int | str
 
 
 class GroupEcho:
@@ -35,7 +35,7 @@ class GroupEcho:
         group_id: int,
         user_id: int,
         raw_text: str,
-        message_id: str,
+        message_id: int | str,
     ) -> bool:
         """Record a group message and echo it when a repeat streak triggers."""
         cfg = get_config()
@@ -89,7 +89,7 @@ async def check_and_echo(
     group_id: int,
     user_id: int,
     raw_text: str,
-    message_id: str,
+    message_id: int | str,
 ) -> bool:
     return await _echo.check_and_echo(
         group_id=group_id,

--- a/src/kouhai_bot/echo.py
+++ b/src/kouhai_bot/echo.py
@@ -1,0 +1,106 @@
+"""Group echo/repeat handling for non-command messages."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import deque
+from dataclasses import dataclass
+
+from .config import get_config
+from .napcat.client import build_plain_message, send_group_msg
+
+logger = logging.getLogger("kouhai-bot.echo")
+
+
+@dataclass(frozen=True)
+class EchoEntry:
+    user_id: int
+    raw_text: str
+    message_id: str
+
+
+class GroupEcho:
+    """Bounded per-group recent-message buffers for repeat detection."""
+
+    def __init__(self, *, max_entries: int = 50, trigger_count: int = 3) -> None:
+        self.max_entries = max_entries
+        self.trigger_count = trigger_count
+        self._buffers: dict[int, deque[EchoEntry]] = {}
+        self._lock = asyncio.Lock()
+
+    def _buffer_for(self, group_id: int) -> deque[EchoEntry]:
+        buf = self._buffers.get(group_id)
+        if buf is None:
+            buf = deque(maxlen=self.max_entries)
+            self._buffers[group_id] = buf
+        return buf
+
+    async def check_and_echo(
+        self,
+        *,
+        group_id: int,
+        user_id: int,
+        raw_text: str,
+        message_id: str,
+    ) -> bool:
+        """Record a group message and echo it when a repeat streak triggers."""
+        cfg = get_config()
+        if group_id != cfg.current_group:
+            return False
+        if not raw_text or raw_text.startswith("/"):
+            return False
+
+        echo_text: str | None = None
+        async with self._lock:
+            buf = self._buffer_for(group_id)
+            buf.append(EchoEntry(user_id=user_id, raw_text=raw_text, message_id=message_id))
+
+            streak_text = buf[-1].raw_text
+            streak_len = 0
+            streak_users: set[int] = set()
+            for entry in reversed(buf):
+                if entry.raw_text != streak_text:
+                    break
+                streak_len += 1
+                streak_users.add(entry.user_id)
+
+            if streak_len < self.trigger_count:
+                return False
+
+            has_bot = any(str(uid) == str(cfg.bot_qq) for uid in streak_users)
+            if not has_bot:
+                echo_text = streak_text
+
+            for _ in range(streak_len):
+                buf.pop()
+
+        if echo_text is None:
+            logger.debug("Skipped echo for group %s because bot was in streak", group_id)
+            return False
+
+        logger.info("Echoing repeated group message in group %s", group_id)
+        await send_group_msg(group_id, build_plain_message(echo_text))
+        return True
+
+    def buffer_snapshot(self, group_id: int) -> list[EchoEntry]:
+        """Return a copy of a group buffer for tests and diagnostics."""
+        return list(self._buffers.get(group_id, ()))
+
+
+_echo = GroupEcho()
+
+
+async def check_and_echo(
+    *,
+    group_id: int,
+    user_id: int,
+    raw_text: str,
+    message_id: str,
+) -> bool:
+    return await _echo.check_and_echo(
+        group_id=group_id,
+        user_id=user_id,
+        raw_text=raw_text,
+        message_id=message_id,
+    )

--- a/src/kouhai_bot/handlers/__init__.py
+++ b/src/kouhai_bot/handlers/__init__.py
@@ -10,6 +10,7 @@ import unicodedata
 from . import registry
 from .registry import CommandDef
 from ..config import get_config
+from .. import echo
 from ..eventlog import (
     EVENT_META_KEY,
     log_command_finished,
@@ -148,6 +149,13 @@ async def process_event(
         if msg_type == "private":
             # DM — respond naturally
             pass  # TODO: chat handler
+        elif msg_type == "group":
+            await echo.check_and_echo(
+                group_id=group_id,
+                user_id=user_id,
+                raw_text=raw_text,
+                message_id=message_id,
+            )
         return
 
     # Extract command name

--- a/src/kouhai_bot/handlers/__init__.py
+++ b/src/kouhai_bot/handlers/__init__.py
@@ -144,18 +144,19 @@ async def process_event(
     if not raw_text:
         return
 
+    if msg_type == "group":
+        await echo.check_and_echo(
+            group_id=group_id,
+            user_id=user_id,
+            raw_text=raw_text,
+            message_id=message_id,
+        )
+
     # Only respond to commands (starting with /) or DMs
     if not raw_text.startswith("/"):
         if msg_type == "private":
             # DM — respond naturally
             pass  # TODO: chat handler
-        elif msg_type == "group":
-            await echo.check_and_echo(
-                group_id=group_id,
-                user_id=user_id,
-                raw_text=raw_text,
-                message_id=message_id,
-            )
         return
 
     # Extract command name

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -1,0 +1,144 @@
+import asyncio
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from kouhai_bot.echo import GroupEcho
+from kouhai_bot.handlers import process_event
+
+
+GID = 123456
+OTHER_GID = 654321
+BOT_QQ = 1234567890
+
+
+class _TestConfig:
+    bot_qq = BOT_QQ
+    current_group = GID
+
+
+def _event(text: str, *, user_id: int = 42, group_id: int = GID) -> dict:
+    return {
+        "type": "message",
+        "message_type": "group",
+        "group_id": group_id,
+        "user_id": user_id,
+        "sender": {"nickname": "Alice", "card": "", "user_id": user_id},
+        "message_id": f"msg_{group_id}_{user_id}_{text}",
+        "raw_message": text,
+        "message": [{"type": "text", "data": {"text": text}}],
+    }
+
+
+async def _feed(echo: GroupEcho, texts: list[str], *, users: list[int] | None = None):
+    sent: list[tuple[int, list[dict]]] = []
+
+    async def _send_group_msg(group_id: int, message: list[dict]):
+        sent.append((group_id, message))
+        return len(sent)
+
+    with patch("kouhai_bot.config._config", _TestConfig()), \
+            patch("kouhai_bot.echo.send_group_msg", _send_group_msg):
+        for i, text in enumerate(texts):
+            user_id = users[i] if users is not None else i + 1
+            await echo.check_and_echo(
+                group_id=GID,
+                user_id=user_id,
+                raw_text=text,
+                message_id=f"msg_{i}",
+            )
+
+    return sent
+
+
+def test_three_identical_messages_trigger_echo():
+    echo = GroupEcho()
+
+    sent = asyncio.run(_feed(echo, ["复读", "复读", "复读"]))
+
+    assert sent == [(GID, [{"type": "text", "data": {"text": "复读"}}])]
+    assert echo.buffer_snapshot(GID) == []
+
+
+def test_two_identical_messages_do_not_trigger():
+    echo = GroupEcho()
+
+    sent = asyncio.run(_feed(echo, ["复读", "复读"]))
+
+    assert sent == []
+    assert [entry.raw_text for entry in echo.buffer_snapshot(GID)] == ["复读", "复读"]
+
+
+def test_identical_messages_with_different_one_in_between_wait_for_suffix_streak():
+    echo = GroupEcho()
+
+    sent = asyncio.run(_feed(echo, ["复读", "复读", "打断", "复读", "复读", "复读"]))
+
+    assert sent == [(GID, [{"type": "text", "data": {"text": "复读"}}])]
+    assert [entry.raw_text for entry in echo.buffer_snapshot(GID)] == ["复读", "复读", "打断"]
+
+
+def test_bot_in_streak_prevents_echo():
+    echo = GroupEcho()
+
+    sent = asyncio.run(_feed(
+        echo,
+        ["复读", "复读", "复读"],
+        users=[101, BOT_QQ, 102],
+    ))
+
+    assert sent == []
+    assert echo.buffer_snapshot(GID) == []
+
+
+def test_command_messages_are_ignored():
+    echo = GroupEcho()
+
+    sent = asyncio.run(_feed(echo, ["复读", "/submit 复读", "复读", "复读"]))
+
+    assert sent == [(GID, [{"type": "text", "data": {"text": "复读"}}])]
+    assert echo.buffer_snapshot(GID) == []
+
+
+def test_non_identical_messages_do_not_trigger():
+    echo = GroupEcho()
+
+    sent = asyncio.run(_feed(echo, ["a", "b", "a", "b", "c"]))
+
+    assert sent == []
+
+
+def test_buffer_is_bounded():
+    echo = GroupEcho(max_entries=5, trigger_count=99)
+
+    sent = asyncio.run(_feed(echo, [f"msg {i}" for i in range(8)]))
+
+    assert sent == []
+    assert [entry.raw_text for entry in echo.buffer_snapshot(GID)] == [
+        "msg 3",
+        "msg 4",
+        "msg 5",
+        "msg 6",
+        "msg 7",
+    ]
+
+
+def test_process_event_hooks_echo_for_non_command_group_messages():
+    sent: list[tuple[int, list[dict]]] = []
+
+    async def _send_group_msg(group_id: int, message: list[dict]):
+        sent.append((group_id, message))
+        return len(sent)
+
+    async def _run():
+        with patch("kouhai_bot.config._config", _TestConfig()), \
+                patch("kouhai_bot.echo.send_group_msg", _send_group_msg):
+            for i in range(3):
+                await process_event(_event("复读", user_id=i + 10), spawn_handlers=False)
+            await process_event(_event("复读", group_id=OTHER_GID), spawn_handlers=False)
+
+    asyncio.run(_run())
+
+    assert sent == [(GID, [{"type": "text", "data": {"text": "复读"}}])]

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -10,7 +10,13 @@ from kouhai_bot.handlers import process_event
 
 
 BOT_QQ = 1234567890
-ECHO_MESSAGE = [{"type": "text", "data": {"text": "复读"}}]
+
+
+def _plain(text: str) -> list[dict]:
+    return [{"type": "text", "data": {"text": text}}]
+
+
+ECHO_MESSAGE = _plain("复读")
 
 
 class _TestConfig:
@@ -92,13 +98,36 @@ def test_bot_in_streak_prevents_echo():
     assert echo.buffer_snapshot() == []
 
 
-def test_command_messages_are_ignored():
+def test_command_messages_break_streak_and_stay_in_buffer():
     echo = GroupEcho()
 
     sent = asyncio.run(_feed(echo, ["复读", "/submit 复读", "复读", "复读"]))
 
-    assert sent == [(_TestConfig.current_group, ECHO_MESSAGE)]
-    assert echo.buffer_snapshot() == []
+    assert sent == []
+    assert [entry.raw_text for entry in echo.buffer_snapshot()] == [
+        "复读",
+        "/submit 复读",
+        "复读",
+        "复读",
+    ]
+
+
+def test_three_messages_after_command_trigger_echo():
+    echo = GroupEcho()
+
+    sent = asyncio.run(_feed(echo, ["msg", "msg", "/cmd", "msg", "msg", "msg"]))
+
+    assert sent == [(_TestConfig.current_group, _plain("msg"))]
+    assert [entry.raw_text for entry in echo.buffer_snapshot()] == ["msg", "msg", "/cmd"]
+
+
+def test_two_messages_after_command_do_not_trigger_echo():
+    echo = GroupEcho()
+
+    sent = asyncio.run(_feed(echo, ["msg", "/cmd", "msg", "msg"]))
+
+    assert sent == []
+    assert [entry.raw_text for entry in echo.buffer_snapshot()] == ["msg", "/cmd", "msg", "msg"]
 
 
 def test_non_identical_messages_do_not_trigger():

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -9,17 +9,16 @@ from kouhai_bot.echo import GroupEcho
 from kouhai_bot.handlers import process_event
 
 
-GID = 123456
-OTHER_GID = 654321
 BOT_QQ = 1234567890
+ECHO_MESSAGE = [{"type": "text", "data": {"text": "复读"}}]
 
 
 class _TestConfig:
     bot_qq = BOT_QQ
-    current_group = GID
+    current_group = 123456
 
 
-def _event(text: str, *, user_id: int = 42, group_id: int = GID) -> dict:
+def _event(text: str, *, user_id: int = 42, group_id: int = _TestConfig.current_group) -> dict:
     return {
         "type": "message",
         "message_type": "group",
@@ -44,7 +43,7 @@ async def _feed(echo: GroupEcho, texts: list[str], *, users: list[int] | None = 
         for i, text in enumerate(texts):
             user_id = users[i] if users is not None else i + 1
             await echo.check_and_echo(
-                group_id=GID,
+                group_id=_TestConfig.current_group,
                 user_id=user_id,
                 raw_text=text,
                 message_id=f"msg_{i}",
@@ -58,8 +57,8 @@ def test_three_identical_messages_trigger_echo():
 
     sent = asyncio.run(_feed(echo, ["复读", "复读", "复读"]))
 
-    assert sent == [(GID, [{"type": "text", "data": {"text": "复读"}}])]
-    assert echo.buffer_snapshot(GID) == []
+    assert sent == [(_TestConfig.current_group, ECHO_MESSAGE)]
+    assert echo.buffer_snapshot() == []
 
 
 def test_two_identical_messages_do_not_trigger():
@@ -68,7 +67,7 @@ def test_two_identical_messages_do_not_trigger():
     sent = asyncio.run(_feed(echo, ["复读", "复读"]))
 
     assert sent == []
-    assert [entry.raw_text for entry in echo.buffer_snapshot(GID)] == ["复读", "复读"]
+    assert [entry.raw_text for entry in echo.buffer_snapshot()] == ["复读", "复读"]
 
 
 def test_identical_messages_with_different_one_in_between_wait_for_suffix_streak():
@@ -76,8 +75,8 @@ def test_identical_messages_with_different_one_in_between_wait_for_suffix_streak
 
     sent = asyncio.run(_feed(echo, ["复读", "复读", "打断", "复读", "复读", "复读"]))
 
-    assert sent == [(GID, [{"type": "text", "data": {"text": "复读"}}])]
-    assert [entry.raw_text for entry in echo.buffer_snapshot(GID)] == ["复读", "复读", "打断"]
+    assert sent == [(_TestConfig.current_group, ECHO_MESSAGE)]
+    assert [entry.raw_text for entry in echo.buffer_snapshot()] == ["复读", "复读", "打断"]
 
 
 def test_bot_in_streak_prevents_echo():
@@ -90,7 +89,7 @@ def test_bot_in_streak_prevents_echo():
     ))
 
     assert sent == []
-    assert echo.buffer_snapshot(GID) == []
+    assert echo.buffer_snapshot() == []
 
 
 def test_command_messages_are_ignored():
@@ -98,8 +97,8 @@ def test_command_messages_are_ignored():
 
     sent = asyncio.run(_feed(echo, ["复读", "/submit 复读", "复读", "复读"]))
 
-    assert sent == [(GID, [{"type": "text", "data": {"text": "复读"}}])]
-    assert echo.buffer_snapshot(GID) == []
+    assert sent == [(_TestConfig.current_group, ECHO_MESSAGE)]
+    assert echo.buffer_snapshot() == []
 
 
 def test_non_identical_messages_do_not_trigger():
@@ -116,7 +115,7 @@ def test_buffer_is_bounded():
     sent = asyncio.run(_feed(echo, [f"msg {i}" for i in range(8)]))
 
     assert sent == []
-    assert [entry.raw_text for entry in echo.buffer_snapshot(GID)] == [
+    assert [entry.raw_text for entry in echo.buffer_snapshot()] == [
         "msg 3",
         "msg 4",
         "msg 5",
@@ -137,8 +136,7 @@ def test_process_event_hooks_echo_for_non_command_group_messages():
                 patch("kouhai_bot.echo.send_group_msg", _send_group_msg):
             for i in range(3):
                 await process_event(_event("复读", user_id=i + 10), spawn_handlers=False)
-            await process_event(_event("复读", group_id=OTHER_GID), spawn_handlers=False)
 
     asyncio.run(_run())
 
-    assert sent == [(GID, [{"type": "text", "data": {"text": "复读"}}])]
+    assert sent == [(_TestConfig.current_group, ECHO_MESSAGE)]


### PR DESCRIPTION
## Summary
- Add bounded per-group echo buffers for repeated non-command group messages
- Hook echo handling into non-command group dispatch for the configured service group
- Add tests for triggering, ignored commands, bot loop prevention, suffix streaks, and bounded buffers

## Validation
- uv run pytest tests/test_echo.py
- uv run pytest