### PR TITLE
Add sock_read idle timeout for streaming LLM calls

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -19,6 +19,7 @@ llm:
   max_retries: 3               # per-provider retries
   retry_base_delay_sec: 1.0
   retry_max_delay_sec: 8.0
+  stream_idle_timeout_sec: 120 # SSE idle timeout; retries if no bytes arrive for this long
 
   # Per-task timeouts (apply to all providers)
   judge_timeout_sec: 1200

--- a/src/kouhai_bot/config.py
+++ b/src/kouhai_bot/config.py
@@ -112,6 +112,7 @@ class BotConfig:
     llm_max_retries: int = 2
     llm_retry_base_delay_sec: float = 1.0
     llm_retry_max_delay_sec: float = 8.0
+    llm_stream_idle_timeout_sec: int = 120
     judge_timeout_sec: int = 1200
     clarify_timeout_sec: int = 600
     review_timeout_sec: int = 600
@@ -182,6 +183,9 @@ class BotConfig:
         )
         c.llm_retry_max_delay_sec = float(
             llm.get("retry_max_delay_sec", c.llm_retry_max_delay_sec)
+        )
+        c.llm_stream_idle_timeout_sec = int(
+            llm.get("stream_idle_timeout_sec", c.llm_stream_idle_timeout_sec)
         )
         c.judge_timeout_sec = int(llm.get("judge_timeout_sec", c.judge_timeout_sec))
         c.clarify_timeout_sec = int(

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -106,6 +106,22 @@ def _provider_accepts_generic_thinking(provider_name: str, base_url: str) -> boo
     return not _provider_is_fable(provider_name, base_url)
 
 
+def _chat_completion_timeout(
+    *,
+    payload: dict,
+    total_timeout_sec: int,
+    stream_idle_timeout_sec: int | float | None,
+) -> aiohttp.ClientTimeout:
+    if payload.get("stream") is True:
+        idle_timeout = (
+            float(stream_idle_timeout_sec)
+            if stream_idle_timeout_sec and stream_idle_timeout_sec > 0
+            else None
+        )
+        return aiohttp.ClientTimeout(total=total_timeout_sec, sock_read=idle_timeout)
+    return aiohttp.ClientTimeout(total=total_timeout_sec)
+
+
 def _should_retry_status(status: int) -> bool:
     return status in {408, 409, 429} or status >= 500
 
@@ -348,13 +364,18 @@ async def _post_chat_completion_once(
     headers: dict[str, str],
     payload: dict,
     timeout: int,
+    stream_idle_timeout_sec: int | float | None = None,
 ) -> _ChatCompletionAttempt:
     try:
         async with session.post(
             _chat_completions_url(base_url),
             json=payload,
             headers=headers,
-            timeout=aiohttp.ClientTimeout(total=timeout),
+            timeout=_chat_completion_timeout(
+                payload=payload,
+                total_timeout_sec=timeout,
+                stream_idle_timeout_sec=stream_idle_timeout_sec,
+            ),
         ) as resp:
             if resp.status != 200:
                 text = await resp.text()
@@ -456,6 +477,9 @@ async def chat_completion(
         retry_base,
         float(getattr(cfg, "llm_retry_max_delay_sec", 8.0) or 0.0),
     )
+    stream_idle_timeout_sec = int(
+        getattr(cfg, "llm_stream_idle_timeout_sec", 120) or 0
+    )
 
     last_failure_kind: str | None = None
     last_failed_provider: str | None = None
@@ -498,6 +522,7 @@ async def chat_completion(
                     headers=headers,
                     payload=payload,
                     timeout=timeout,
+                    stream_idle_timeout_sec=stream_idle_timeout_sec,
                 )
                 if result.text is not None:
                     if last_failed_provider:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -121,6 +121,7 @@ def test_llm_timeouts_load_from_yaml(monkeypatch, tmp_path):
             "general_model": [
                 {"name": "general", "api_key": "k", "base_url": "http://x/v1", "model": "general"}
             ],
+            "stream_idle_timeout_sec": 456,
             "judge_timeout_sec": 1500,
             "clarify_timeout_sec": 700,
             "review_timeout_sec": 800,
@@ -128,10 +129,17 @@ def test_llm_timeouts_load_from_yaml(monkeypatch, tmp_path):
         }
     )
     cfg = _from_yaml(yaml_str, monkeypatch, tmp_path)
+    assert cfg.llm_stream_idle_timeout_sec == 456
     assert cfg.judge_timeout_sec == 1500
     assert cfg.clarify_timeout_sec == 700
     assert cfg.review_timeout_sec == 800
     assert cfg.summary_timeout_sec == 180
+
+
+def test_llm_stream_idle_timeout_defaults_to_120(monkeypatch, tmp_path):
+    cfg = _from_yaml(_make_yaml(), monkeypatch, tmp_path)
+
+    assert cfg.llm_stream_idle_timeout_sec == 120
 
 
 def test_provider_stream_loads_from_yaml(monkeypatch, tmp_path):

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -418,11 +418,14 @@ def test_dashscope_provider_payload_enables_stream():
         base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
         model="qwen-test",
     )
