### PR TITLE
Use raw message segments for echo comparison

### DIFF
--- a/src/kouhai_bot/echo.py
+++ b/src/kouhai_bot/echo.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 import random
+import unicodedata
 from collections import deque
 from dataclasses import dataclass
 from typing import Callable
 
 from .config import get_config
-from .napcat.client import build_plain_message, send_group_msg
+from .napcat.client import send_group_msg
 
 logger = logging.getLogger("kouhai-bot.echo")
 
@@ -18,8 +20,34 @@ logger = logging.getLogger("kouhai-bot.echo")
 @dataclass(frozen=True)
 class EchoEntry:
     user_id: int
-    raw_text: str
+    echo_key: str
+    segments: list[dict]
     message_id: int | str
+    is_command: bool = False
+
+
+def canonical_echo_key(segments: list[dict]) -> str:
+    """Build a stable repeat-comparison key from echoable message segments."""
+    cfg = get_config()
+    parts: list[str] = []
+    for seg in segments:
+        seg_type = seg.get("type", "")
+        data = seg.get("data", {})
+        if seg_type == "text":
+            text = unicodedata.normalize("NFC", str(data.get("text", "")))
+            parts.append(f"text:{text}")
+        elif seg_type == "face":
+            parts.append(f"face:{data.get('id', '')}")
+        elif seg_type == "at":
+            qq = str(data.get("qq", ""))
+            if qq == str(cfg.bot_qq):
+                qq = "bot"
+            parts.append(f"at:{qq}")
+    return "\x1f".join(parts)
+
+
+def _clone_segments(segments: list[dict]) -> list[dict]:
+    return copy.deepcopy(segments)
 
 
 class GroupEcho:
@@ -45,6 +73,7 @@ class GroupEcho:
         *,
         group_id: int,
         user_id: int,
+        segments: list[dict],
         raw_text: str,
         message_id: int | str,
     ) -> bool:
@@ -52,19 +81,30 @@ class GroupEcho:
         cfg = get_config()
         if group_id != cfg.current_group:
             return False
-        if not raw_text:
+        if not segments:
             return False
 
-        echo_text: str | None = None
+        echo_key = canonical_echo_key(segments)
+        if not echo_key:
+            return False
+
+        echo_segments: list[dict] | None = None
         async with self._lock:
             buf = self._buffer
-            buf.append(EchoEntry(user_id=user_id, raw_text=raw_text, message_id=message_id))
+            stored_segments = _clone_segments(segments)
+            buf.append(EchoEntry(
+                user_id=user_id,
+                echo_key=echo_key,
+                segments=stored_segments,
+                message_id=message_id,
+                is_command=raw_text.startswith("/"),
+            ))
 
-            streak_text = buf[-1].raw_text
+            streak_key = buf[-1].echo_key
             streak_len = 0
             streak_users: set[int] = set()
             for entry in reversed(buf):
-                if entry.raw_text != streak_text or entry.raw_text.startswith("/"):
+                if entry.echo_key != streak_key or entry.is_command:
                     break
                 streak_len += 1
                 streak_users.add(entry.user_id)
@@ -74,19 +114,20 @@ class GroupEcho:
 
             has_bot = any(str(uid) == str(cfg.bot_qq) for uid in streak_users)
             if not has_bot and self._rng() < self.echo_probability:
-                echo_text = streak_text
+                echo_segments = _clone_segments(stored_segments)
                 buf.append(EchoEntry(
                     user_id=int(cfg.bot_qq),
-                    raw_text=streak_text,
+                    echo_key=streak_key,
+                    segments=_clone_segments(stored_segments),
                     message_id=f"echo:{message_id}",
                 ))
 
-        if echo_text is None:
+        if echo_segments is None:
             logger.debug("Skipped probabilistic echo for group %s", group_id)
             return False
 
         logger.info("Echoing repeated group message in group %s", group_id)
-        await send_group_msg(group_id, build_plain_message(echo_text))
+        await send_group_msg(group_id, echo_segments)
         return True
 
     def buffer_snapshot(self) -> list[EchoEntry]:
@@ -101,12 +142,14 @@ async def check_and_echo(
     *,
     group_id: int,
     user_id: int,
+    segments: list[dict],
     raw_text: str,
     message_id: int | str,
 ) -> bool:
     return await _echo.check_and_echo(
         group_id=group_id,
         user_id=user_id,
+        segments=segments,
         raw_text=raw_text,
         message_id=message_id,
     )