-    cfg = _openai_cfg(llm_smart_providers=[provider])
+    cfg = _openai_cfg(llm_smart_providers=[provider], llm_stream_idle_timeout_sec=321)
     calls = []
 
     async def fake_once(session, **kwargs):
-        calls.append(kwargs["payload"].copy())
+        calls.append({
+            "payload": kwargs["payload"].copy(),
+            "stream_idle_timeout_sec": kwargs["stream_idle_timeout_sec"],
+        })
         return _ChatCompletionAttempt(text="OK", retryable=False, retry_after_sec=None)
 
     with patch("kouhai_bot.llm.get_config", return_value=cfg), \
@@ -435,9 +438,36 @@ def test_dashscope_provider_payload_enables_stream():
         ))
 
     assert result == "OK"
-    assert calls[0]["stream"] is True
-    assert calls[0]["thinking"] == {"type": "enabled"}
-    assert calls[0]["enable_thinking"] is True
+    assert calls[0]["payload"]["stream"] is True
+    assert calls[0]["payload"]["thinking"] == {"type": "enabled"}
+    assert calls[0]["payload"]["enable_thinking"] is True
+    assert calls[0]["stream_idle_timeout_sec"] == 321
+
+
+def test_streaming_provider_uses_default_idle_timeout():
+    provider = LlmProviderConfig(
+        name="qwen",
+        api_key="sk-test",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        model="qwen-test",
+    )
+    cfg = _openai_cfg(llm_smart_providers=[provider])
+    calls = []
+
+    async def fake_once(session, **kwargs):
+        calls.append(kwargs["stream_idle_timeout_sec"])
+        return _ChatCompletionAttempt(text="OK", retryable=False, retry_after_sec=None)
+
+    with patch("kouhai_bot.llm.get_config", return_value=cfg), \
+            patch("kouhai_bot.llm.aiohttp.ClientSession", _DummySession), \
+            patch("kouhai_bot.llm._post_chat_completion_once", side_effect=fake_once):
+        result = asyncio.run(call_chat_completion(
+            [{"role": "user", "content": "Reply with exactly OK."}],
+            task="judge",
+        ))
+
+    assert result == "OK"
+    assert calls == [120]
 
 
 def test_zenmux_fable_payload_uses_reasoning_effort_without_generic_thinking():
@@ -524,6 +554,53 @@ def test_explicit_stream_provider_payload_enables_stream():
 
     assert result == "OK"
     assert calls[0]["stream"] is True
+
+
+def test_streaming_chat_completion_uses_sock_read_idle_timeout():
+    response = _DummyResponse(lines=[
+        'data: {"choices":[{"delta":{"content":"OK"}}]}\n',
+        '\n',
+        'data: [DONE]\n',
+        '\n',
+    ])
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="qwen",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        headers={},
+        payload={"stream": True},
+        timeout=7200,
+        stream_idle_timeout_sec=600,
+    ))
+
+    timeout = session.calls[0][1]["timeout"]
+    assert result.text == "OK"
+    assert timeout.total == 7200
+    assert timeout.sock_read == 600
+
+
+def test_non_streaming_chat_completion_does_not_use_sock_read_idle_timeout():
+    response = _DummyResponse(json_data={
+        "choices": [{"message": {"content": "OK"}}],
+    })
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="openai",
+        base_url="http://localhost:8080/v1",
+        headers={},
+        payload={},
+        timeout=7200,
+        stream_idle_timeout_sec=600,
+    ))
+
+    timeout = session.calls[0][1]["timeout"]
+    assert result.text == "OK"
+    assert timeout.total == 7200
+    assert timeout.sock_read is None
 
 
 def test_streaming_chat_completion_reads_sse_delta_chunks(caplog):


### PR DESCRIPTION
## Problem
DashScope SSE streaming can hang — TCP stays ESTABLISHED but no data flows. The existing aiohttp.ClientTimeout(total=7200) never triggers because the connection is not closed. A hung judge can sit for 2 hours before timing out.

## Fix
Add configurable stream_idle_timeout_sec (default 120s) that sets aiohttp.ClientTimeout.sock_read for streaming providers. If no bytes arrive for 120 seconds, the connection is terminated with TimeoutError, triggering the existing retry logic.

## Design
- Only applied to streaming providers (payload.stream=True), including DashScope auto-stream
- Non-streaming providers keep total-only timeout, unchanged
- Preserves judge_timeout_sec=7200 as the total upper bound — does NOT cap thinking time
- Active streams that produce data continuously (even slowly) are never interrupted
- Only truly hung/silent streams are detected

## Changes
- llm.py: new _chat_completion_timeout() helper, sock_read for streaming payloads
- config.py: llm_stream_idle_timeout_sec config field, default 120
- config.example.yaml: documented new field
- Tests: 4 new tests covering streaming sock_read, non-streaming no sock_read, default config, custom config

## Verification
- uv run pytest: 278 passed