--- a/src/kouhai_bot/handlers/__init__.py
+++ b/src/kouhai_bot/handlers/__init__.py
@@ -141,13 +141,14 @@ async def process_event(
 
     raw_text, was_mentioned = extract_text(segments)
     raw_text = _normalize_leading_command_junk(raw_text)
-    if not raw_text:
+    if not segments:
         return
 
     if msg_type == "group":
         await echo.check_and_echo(
             group_id=group_id,
             user_id=user_id,
+            segments=segments,
             raw_text=raw_text,
             message_id=message_id,
         )

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -16,6 +16,22 @@ def _plain(text: str) -> list[dict]:
     return [{"type": "text", "data": {"text": text}}]
 
 
+def _face(face_id: int | str) -> list[dict]:
+    return [{"type": "face", "data": {"id": face_id}}]
+
+
+def _text_face(text: str, face_id: int | str) -> list[dict]:
+    return [{"type": "text", "data": {"text": text}}, {"type": "face", "data": {"id": face_id}}]
+
+
+def _raw_text(segments: list[dict]) -> str:
+    return " ".join(
+        seg.get("data", {}).get("text", "").strip()
+        for seg in segments
+        if seg.get("type") == "text" and seg.get("data", {}).get("text", "").strip()
+    ).strip()
+
+
 ECHO_MESSAGE = _plain("复读")
 
 
@@ -24,16 +40,24 @@ class _TestConfig:
     current_group = 123456
 
 
-def _event(text: str, *, user_id: int = 42, group_id: int = _TestConfig.current_group) -> dict:
+def _event(
+    text: str | None = None,
+    *,
+    segments: list[dict] | None = None,
+    user_id: int = 42,
+    group_id: int = _TestConfig.current_group,
+) -> dict:
+    message = segments if segments is not None else _plain(text or "")
+    raw_message = _raw_text(message)
     return {
         "type": "message",
         "message_type": "group",
         "group_id": group_id,
         "user_id": user_id,
         "sender": {"nickname": "Alice", "card": "", "user_id": user_id},
-        "message_id": f"msg_{group_id}_{user_id}_{text}",
-        "raw_message": text,
-        "message": [{"type": "text", "data": {"text": text}}],
+        "message_id": f"msg_{group_id}_{user_id}_{raw_message}",
+        "raw_message": raw_message,
+        "message": message,
     }
 
 
@@ -47,7 +71,12 @@ class _Rng:
         return self.values.pop(0)
 
 
-async def _feed(echo: GroupEcho, texts: list[str], *, users: list[int] | None = None):
+async def _feed(
+    echo: GroupEcho,
+    messages: list[str | list[dict]],
+    *,
+    users: list[int] | None = None,
+):
     sent: list[tuple[int, list[dict]]] = []
 
     async def _send_group_msg(group_id: int, message: list[dict]):
@@ -56,12 +85,14 @@ async def _feed(echo: GroupEcho, texts: list[str], *, users: list[int] | None = 
 
     with patch("kouhai_bot.config._config", _TestConfig()), \
             patch("kouhai_bot.echo.send_group_msg", _send_group_msg):
-        for i, text in enumerate(texts):
+        for i, message in enumerate(messages):
             user_id = users[i] if users is not None else i + 1
+            segments = _plain(message) if isinstance(message, str) else message
             await echo.check_and_echo(
                 group_id=_TestConfig.current_group,
                 user_id=user_id,
-                raw_text=text,
+                segments=segments,
+                raw_text=_raw_text(segments),
                 message_id=f"msg_{i}",
             )
 
@@ -75,7 +106,8 @@ def test_two_identical_messages_can_make_bot_third_repeater():
 
     assert sent == [(_TestConfig.current_group, ECHO_MESSAGE)]
     snapshot = echo.buffer_snapshot()
-    assert [entry.raw_text for entry in snapshot] == ["复读", "复读", "复读"]
+    assert [entry.echo_key for entry in snapshot] == ["text:复读", "text:复读", "text:复读"]
+    assert [entry.segments for entry in snapshot] == [ECHO_MESSAGE, ECHO_MESSAGE, ECHO_MESSAGE]
     assert snapshot[-1].user_id == BOT_QQ
 
 
@@ -86,7 +118,7 @@ def test_missed_echo_can_trigger_on_later_repeater():
 
     assert sent == [(_TestConfig.current_group, ECHO_MESSAGE)]
     snapshot = echo.buffer_snapshot()
-    assert [entry.raw_text for entry in snapshot] == ["复读", "复读", "复读", "复读"]
+    assert [entry.echo_key for entry in snapshot] == ["text:复读", "text:复读", "text:复读", "text:复读"]
     assert snapshot[-1].user_id == BOT_QQ
 
 
@@ -96,7 +128,7 @@ def test_probability_miss_leaves_repeat_streak_in_buffer():
     sent = asyncio.run(_feed(echo, ["复读", "复读"]))
 
     assert sent == []
-    assert [entry.raw_text for entry in echo.buffer_snapshot()] == ["复读", "复读"]
+    assert [entry.echo_key for entry in echo.buffer_snapshot()] == ["text:复读", "text:复读"]
 
 
 def test_bot_in_streak_prevents_duplicate_echo():
@@ -128,13 +160,14 @@ def test_command_messages_break_streak_and_stay_in_buffer():
     sent = asyncio.run(_feed(echo, ["复读", "/submit 复读", "复读", "复读"]))
 
     assert sent == [(_TestConfig.current_group, ECHO_MESSAGE)]
-    assert [entry.raw_text for entry in echo.buffer_snapshot()] == [
-        "复读",
-        "/submit 复读",
-        "复读",
-        "复读",
-        "复读",
+    assert [entry.echo_key for entry in echo.buffer_snapshot()] == [
+        "text:复读",
+        "text:/submit 复读",
+        "text:复读",
+        "text:复读",
+        "text:复读",
     ]
+    assert [entry.is_command for entry in echo.buffer_snapshot()] == [False, True, False, False, False]
 
 
 def test_messages_after_command_can_trigger_echo():
@@ -143,7 +176,15 @@ def test_messages_after_command_can_trigger_echo():
     sent = asyncio.run(_feed(echo, ["msg", "msg", "/cmd", "msg", "msg"]))
 
     assert sent == [(_TestConfig.current_group, _plain("msg")), (_TestConfig.current_group, _plain("msg"))]
-    assert [entry.raw_text for entry in echo.buffer_snapshot()] == ["msg", "msg", "msg", "/cmd", "msg", "msg", "msg"]
+    assert [entry.echo_key for entry in echo.buffer_snapshot()] == [
+        "text:msg",
+        "text:msg",
+        "text:msg",
+        "text:/cmd",
+        "text:msg",
+        "text:msg",
+        "text:msg",
+    ]
 
 
 def test_non_identical_messages_do_not_trigger():
@@ -160,13 +201,62 @@ def test_buffer_is_bounded():
     sent = asyncio.run(_feed(echo, [f"msg {i}" for i in range(8)]))
 
     assert sent == []
-    assert [entry.raw_text for entry in echo.buffer_snapshot()] == [
-        "msg 3",
-        "msg 4",
-        "msg 5",
-        "msg 6",
-        "msg 7",
+    assert [entry.echo_key for entry in echo.buffer_snapshot()] == [
+        "text:msg 3",
+        "text:msg 4",
+        "text:msg 5",
+        "text:msg 6",
+        "text:msg 7",
     ]
+
+
+def test_three_identical_face_only_messages_trigger_echo():
+    echo = GroupEcho(trigger_count=3, rng=lambda: 0.0)
+    message = _face(123)
+
+    sent = asyncio.run(_feed(echo, [message, message, message]))
+
+    assert sent == [(_TestConfig.current_group, message)]
+    snapshot = echo.buffer_snapshot()
+    assert [entry.echo_key for entry in snapshot] == ["face:123", "face:123", "face:123", "face:123"]
+    assert snapshot[-1].segments == message
+    assert snapshot[-1].user_id == BOT_QQ
+
+
+def test_three_identical_text_face_messages_trigger_echo():
+    echo = GroupEcho(trigger_count=3, rng=lambda: 0.0)
+    message = _text_face("复读", 66)
+
+    sent = asyncio.run(_feed(echo, [message, message, message]))
+
+    assert sent == [(_TestConfig.current_group, message)]
+    assert [entry.echo_key for entry in echo.buffer_snapshot()] == [
+        "text:复读\x1fface:66",
+        "text:复读\x1fface:66",
+        "text:复读\x1fface:66",
+        "text:复读\x1fface:66",
+    ]
+
+
+def test_text_face_and_text_only_are_not_same_streak():
+    echo = GroupEcho(rng=lambda: 0.0)
+
+    sent = asyncio.run(_feed(echo, [_text_face("复读", 66), "复读"]))
+
+    assert sent == []
+    assert [entry.echo_key for entry in echo.buffer_snapshot()] == [
+        "text:复读\x1fface:66",
+        "text:复读",
+    ]
+
+
+def test_different_face_ids_break_streak():
+    echo = GroupEcho(rng=lambda: 0.0)
+
+    sent = asyncio.run(_feed(echo, [_face(123), _face(456), _face(123)]))
+
+    assert sent == []
+    assert [entry.echo_key for entry in echo.buffer_snapshot()] == ["face:123", "face:456", "face:123"]
 
 
 def test_process_event_hooks_echo_for_non_command_group_messages():
@@ -186,3 +276,23 @@ def test_process_event_hooks_echo_for_non_command_group_messages():
     asyncio.run(_run())
 
     assert sent == [(_TestConfig.current_group, ECHO_MESSAGE)]
+
+
+def test_process_event_hooks_echo_for_face_only_group_messages():
+    sent: list[tuple[int, list[dict]]] = []
+    message = _face(123)
+
+    async def _send_group_msg(group_id: int, message: list[dict]):
+        sent.append((group_id, message))
+        return len(sent)
+
+    async def _run():
+        with patch("kouhai_bot.config._config", _TestConfig()), \
+                patch("kouhai_bot.echo._echo", GroupEcho(rng=lambda: 0.0)), \
+                patch("kouhai_bot.echo.send_group_msg", _send_group_msg):
+            for i in range(2):
+                await process_event(_event(segments=message, user_id=i + 10), spawn_handlers=False)
+
+    asyncio.run(_run())
+
+    assert sent == [(_TestConfig.current_group, message)]


### PR DESCRIPTION
## Summary
- compare group echo streaks with canonical keys built from raw message segments
- preserve original message segments for echo sends, including QQ face segments
- allow segment-only group messages to reach echo and add face/text+face coverage

## Tests
- uv run pytest