### PR TITLE
Tighten problem summary generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,9 @@ NapCat (QQ) ──WS──> worker.py
   DashScope/阿里云百炼 providers are called with HTTP+SSE streaming to avoid the
   10-minute synchronous HTTP limit; providers with `stream: true` do the same;
   other providers use the normal JSON response path.
-  `thinking` and `reasoning_effort` are sent unconditionally; unsupported
-  fields are silently ignored by upstream APIs.
+  `reasoning_effort`, `thinking`, temperature override, and provider-specific
+  extra body fields are controlled per provider; unsupported fields may be ignored
+  or rejected by upstream APIs.
 - **Official CF tutorials**: Scraped editorials live under `{data_dir}/tutorials/{pid}.json`
   (see `tools/cf_tutorial_agent.py`; low-level CF HTML helpers live in `tools/scrape_cf_tutorial.py`). Runtime extraction is in `tutorials.py`. On the
   On **new problem** (`do_daily_post` / `/newproblem`), `schedule_prefetch_editorial(pid)`
@@ -106,8 +107,11 @@ Each provider in `llm.smart_model` or `llm.general_model`:
 | `api_key` | — | API key (**required**) |
 | `base_url` | `https://api.openai.com/v1` | Base URL for chat completions |
 | `model` | — | Model name for this provider entry (**required**) |
-| `reasoning_effort` | — | OpenAI reasoning effort: `minimal`/`low`/`medium`/`high`/`xhigh` |
+| `reasoning_effort` | — | Provider reasoning effort (e.g. `minimal`/`low`/`medium`/`high`/`xhigh`/`max`, if supported upstream) |
 | `stream` | `false` | Send `stream=true` and read SSE chunks for this provider; DashScope/阿里云百炼 streams automatically |
+| `send_thinking` | `true` | Whether to pass handler-provided `thinking` payloads to this provider |
+| `temperature` | — | Optional provider-level temperature override; omit to use the task's requested temperature |
+| `extra_body` | `{}` | Extra JSON fields merged into this provider's chat-completions request body |
 | `model_tag` | `""` | Short string appended to every LLM-generated user message (judge/clarify/review/summary/editorial); empty means no tag |
 
 #### `qwen` section
@@ -281,11 +285,13 @@ llm:
       model: "deepseek-v4-chat"
 ```
 
-All providers receive the same base request payload. Non-applicable fields (e.g.
-`reasoning_effort` on DeepSeek, `thinking` on OpenAI) are silently ignored by the
-upstream API. `thinking={"type": "enabled"}` is always sent when the judge handler
-requests it — it's an OpenAI-compatible extension that DeepSeek supports.
-DashScope/阿里云百炼 providers (detected by `dashscope.aliyuncs.com` base URL or
+All providers receive the same base request payload, then provider-level controls
+can add or suppress optional fields. `reasoning_effort` is sent when configured and
+not disabled by the caller. `thinking={"type": "enabled"}` is sent only when the
+handler requests it and the provider has `send_thinking` enabled. Use `temperature`
+or `extra_body` for gateway-specific requirements instead of adding per-model
+branches in `llm.py`. DashScope/阿里云百炼 providers (detected by
+`dashscope.aliyuncs.com` base URL or
 `aliyun`/`bailian`/`dashscope` provider name) and providers with `stream: true`
 additionally receive
 `stream=true`; `llm.py` reads the SSE `data:` stream and concatenates

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cp config.example.yaml config.yaml
 
 > 在我们的测试中，gpt-5.5 high 基本胜任，qwen-3.7-max 也相当不错，Deepseek v4 pro 可用，但由于其 CoT 较长，响应慢，推理能力也确实不及前者，建议只作为 API 连接不稳时的 fallback
 
-ZenMux/Fable 也可以作为 OpenAI-compatible provider 配置。示例见 `config.example.yaml`，推荐放在 fallback 列表靠前位置，使用 `reasoning_effort: "max"` 打开高强度 thinking，并设置 `model_tag: "『Fable』"` 方便在群内识别。Fable 的网关在启用 reasoning 时要求 temperature 为 1，bot 会在检测到 Fable provider 时自动处理这个参数，不需要在配置里额外设置。
+ZenMux 上的体验模型也可以作为 OpenAI-compatible provider 配置。示例见 `config.example.yaml`；例如 Grok 4.5 Free 可使用 `model: "x-ai/grok-4.5-free"`、`reasoning_effort: "xhigh"`、`model_tag: "『∅』"`。如果某个网关需要特殊 payload，可在 provider 上配置 `temperature`、`send_thinking` 或 `extra_body`，避免为每个模型在代码里新增分支。
 
 #### 公式识别
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -29,13 +29,13 @@ llm:
 
   # Smart-model fallback queue — judge/review use this list. Order matters.
   smart_model:
-    # ── Optional primary: ZenMux/Fable (OpenAI-compatible) ──
-    # - name: fable
+    # ── Optional primary: ZenMux Grok 4.5 Free (OpenAI-compatible) ──
+    # - name: grok45free
     #   api_key: "..."
     #   base_url: "https://zenmux.ai/api/v1"
-    #   model: "anthropic/claude-fable-5-free"
-    #   reasoning_effort: "max"
-    #   model_tag: "『Fable』"
+    #   model: "x-ai/grok-4.5-free"
+    #   reasoning_effort: "xhigh"  # highest accepted by this ZenMux model
+    #   model_tag: "『∅』"
 
     # ── Primary: OpenAI-compatible ──
     - name: openai
@@ -63,6 +63,13 @@ llm:
   # General-model fallback queue — clarify/summary/editorial and other tasks use this list.
   # This queue can use completely different providers/models from smart_model.
   general_model:
+    # Optional stronger summary/general provider: ZenMux MiniMax M3 (OpenAI-compatible)
+    # - name: minimax-m3
+    #   api_key: "..."
+    #   base_url: "https://zenmux.ai/api/v1"
+    #   model: "minimax/minimax-m3"
+    #   model_tag: "『M3』"
+
     - name: qwen
       api_key: "..."
       base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1"

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -37,7 +37,7 @@ from ..shared import (
     load_user_submissions,
     rating_to_points,
     remember_problem_rating,
-    robust_json_parse,
+    parse_json_with_llm_repair,
     save_scoreboard,
     save_user_submission,
     second_judge_submission_result,
@@ -805,7 +805,22 @@ class GroupCoordinator:
                 result.failure_kind,
             )
             return {"kind": result.failure_kind or "error", "pid": pid}
-        parsed = robust_json_parse(result.text)
+        parsed, _repair_tag = await parse_json_with_llm_repair(
+            result.text,
+            expected_schema='{ "correct": boolean, "reason": string, "reply": string, "reaction": string }',
+            task="summary",
+            timeout=get_config().summary_timeout_sec,
+        )
+        if not parsed:
+            logger.warning(
+                "[group_%s] first judge malformed JSON after repair pid=%s seq=%s provider=%s model=%s",
+                req.group_id,
+                pid,
+                req.seq,
+                result.provider_name,
+                result.model,
+            )
+            return {"kind": "service_unavailable", "pid": pid}
         logger.info(
             "[group_%s] first judge result pid=%s seq=%s provider=%s model=%s correct=%s reaction=%s reason=%s",
             req.group_id,
@@ -841,7 +856,12 @@ class GroupCoordinator:
                     source,
                 )
                 if second.text:
-                    second_parsed = robust_json_parse(second.text)
+                    second_parsed, _second_repair_tag = await parse_json_with_llm_repair(
+                        second.text,
+                        expected_schema='{ "correct": boolean, "reason": string, "reply": string, "reaction": string }',
+                        task="summary",
+                        timeout=get_config().summary_timeout_sec,
+                    )
                     if "correct" in second_parsed:
                         logger.info(
                             "[group_%s] second judge result pid=%s seq=%s provider=%s model=%s correct=%s reaction=%s reason=%s",
@@ -908,7 +928,12 @@ class GroupCoordinator:
         if not result.text:
             return {"kind": result.failure_kind or "error", "pid": pid}
 
-        parsed = robust_json_parse(result.text)
+        parsed, _repair_tag = await parse_json_with_llm_repair(
+            result.text,
+            expected_schema='{ "reply": string, "reaction": string }',
+            task="summary",
+            timeout=get_config().summary_timeout_sec,
+        )
         if not parsed:
             return {"kind": "unavailable", "pid": pid}
 

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -138,6 +138,95 @@ def robust_json_parse(text: str) -> dict:
         return result
 
 
+_JSON_REPAIR_MAX_ATTEMPTS = 3
+_JSON_REPAIR_MAX_CHARS = 12000
+
+
+def _json_repair_prompt(text: str, expected_schema: str, parse_note: str) -> str:
+    payload = {
+        "expected_schema": expected_schema or "JSON object",
+        "parse_note": parse_note or "local parser could not read a JSON object",
+        "bad_output": (text or "")[:_JSON_REPAIR_MAX_CHARS],
+    }
+    return (
+        "你是一个 JSON 编写高手。下面是另一个模型本应输出 JSON 对象、但格式不合法的回复。\n"
+        "请只修复格式，不要改写含义，不要补充新事实，不要解释。\n"
+        "必须只输出一个合法 JSON 对象；不要 Markdown、不要代码块、不要前后缀文字。\n"
+        "如果原回复只是纯文本 summary，请按 expected_schema 包成对应字段；"
+        "如果原回复已经包含字段但引号、逗号、布尔值或转义有错，只做最小修复。\n\n"
+        f"{json.dumps(payload, ensure_ascii=False)}"
+    )
+
+
+async def parse_json_with_llm_repair(
+    text: str | None,
+    *,
+    expected_schema: str = "JSON object",
+    task: str = "summary",
+    timeout: int | None = None,
+    max_attempts: int = _JSON_REPAIR_MAX_ATTEMPTS,
+) -> tuple[dict, str]:
+    """Parse an LLM JSON object, using general_model to repair malformed output.
+
+    Returns (parsed_object, repair_model_tag). repair_model_tag is non-empty only
+    when a repair model response was used.
+    """
+    current = (text or "").strip()
+    parsed = robust_json_parse(current)
+    if parsed:
+        return parsed, ""
+    if not current:
+        return {}, ""
+
+    cfg = get_config()
+    repair_timeout = timeout or getattr(cfg, "summary_timeout_sec", 120)
+    parse_note = "no valid JSON object found"
+    last_tag = ""
+    attempts = max(0, int(max_attempts or 0))
+    for attempt in range(attempts):
+        logger.info(
+            "json repair requested attempt=%s schema=%s",
+            attempt + 1,
+            expected_schema,
+        )
+        result = await call_chat_completion_result(
+            [
+                {
+                    "role": "system",
+                    "content": (
+                        "你只负责把模型输出修成合法 JSON 对象。"
+                        "禁止解释，禁止改变语义，禁止输出 JSON 以外的文本。"
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": _json_repair_prompt(current, expected_schema, parse_note),
+                },
+            ],
+            task=task,
+            temperature=0.0,
+            timeout=repair_timeout,
+            response_format={"type": "json_object"},
+        )
+        last_tag = result.model_tag
+        if not result.text:
+            parse_note = f"repair model returned no text ({result.failure_kind or 'unknown failure'})"
+            continue
+        current = result.text.strip()
+        parsed = robust_json_parse(current)
+        if parsed:
+            return parsed, last_tag
+        parse_note = "repair output was still not valid JSON"
+
+    logger.warning(
+        "json repair failed after %s attempts for schema=%s; last_output=%s",
+        attempts,
+        expected_schema,
+        current[:200],
+    )
+    return {}, ""
+
+
 # ── Problem statement loading ───────────────────────────────────────────
 
 def load_problem_statement(pid: str) -> str:
@@ -909,47 +998,321 @@ async def judge_submission(
     result = await judge_submission_result(problem_text, submission, history)
     if not result.text:
         return None
-    return robust_json_parse(result.text)
+    parsed, _repair_tag = await parse_json_with_llm_repair(
+        result.text,
+        expected_schema='{ "correct": boolean, "reason": string, "reply": string, "reaction": string }',
+        task="summary",
+        timeout=get_config().summary_timeout_sec,
+    )
+    return parsed
 
 
 # ── Judge ───────────────────────────────────────────────────────────────
 
+_SUMMARY_TARGET_CHARS = 520
+_SUMMARY_HARD_MAX_CHARS = 700
+_SUMMARY_LEAK_RE = re.compile(
+    r"(题解|解题思路|计数思路|算法思路|复杂度|"
+    r"可以用[^。；\n]*(?:枚举|贪心|动态规划|DP|dp|二分|排序|线段树|树状数组|最短路)|"
+    r"(?:枚举|贪心|动态规划|DP|dp|二分|排序|线段树|树状数组)[^。；\n]*即可)"
+)
+_SUMMARY_FORMAT_RE = re.compile(r"(^|\n)\s*(输入|输出|样例)\s*[:：]", re.I)
+_SUMMARY_MARKDOWN_RE = re.compile(r"(^|\n)\s*(#{1,6}\s+|[-*]\s+|```|\d+\.\s+)")
+_SUMMARY_SIMPLE_SUBSCRIPT_RE = re.compile(r"\b[A-Za-z]_(?:\{[^}]{1,24}\}|[A-Za-z0-9]+)")
+_SUMMARY_UNICODE_SUBSCRIPT_RE = re.compile(r"([A-Za-z])([₀₁₂₃₄₅₆₇₈₉ᵢⱼₖₙ₊₋]+)")
+_SUMMARY_LATEX_COMMAND_RE = re.compile(r"\\[A-Za-z]+")
+_SUMMARY_COMPLEX_LATEX_RE = re.compile(
+    r"\\(?:sum|prod|frac|binom|sqrt|lfloor|rfloor|lceil|rceil|left|right)|[_^]\{[^}]{3,}\}"
+)
+_SUMMARY_UNICODE_NOTATION_GUIDE = (
+    "Unicode 角标弹药表："
+    "下标数字 ₀₁₂₃₄₅₆₇₈₉；"
+    "常用下标字母/符号 ₐ ₑ ₕ ᵢ ⱼ ₖ ₗ ₘ ₙ ₒ ₚ ᵣ ₛ ₜ ᵤ ᵥ ₓ ₊ ₋ ₌ ₍ ₎；"
+    "上标数字 ⁰¹²³⁴⁵⁶⁷⁸⁹；"
+    "常用上标字母/符号 ᵃ ᵇ ᶜ ᵈ ᵉ ᶠ ᵍ ʰ ⁱ ʲ ᵏ ˡ ᵐ ⁿ ᵒ ᵖ ʳ ˢ ᵗ ᵘ ᵛ ʷ ˣ ʸ ᶻ ⁺ ⁻ ⁼ ⁽ ⁾。"
+    "常见写法：aᵢ、aⱼ、aₖ、aₙ、aᵢ₊₁、x²、2ᵏ、10¹⁸、10⁹+7。"
+    "没有常用 Unicode 下标的变量不要硬造；端点下标不确定时优先写成自然语言，如“给定的若干元素/所有给定位置”。"
+)
+_SUBSCRIPT_TRANS = str.maketrans({
+    "0": "₀",
+    "1": "₁",
+    "2": "₂",
+    "3": "₃",
+    "4": "₄",
+    "5": "₅",
+    "6": "₆",
+    "7": "₇",
+    "8": "₈",
+    "9": "₉",
+    "i": "ᵢ",
+    "j": "ⱼ",
+    "k": "ₖ",
+    "n": "ₙ",
+    "+": "₊",
+    "-": "₋",
+})
+_SUPERSCRIPT_TRANS = str.maketrans({
+    "0": "⁰",
+    "1": "¹",
+    "2": "²",
+    "3": "³",
+    "4": "⁴",
+    "5": "⁵",
+    "6": "⁶",
+    "7": "⁷",
+    "8": "⁸",
+    "9": "⁹",
+})
+
+
+def _to_subscript(text: str) -> str:
+    return text.translate(_SUBSCRIPT_TRANS)
+
+
+def _to_superscript(text: str) -> str:
+    return text.translate(_SUPERSCRIPT_TRANS)
+
+
+def _polish_summary_notation(summary: str) -> str:
+    text = summary.strip()
+    if not _SUMMARY_COMPLEX_LATEX_RE.search(text):
+        text = re.sub(
+            r"\b([A-Za-z])_\{([0-9ijkn+-]{1,8})\}",
+            lambda m: m.group(1) + _to_subscript(m.group(2)),
+            text,
+        )
+        text = re.sub(
+            r"\b([A-Za-z])_([0-9ijkn])\b",
+            lambda m: m.group(1) + _to_subscript(m.group(2)),
+            text,
+        )
+    text = re.sub(
+        r"10\^\{?([0-9]{1,3})\}?",
+        lambda m: "10" + _to_superscript(m.group(1)),
+        text,
+    )
+    text = re.sub(
+        r"\b1e([0-9]{1,3})\b",
+        lambda m: "10" + _to_superscript(m.group(1)),
+        text,
+        flags=re.I,
+    )
+    return text
+
+
+def _summary_system_prompt() -> str:
+    return (
+        "你是算法竞赛选手，在 QQ 群用中文介绍每日一题。你的目标不是完整翻译题面，"
+        "而是在不丢失限制和目标的前提下，写出短、自然、让人愿意读题的题意简述。"
+        "必须只输出 JSON 对象，格式为 {\"summary\":\"...\"}。"
+    )
+
+
+def _summary_source_payload(stmt_text: str, input_text: str, limits_text: str) -> dict[str, str]:
+    return {
+        "statement": stmt_text or "",
+        "input": input_text or "",
+        "limits": limits_text or "",
+    }
+
+
+def _build_summary_prompt(stmt_text: str, input_text: str, limits_text: str) -> str:
+    payload = _summary_source_payload(stmt_text, input_text, limits_text)
+    return (
+        "把下面 Codeforces 题面素材压缩转述为中文 QQ 群题意 summary。\n\n"
+        "硬性要求：\n"
+        "1. 只写题意，不写题解、算法、思路、复杂度、样例推导或任何“怎么做”。\n"
+        "2. 读者只看 summary 应该知道：给了什么、允许做什么、要求算/判定/构造什么、输出含义、全部数据范围、时限和内存限制。\n"
+        "3. 不要单列“输入：”“输出：”“样例：”。群友是交流做法，不是写代码；普通读入/输出格式默认省略。"
+        "只保留会影响理解的输出对象/答案含义，以及多测、所有 n 之和这类限制。交互题、构造输出、多答案、YES/NO 判定、特殊输出格式会影响题意时才自然说明。\n"
+        "4. 所有数据范围必须完整出现；可合并压缩但不能丢。题面给了上下界时尽量写完整区间，如 1≤n≤2×10⁵、0≤aᵢ≤10⁹、1≤t≤10⁴、多测且所有 n 之和≤2×10⁵；范围里也使用角标，不要写 a_i。\n"
+        "5. 时限和内存必须写在末尾，例如“时限2s，内存256MB”。\n"
+        "6. 背景故事、角色名、修辞、样例细节能删就删；定义、边界、判定规则、输出目标、数据范围、时空限制不能删。不要改变规则适用对象：若原文说每次操作/每个玩家/任意元素满足某条件，不能误写成只对先手、只对某一次或只对某一类对象成立。\n"
+        "7. LaTeX 是最后手段：普通数组下标和幂次优先用 Unicode 角标，如 aᵢ、a₁、a₂、aₙ、10¹⁸、10⁹+7；也可写“第 i 个/每个位置的 a”。"
+        f"{_SUMMARY_UNICODE_NOTATION_GUIDE}"
+        "严格递增序列写 a₁<a₂<…<aₙ 或“严格递增坐标”。不要猜测列表端点或把原文没有的下标终点写进 summary；端点不适合用 Unicode 角标时改用自然语言。"
+        "简单关系用 ≤、≥、×、mod。只有复杂求和、递推、分式、多重下标、精确定义用中文会失真时，才保留最少必要 LaTeX。\n"
+        f"8. 目标长度不超过 {_SUMMARY_TARGET_CHARS} 个中文字符；复杂题可略长，但完整限制优先于短。\n"
+        "9. 不要 Markdown、标题、列表、代码块、粗体斜体。\n\n"
+        "好风格示例：\n"
+        "给定长度为 n 的数组 a 和 q 个询问。每次询问给出区间 [l,r]，要求把区间划分成尽量少的连续段，"
+        "使每段内所有数的乘积等于它们的 LCM；输出最少段数。1≤n,q≤10⁵，1≤aᵢ≤10⁵，时限1s，内存256MB。\n"
+        "给定多组数据，每组有数组 a。对每个循环移位求某个二元答案 (cnt,cost)，其中 cost 对 10⁹+7 取模；1≤t≤2×10⁴，所有 n 之和≤10⁶，1≤aᵢ≤10⁹，时限3s，内存256MB。\n"
+        "给定递增坐标 1≤a₁<a₂<…<aₙ，可在整数点新增传送器，要求从 0 到 aₙ 的总代价≤m，求最少新增数。1≤n≤2×10⁵，aₙ≤m≤10¹⁸，时限7s，内存512MB。\n\n"
+        "坏风格示例（禁止）：\n"
+        "输入：第一行 n 和 q... 输出：每个询问输出答案... 解题思路是预处理每个位置能延伸到哪里，然后倍增。\n\n"
+        "题面素材 JSON：\n"
+        f"{json.dumps(payload, ensure_ascii=False)}"
+    )
+
+
+async def _parse_summary_json(text: str | None, *, timeout: int) -> tuple[str | None, str]:
+    parsed, repair_tag = await parse_json_with_llm_repair(
+        text,
+        expected_schema='{ "summary": string }',
+        task="summary",
+        timeout=timeout,
+    )
+    summary = parsed.get("summary") if isinstance(parsed, dict) else None
+    if not isinstance(summary, str):
+        return None, ""
+    summary = _polish_summary_notation(summary)
+    return summary or None, repair_tag
+
+
+def _limit_values(limits_text: str) -> tuple[str, str]:
+    time_value = ""
+    memory_value = ""
+    time_match = re.search(r"Time:\s*([^,]+)", limits_text or "", re.I)
+    memory_match = re.search(r"Memory:\s*(.+)$", limits_text or "", re.I)
+    if time_match:
+        time_value = time_match.group(1).strip().lower()
+    if memory_match:
+        memory_value = memory_match.group(1).strip().lower()
+    return time_value, memory_value
+
+
+def _limit_value_present(summary: str, value: str, *, kind: str) -> bool:
+    if not value or "?" in value:
+        return True
+    text = summary.lower().replace(" ", "")
+    raw = value.replace(" ", "")
+    if raw and raw in text:
+        return True
+    number_match = re.search(r"\d+(?:\.\d+)?", value)
+    if not number_match:
+        return True
+    number = number_match.group(0)
+    if "." in number:
+        number = number.rstrip("0").rstrip(".")
+    if kind == "time":
+        return bool(re.search(rf"{re.escape(number)}(?:s|秒|second|seconds)", text))
+    return bool(re.search(rf"{re.escape(number)}(?:mb|mib|兆|megabyte|megabytes)", text))
+
+
+def _summary_quality_issues(summary: str, limits_text: str = "") -> list[str]:
+    issues: list[str] = []
+    text = (summary or "").strip()
+    if not text:
+        return ["summary is empty"]
+    if len(text) > _SUMMARY_HARD_MAX_CHARS:
+        issues.append(f"summary is too long ({len(text)} chars)")
+    elif len(text) > _SUMMARY_TARGET_CHARS:
+        issues.append(f"summary should be more compressed ({len(text)} chars)")
+    if _SUMMARY_LEAK_RE.search(text):
+        issues.append("summary appears to include solution/editorial content")
+    if _SUMMARY_FORMAT_RE.search(text):
+        issues.append("summary uses explicit input/output/sample sections")
+    if _SUMMARY_MARKDOWN_RE.search(text):
+        issues.append("summary uses markdown/list formatting")
+
+    time_value, memory_value = _limit_values(limits_text)
+    if not _limit_value_present(text, time_value, kind="time"):
+        issues.append("summary omits time limit")
+    if not _limit_value_present(text, memory_value, kind="memory"):
+        issues.append("summary omits memory limit")
+
+    simple_subscripts = _SUMMARY_SIMPLE_SUBSCRIPT_RE.findall(text)
+    unicode_subscripts = _SUMMARY_UNICODE_SUBSCRIPT_RE.findall(text)
+    generic_i_bases = {base for base, sub in unicode_subscripts if sub == "ᵢ"}
+    latex_commands = _SUMMARY_LATEX_COMMAND_RE.findall(text)
+    has_complex_latex = bool(_SUMMARY_COMPLEX_LATEX_RE.search(text))
+    if (
+        (simple_subscripts and not has_complex_latex)
+        or len(simple_subscripts) >= 6
+        or len(generic_i_bases) >= 5
+        or len(unicode_subscripts) >= 18
+        or len(latex_commands) >= 4
+    ):
+        issues.append("summary overuses LaTeX/simple subscripts")
+    return issues
+
+
+def _build_summary_repair_prompt(
+    stmt_text: str,
+    input_text: str,
+    limits_text: str,
+    summary: str,
+    issues: list[str],
+) -> str:
+    payload = {
+        "source": _summary_source_payload(stmt_text, input_text, limits_text),
+        "bad_summary": summary,
+        "issues": issues,
+    }
+    return (
+        "请修正 bad_summary，并仍然只输出 JSON：{\"summary\":\"...\"}。\n"
+        "修正规则：只压缩、改写、删除违规内容；不要加入 source 中没有的新事实。\n"
+        "必须保留题目目标、关键定义、输出含义、全部数据范围（上下界都保留）、时限和内存；删除题解/思路/复杂度/样例推导；"
+        "修正任何把“每次/任意/双方/所有对象”的规则误写成只对先手、只对一次或只对部分对象成立的表述；"
+        "不要单列输入输出；普通输入格式删掉，只保留答案含义、多测和总和限制；正文和数据范围里的普通 a_i、a_{i+1}、a_1<...<a_n 都改成 aᵢ、aᵢ₊₁、a₁<…<aₙ、相邻位置等角标或自然写法；"
+        f"{_SUMMARY_UNICODE_NOTATION_GUIDE}"
+        "把端点无法从 source 直接确认的角标范围改成自然语言，除非 source 明确给出该终点；"
+        "把 10^18、1e18、10^9+7、1e9+7 等普通幂次改成 10¹⁸、10⁹+7；"
+        "LaTeX 只在复杂公式不可自然中文化时保留。\n\n"
+        f"{json.dumps(payload, ensure_ascii=False)}"
+    )
+
+
 async def summarize_problem(stmt_text: str, input_text: str, limits_text: str) -> tuple[str | None, str]:
     """Generate Chinese summary of a problem via the configured chat provider.
-    
+
     Returns (summary_text, model_tag). model_tag is empty if the LLM call failed.
     """
     cfg = get_config()
-    prompt = (
-        f"下面是需要压缩转述的题面素材（可能含英文，以及从公式图识别得到的 LaTeX；勿臆造素材里未出现的事实）：\n\n"
-        f"【题干主体】\n{stmt_text}\n\n"
-        f"【输入说明】（若几乎为空可略写）\n{input_text}\n\n"
-        f"【时空限制】\n{limits_text}\n\n"
-        "请输出一段连贯的中文题意简述，使群友只读这段也能明白「要算什么 / 判定什么 / 输出什么」并能开始思考做法。\n\n"
-        "完整性（最高优先级）：\n"
-        "1) 只基于上述素材转述与压缩；禁止编造素材未写明的性质、定理、样例推论或「显然」步骤。\n"
-        "2) 禁止为缩短篇幅而删掉题意关键信息。下列若在素材中出现，则简述中必须保留（可用等价中文复述；"
-        "若删掉会改变题目则绝对禁止删）：目标或优化对象；答案/计数/图论对象的精确定义；核心等式、不等式、递推式；"
-        "YES/NO 的判定规则；构造题要输出什么的精确定义；交互题里询问/回答的含义；会改变结论的特例或边界。\n"
-        "3) 素材中的公式（含 LaTeX）凡参与题意定义、而非仅装饰的，必须在简述中体现：优先用清晰中文把关系说完整；"
-        "若仅用中文会产生歧义或无法保留必要的符号结构，允许保留最少必要的 LaTeX 片段（如分式、求和、多重下标），"
-        "禁止大段堆砌 LaTeX、禁止代码围栏或 Markdown 数学块。\n\n"
-        "表达与长度：\n"
-        "1) 背景故事、角色名、与算法无关的修辞可删；定义、约束、关键公式不可删。\n"
-        "2) 默认流畅中文 + 简单符号（如 ≤、≥、×）；非交互且无特殊读入要求时，I/O 格式可点到为止。\n"
-        "3) 数据范围跟在变量后括号里（如 n(1e5)、a_i(0～1e18)）；时空限制写在段末。\n"
-        "4) 交互题在简述末尾加「交互题」。\n"
-        "5) 在保证信息等价、无歧义的前提下尽量短；信息完整优先于「字数减半」类目标。\n"
+    messages = [
+        {"role": "system", "content": _summary_system_prompt()},
+        {"role": "user", "content": _build_summary_prompt(stmt_text, input_text, limits_text)},
+    ]
+    result = await call_chat_completion_result(
+        messages,
+        task="summary",
+        temperature=0.4,
+        timeout=cfg.summary_timeout_sec,
+        response_format={"type": "json_object"},
     )
-    result = await call_chat_completion_result([
-        {"role": "system", "content": (
-            "你是算法竞赛选手，在 QQ 群用中文介绍每日一题。"
-            "输出连贯、可读、信息完整的中文简述；默认少用 LaTeX 以降低阅读成本，但题意所依赖的关键公式与定义必须交代清楚，"
-            "必要时可保留少量 LaTeX。不要使用 Markdown（标题井号、列表语法、代码围栏、粗体斜体）。"
-        )},
-        {"role": "user", "content": prompt},
-    ], task="summary", timeout=cfg.summary_timeout_sec)
-    return result.text, result.model_tag
+    summary, repair_tag = await _parse_summary_json(result.text, timeout=cfg.summary_timeout_sec)
+    tag = repair_tag or result.model_tag
+    if not summary:
+        logger.warning("summary generation returned invalid JSON/object")
+        return None, ""
+
+    issues = _summary_quality_issues(summary, limits_text)
+    if not issues:
+        return summary, tag
+
+    logger.info("summary quality repair requested: %s", "; ".join(issues))
+    repair_result = await call_chat_completion_result(
+        [
+            {"role": "system", "content": _summary_system_prompt()},
+            {
+                "role": "user",
+                "content": _build_summary_repair_prompt(
+                    stmt_text,
+                    input_text,
+                    limits_text,
+                    summary,
+                    issues,
+                ),
+            },
+        ],
+        task="summary",
+        temperature=0.2,
+        timeout=cfg.summary_timeout_sec,
+        response_format={"type": "json_object"},
+    )
+    repaired, repaired_json_tag = await _parse_summary_json(
+        repair_result.text,
+        timeout=cfg.summary_timeout_sec,
+    )
+    if not repaired:
+        logger.warning("summary repair returned invalid JSON/object")
+        return None, ""
+    repair_issues = _summary_quality_issues(repaired, limits_text)
+    if repair_issues:
+        logger.warning("summary repair still failed quality gate: %s", "; ".join(repair_issues))
+        return None, ""
+    return repaired, repaired_json_tag or repair_result.model_tag
 
 
 async def translate_sample_notes(notes_text: str) -> tuple[str | None, str]:
@@ -1010,6 +1373,7 @@ async def translate_editorial_to_zh(
         "problem": problem_body,
         "official_editorial": body,
     }
+    cfg = get_config()
     result = await call_chat_completion_result(
         [
             {
@@ -1047,7 +1411,12 @@ async def translate_editorial_to_zh(
     )
     if not result.text:
         return None, "", None
-    parsed = robust_json_parse(result.text)
+    parsed, repair_tag = await parse_json_with_llm_repair(
+        result.text,
+        expected_schema='{ "matched": "yes" | "no", "result": string }',
+        task="summary",
+        timeout=cfg.summary_timeout_sec,
+    )
     matched = str(parsed.get("matched", "")).strip().lower()
     if matched == "no":
         return None, "", False
@@ -1056,7 +1425,7 @@ async def translate_editorial_to_zh(
     translated = str(parsed.get("result", "") or "").strip()
     if not translated:
         return None, "", None
-    return translated, result.model_tag, True
+    return translated, repair_tag or result.model_tag, True
 
 
 # ── Contest checking ────────────────────────────────────────────────────

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -95,16 +95,6 @@ def _provider_is_dashscope(provider_name: str, base_url: str) -> bool:
     )
 
 
-def _provider_is_fable(provider_name: str, base_url: str) -> bool:
-    name = (provider_name or "").strip().lower()
-    parsed = urlparse((base_url or "").strip())
-    host = (parsed.hostname or "").lower()
-    return name == "fable" or host == "zenmux.ai"
-
-
-def _provider_accepts_generic_thinking(provider_name: str, base_url: str) -> bool:
-    return not _provider_is_fable(provider_name, base_url)
-
 
 def _chat_completion_timeout(
     *,
@@ -494,19 +484,23 @@ async def chat_completion(
             payload: dict = {
                 "model": model_name,
                 "messages": messages,
-                "temperature": temperature,
+                "temperature": (
+                    provider.temperature
+                    if provider.temperature is not None
+                    else temperature
+                ),
             }
             if response_format:
                 payload["response_format"] = response_format
-            if thinking and _provider_accepts_generic_thinking(provider.name, provider.base_url):
+            if thinking and provider.send_thinking:
                 payload["thinking"] = thinking
                 if _provider_is_dashscope(provider.name, provider.base_url):
                     payload["enable_thinking"] = True
             reasoning_effort = provider.reasoning_effort.strip().lower()
             if reasoning_effort and send_reasoning_effort:
                 payload["reasoning_effort"] = reasoning_effort
-                if _provider_is_fable(provider.name, provider.base_url):
-                    payload["temperature"] = 1
+            if provider.extra_body:
+                payload.update(provider.extra_body)
             if _provider_uses_stream(
                 provider.name,
                 provider.base_url,

--- a/src/kouhai_bot/llm_config.py
+++ b/src/kouhai_bot/llm_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 
@@ -36,6 +36,9 @@ class LlmProviderConfig:
     reasoning_effort: str = ""
     model_tag: str = ""
     stream: bool = False
+    send_thinking: bool = True
+    temperature: float | None = None
+    extra_body: dict[str, Any] = field(default_factory=dict)
 
     def model_for(self, explicit_model: str = "") -> str:
         """Resolve the model name for this provider.
@@ -93,6 +96,18 @@ def _build_provider_list(raw: Any, *, section_name: str) -> list[LlmProviderConf
                 f"set base_url (e.g. https://api.deepseek.com) or omit for OpenAI default"
             )
 
+        temperature = None
+        if p.get("temperature") is not None:
+            temperature = float(p["temperature"])
+
+        extra_body = p.get("extra_body", {})
+        if extra_body is None:
+            extra_body = {}
+        if not isinstance(extra_body, dict):
+            raise RuntimeError(
+                f"LLM provider '{name}' in llm.{section_name} has non-mapping extra_body"
+            )
+
         providers.append(
             LlmProviderConfig(
                 name=name,
@@ -102,6 +117,9 @@ def _build_provider_list(raw: Any, *, section_name: str) -> list[LlmProviderConf
                 reasoning_effort=str(p.get("reasoning_effort", "")).strip(),
                 model_tag=str(p.get("model_tag", "")).strip(),
                 stream=_parse_bool(p.get("stream", False)),
+                send_thinking=_parse_bool(p.get("send_thinking", True), default=True),
+                temperature=temperature,
+                extra_body=dict(extra_body),
             )
         )
     return providers

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -150,6 +150,28 @@ def test_provider_stream_loads_from_yaml(monkeypatch, tmp_path):
     assert cfg.llm_smart_providers[0].stream is True
 
 
+def test_provider_payload_options_load_from_yaml(monkeypatch, tmp_path):
+    data = yaml.safe_load(_make_yaml())
+    provider = data["llm"]["smart_model"][0]
+    provider["send_thinking"] = False
+    provider["temperature"] = 1
+    provider["extra_body"] = {"service_tier": "priority"}
+    cfg = _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
+
+    loaded = cfg.llm_smart_providers[0]
+    assert loaded.send_thinking is False
+    assert loaded.temperature == 1.0
+    assert loaded.extra_body == {"service_tier": "priority"}
+
+
+def test_provider_extra_body_must_be_mapping(monkeypatch, tmp_path):
+    data = yaml.safe_load(_make_yaml())
+    data["llm"]["smart_model"][0]["extra_body"] = "bad"
+
+    with pytest.raises(RuntimeError, match="extra_body"):
+        _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
+
+
 def test_current_group_loaded(monkeypatch, tmp_path):
     cfg = _from_yaml(_make_yaml(current_group=123456), monkeypatch, tmp_path)
     assert cfg.current_group == 123456

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -11,10 +11,14 @@ from kouhai_bot.llm_config import LlmProviderConfig
 from kouhai_bot.handlers.shared import (
     build_judge_messages,
     build_second_judge_messages,
+    _build_summary_prompt,
+    _build_summary_repair_prompt,
     call_chat_completion,
     get_judge_prompt,
     call_chat_completion_result,
+    judge_submission,
     judge_submission_result,
+    parse_json_with_llm_repair,
     robust_json_parse,
     summarize_problem,
     translate_editorial_to_zh,
@@ -43,7 +47,9 @@ def test_translate_editorial_to_zh_uses_structured_match_output():
             model_tag="🐳",
         )
 
-    with patch("kouhai_bot.handlers.shared.call_chat_completion_result", fake_call):
+    cfg = _openai_cfg(summary_timeout_sec=123)
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", fake_call):
         translated, tag, matched = asyncio.run(translate_editorial_to_zh(
             "Official editorial",
             pid="542D",
@@ -296,8 +302,11 @@ def test_task_entrypoints_are_blackbox_except_model_class_and_tag():
         text = "OK"
         if payload.get("response_format") == {"type": "json_object"}:
             user_content = payload["messages"][-1]["content"]
+            system_content = payload["messages"][0]["content"]
             if "official_editorial" in user_content:
                 text = json.dumps({"matched": "yes", "result": "中文题解"})
+            elif "summary" in system_content:
+                text = json.dumps({"summary": "OK"})
             else:
                 text = json.dumps({
                     "correct": False,
@@ -438,6 +447,7 @@ def test_call_chat_completion_stops_on_non_retryable_failure():
     sleep_mock.assert_not_awaited()
 
 
+
 def test_call_chat_completion_honors_retry_after_with_cap():
     cfg = _openai_cfg(
         llm_max_retries=1,
@@ -466,6 +476,92 @@ def test_call_chat_completion_honors_retry_after_with_cap():
     sleep_mock.assert_awaited_once_with(2.5)
 
 
+
+
+def test_parse_json_with_llm_repair_wraps_plain_text_summary():
+    calls = []
+
+    async def fake_call(messages, **kwargs):
+        calls.append({"messages": messages, **kwargs})
+        return ChatCompletionResult(
+            text=json.dumps({"summary": "纯文本题意"}),
+            model_tag="『FIX』",
+        )
+
+    cfg = _openai_cfg(summary_timeout_sec=123)
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call):
+        parsed, tag = asyncio.run(parse_json_with_llm_repair(
+            "纯文本题意",
+            expected_schema='{ "summary": string }',
+            timeout=123,
+        ))
+
+    assert parsed == {"summary": "纯文本题意"}
+    assert tag == "『FIX』"
+    assert len(calls) == 1
+    assert calls[0]["task"] == "summary"
+    assert calls[0]["temperature"] == 0.0
+    assert calls[0]["timeout"] == 123
+    assert calls[0]["response_format"] == {"type": "json_object"}
+
+
+def test_parse_json_with_llm_repair_retries_until_valid_json():
+    outputs = ["still not json", json.dumps({"ok": True})]
+
+    async def fake_call(messages, **kwargs):
+        return ChatCompletionResult(text=outputs.pop(0), model_tag="『FIX』")
+
+    cfg = _openai_cfg(summary_timeout_sec=123)
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call):
+        parsed, tag = asyncio.run(parse_json_with_llm_repair(
+            "bad",
+            expected_schema='{ "ok": boolean }',
+            max_attempts=3,
+        ))
+
+    assert parsed == {"ok": True}
+    assert tag == "『FIX』"
+    assert outputs == []
+
+
+def test_judge_submission_repairs_malformed_json_response():
+    async def fake_judge_result(*args, **kwargs):
+        return ChatCompletionResult(text='正确，应判 true', model_tag="『J』")
+
+    async def fake_repair(messages, **kwargs):
+        return ChatCompletionResult(
+            text=json.dumps({"correct": True, "reason": "格式已修复", "reply": "", "reaction": ""}),
+            model_tag="『FIX』",
+        )
+
+    cfg = _openai_cfg(summary_timeout_sec=123)
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared.judge_submission_result", side_effect=fake_judge_result), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_repair):
+        parsed = asyncio.run(judge_submission("problem", "solution"))
+
+    assert parsed["correct"] is True
+    assert parsed["reason"] == "格式已修复"
+
+
+def test_summary_prompt_lists_unicode_notation_inventory():
+    prompt = _build_summary_prompt("stmt", "input", "limits")
+    repair = _build_summary_repair_prompt("stmt", "input", "limits", "bad", ["issue"])
+
+    for text in (prompt, repair):
+        assert "Unicode 角标弹药表" in text
+        assert "₀₁₂₃₄₅₆₇₈₉" in text
+        assert "⁰¹²³⁴⁵⁶⁷⁸⁹" in text
+        assert "ᵢ ⱼ ₖ" in text
+        assert "ᵃ ᵇ ᶜ" in text
+        assert "aᵢ₊₁" in text
+        assert "10¹⁸" in text
+        assert "10⁹+7" in text
+        assert "端点下标不确定时优先写成自然语言" in text
+
+
 def test_summarize_problem_uses_configured_timeout():
     cfg = _openai_cfg(summary_timeout_sec=321)
 
@@ -475,13 +571,126 @@ def test_summarize_problem_uses_configured_timeout():
                              response_format=None, thinking=None):
         assert task == "summary"
         assert timeout == 321
-        return ChatCompletionResult(text="summary ok", model_tag="🐳")
+        assert response_format == {"type": "json_object"}
+        assert temperature == 0.4
+        return ChatCompletionResult(text=json.dumps({"summary": "summary ok"}), model_tag="🐳")
 
     with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
             patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat):
         summary, tag = asyncio.run(summarize_problem("stmt", "input", "limits"))
         assert summary == "summary ok"
         assert tag == "🐳"
+
+
+def test_summarize_problem_repairs_solution_leak_and_format_sections():
+    cfg = _openai_cfg(summary_timeout_sec=321)
+    calls = []
+    bad = (
+        "给定数组 a。\n输入：第一行 n。\n输出：答案。"
+        "解题思路是枚举每个位置即可，复杂度 O(n)。"
+    )
+    fixed = "给定长度为 n 的数组 a，要求计算满足题目条件的答案并输出。n≤10⁵，时限 1s。"
+
+    async def fake_call_chat(messages, **kwargs):
+        calls.append({"messages": messages, **kwargs})
+        text = bad if len(calls) == 1 else fixed
+        tag = "bad" if len(calls) == 1 else "fixed"
+        return ChatCompletionResult(text=json.dumps({"summary": text}), model_tag=tag)
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat):
+        summary, tag = asyncio.run(summarize_problem("stmt", "input", "limits"))
+
+    assert summary == fixed
+    assert tag == "fixed"
+    assert len(calls) == 2
+    assert calls[0]["response_format"] == {"type": "json_object"}
+    assert calls[1]["temperature"] == 0.2
+    assert "bad_summary" in calls[1]["messages"][-1]["content"]
+
+
+def test_summarize_problem_invalid_json_returns_none():
+    cfg = _openai_cfg(summary_timeout_sec=321)
+
+    async def fake_call_chat(messages, **kwargs):
+        return ChatCompletionResult(text="plain text summary", model_tag="🐳")
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat):
+        summary, tag = asyncio.run(summarize_problem("stmt", "input", "limits"))
+
+    assert summary is None
+    assert tag == ""
+
+
+def test_summarize_problem_repairs_missing_time_and_memory_limits():
+    cfg = _openai_cfg(summary_timeout_sec=321)
+    calls = []
+    first = "给定长度为 n 的数组 a，要求输出答案。n≤10⁵。"
+    fixed = "给定长度为 n 的数组 a，要求输出答案。n≤10⁵，时限2s，内存256MB。"
+
+    async def fake_call_chat(messages, **kwargs):
+        calls.append(messages[-1]["content"])
+        text = first if len(calls) == 1 else fixed
+        return ChatCompletionResult(text=json.dumps({"summary": text}), model_tag="🐳")
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat):
+        summary, tag = asyncio.run(summarize_problem(
+            "stmt",
+            "input",
+            "Time: 2 seconds, Memory: 256 megabytes",
+        ))
+
+    assert summary == fixed
+    assert tag == "🐳"
+    assert len(calls) == 2
+    assert "summary omits time limit" in calls[1]
+    assert "summary omits memory limit" in calls[1]
+
+
+def test_summarize_problem_repairs_ordinary_subscript_clutter_but_allows_complex_formula():
+    cfg = _openai_cfg(summary_timeout_sec=321)
+    calls = []
+    clutter = "给定 a_i、b_i、c_i、d_i、e_i、f_i，要求对每个 i 输出答案。"
+    repaired = "给定每个位置的若干参数，要求逐位置计算并输出答案。"
+
+    async def fake_call_chat(messages, **kwargs):
+        calls.append(messages[-1]["content"])
+        text = clutter if len(calls) == 1 else repaired
+        return ChatCompletionResult(text=json.dumps({"summary": text}), model_tag="🐳")
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat):
+        summary, tag = asyncio.run(summarize_problem("stmt", "input", "limits"))
+
+    assert summary == repaired
+    assert tag == "🐳"
+    assert len(calls) == 2
+
+    simple = "给定 a_i、a_n、1e18 和 10^9+7。"
+
+    async def fake_simple_call(messages, **kwargs):
+        return ChatCompletionResult(text=json.dumps({"summary": simple}), model_tag="🐳")
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_simple_call):
+        summary, tag = asyncio.run(summarize_problem("stmt", "input", "limits"))
+
+    assert summary == "给定 aᵢ、aₙ、10¹⁸ 和 10⁹+7。"
+    assert tag == "🐳"
+
+    complex_formula = r"定义 f(x)=\sum_{i=1}^{n} floor(x / p_i)，要求对每个询问计算满足条件的最小 x。"
+
+    async def fake_formula_call(messages, **kwargs):
+        return ChatCompletionResult(text=json.dumps({"summary": complex_formula}), model_tag="🐳")
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_formula_call):
+        summary, tag = asyncio.run(summarize_problem("stmt", "input", "limits"))
+
+    assert summary == complex_formula
+    assert tag == "🐳"
 
 
 def test_dashscope_provider_payload_enables_stream():
@@ -543,13 +752,47 @@ def test_streaming_provider_uses_default_idle_timeout():
     assert calls == [120]
 
 
-def test_zenmux_fable_payload_uses_reasoning_effort_without_generic_thinking():
+
+def test_zenmux_minimax_m3_payload_accepts_adaptive_thinking():
     provider = LlmProviderConfig(
-        name="fable",
+        name="minimax-m3",
         api_key="sk-test",
         base_url="https://zenmux.ai/api/v1",
-        model="anthropic/claude-fable-5-free",
+        model="minimax/minimax-m3",
+    )
+    cfg = _openai_cfg(llm_general_providers=[provider])
+    calls = []
+
+    async def fake_once(session, **kwargs):
+        calls.append(kwargs["payload"].copy())
+        return _ChatCompletionAttempt(text="OK", retryable=False, retry_after_sec=None)
+
+    with patch("kouhai_bot.llm.get_config", return_value=cfg), \
+            patch("kouhai_bot.llm.aiohttp.ClientSession", _DummySession), \
+            patch("kouhai_bot.llm._post_chat_completion_once", side_effect=fake_once):
+        result = asyncio.run(call_chat_completion_result(
+            [{"role": "user", "content": "Reply OK."}],
+            task="summary",
+            thinking={"type": "adaptive"},
+        ))
+
+    assert result.text == "OK"
+    assert calls[0]["model"] == "minimax/minimax-m3"
+    assert calls[0]["thinking"] == {"type": "adaptive"}
+    assert "enable_thinking" not in calls[0]
+    assert "reasoning_effort" not in calls[0]
+
+
+def test_provider_payload_options_control_thinking_temperature_and_extra_body():
+    provider = LlmProviderConfig(
+        name="custom-zenmux",
+        api_key="sk-test",
+        base_url="https://zenmux.ai/api/v1",
+        model="provider/custom-model",
         reasoning_effort="max",
+        send_thinking=False,
+        temperature=1.0,
+        extra_body={"service_tier": "priority"},
     )
     cfg = _openai_cfg(llm_smart_providers=[provider])
     calls = []
@@ -573,13 +816,46 @@ def test_zenmux_fable_payload_uses_reasoning_effort_without_generic_thinking():
         ))
 
     assert result.text == "{\"ok\":true}"
-    assert calls[0]["model"] == "anthropic/claude-fable-5-free"
+    assert calls[0]["model"] == "provider/custom-model"
     assert calls[0]["response_format"] == {"type": "json_object"}
     assert calls[0]["reasoning_effort"] == "max"
-    assert calls[0]["temperature"] == 1
+    assert calls[0]["temperature"] == 1.0
+    assert calls[0]["service_tier"] == "priority"
     assert "thinking" not in calls[0]
     assert "enable_thinking" not in calls[0]
     assert "stream" not in calls[0]
+
+
+def test_zenmux_grok45free_payload_uses_xhigh_reasoning_and_tag():
+    provider = LlmProviderConfig(
+        name="grok45free",
+        api_key="sk-test",
+        base_url="https://zenmux.ai/api/v1",
+        model="x-ai/grok-4.5-free",
+        reasoning_effort="xhigh",
+        model_tag="『∅』",
+    )
+    cfg = _openai_cfg(llm_smart_providers=[provider])
+    calls = []
+
+    async def fake_once(session, **kwargs):
+        calls.append(kwargs["payload"].copy())
+        return _ChatCompletionAttempt(text="OK", retryable=False, retry_after_sec=None)
+
+    with patch("kouhai_bot.llm.get_config", return_value=cfg), \
+            patch("kouhai_bot.llm.aiohttp.ClientSession", _DummySession), \
+            patch("kouhai_bot.llm._post_chat_completion_once", side_effect=fake_once):
+        result = asyncio.run(call_chat_completion_result(
+            [{"role": "user", "content": "Reply OK."}],
+            task="judge",
+            thinking={"type": "enabled"},
+        ))
+
+    assert result.text == "OK"
+    assert result.model_tag == "『∅』"
+    assert calls[0]["model"] == "x-ai/grok-4.5-free"
+    assert calls[0]["reasoning_effort"] == "xhigh"
+    assert calls[0]["thinking"] == {"type": "enabled"}
 
 
 def test_non_dashscope_provider_payload_does_not_enable_stream():
@@ -627,6 +903,36 @@ def test_explicit_stream_provider_payload_enables_stream():
 
     assert result == "OK"
     assert calls[0]["stream"] is True
+
+
+def test_zenmux_minimax_payload_does_not_use_fable_temperature_special_case():
+    provider = LlmProviderConfig(
+        name="minimax-m3",
+        api_key="sk-test",
+        base_url="https://zenmux.ai/api/v1",
+        model="minimax/minimax-m3",
+        reasoning_effort="high",
+    )
+    cfg = _openai_cfg(llm_general_providers=[provider])
+    calls = []
+
+    async def fake_once(session, **kwargs):
+        calls.append(kwargs["payload"].copy())
+        return _ChatCompletionAttempt(text="OK", retryable=False, retry_after_sec=None)
+
+    with patch("kouhai_bot.llm.get_config", return_value=cfg), \
+            patch("kouhai_bot.llm.aiohttp.ClientSession", _DummySession), \
+            patch("kouhai_bot.llm._post_chat_completion_once", side_effect=fake_once):
+        result = asyncio.run(call_chat_completion(
+            [{"role": "user", "content": "Reply with exactly OK."}],
+            task="summary",
+        ))
+
+    assert result == "OK"
+    assert calls[0]["model"] == "minimax/minimax-m3"
+    assert calls[0]["reasoning_effort"] == "high"
+    assert calls[0]["temperature"] == 0.7
+
 
 
 def test_streaming_chat_completion_uses_sock_read_idle_timeout():


### PR DESCRIPTION
## What changed
- Reworked problem summary generation to require JSON output with a `summary` field.
- Added a QQ-focused summary prompt that avoids solution leakage, omits routine input/output layout, preserves full data bounds plus time/memory, and treats LaTeX as a last resort.
- Added an explicit Unicode notation inventory to the summary and repair prompts so weaker models see the actual subscript/superscript tokens: `₀₁₂...`, `⁰¹²...`, `ᵢ`, `ⱼ`, `ₖ`, `ₙ`, `ⁿ`, `⁺`, `₊`, etc.
- Kept the notation guidance generic: symbol endpoints must be traceable to the source; when an endpoint is uncertain or lacks a readable Unicode form, use natural language instead of guessing. Removed the earlier overly specific `b₁…bᵢ`-style patch.
- Added Unicode notation polishing for ordinary notation: `a_i`/`a_{i+1}`/`10^18`/`1e18` become `aᵢ`/`aᵢ₊₁`/`10¹⁸`, while complex TeX contexts such as `\sum`/`\frac` are preserved.
- Added a local quality gate with one repair pass for overlong summaries, format sections, Markdown/list formatting, solution-like phrasing, ASCII subscript clutter, missing time/memory limits, and excessive generic-index clutter.
- Added a generic JSON repair harness for LLM outputs that are supposed to be JSON: local parse first, then up to 3 low-temperature general-model repair attempts. This is used by summary parsing, first/second judge JSON parsing, clarify JSON parsing, direct judge helper parsing, and editorial match/translation JSON parsing.
- Replaced the stale Fable free example with ZenMux Grok 4.5 Free: `model: "x-ai/grok-4.5-free"`, `reasoning_effort: "xhigh"`, `model_tag: "『∅』"`.
- Removed Fable-specific payload hacks from `llm.py`. Provider-specific behavior is now configured generically via `send_thinking`, provider-level `temperature`, and `extra_body`.
- Added payload coverage for MiniMax M3 adaptive thinking, Grok 4.5 Free `xhigh` reasoning/tagging, generic provider payload controls, and the JSON repair loop.

## ZenMux / model notes
MiniMax's official OpenAI-compatible schema says M3 supports `thinking.type` values `adaptive` and `disabled`; omitting `thinking` defaults to adaptive thinking. There is no official “max thinking” value for M3 in that schema.

ZenMux Grok 4.5 Free was live-tested through the existing judge path. `reasoning_effort: "max"` returned `400 Invalid reasoning effort`; `xhigh`, `high`, `medium`, `low`, and an empty value were accepted. The example therefore uses `xhigh` as the highest accepted setting for this model.

Because ZenMux forwards OpenAI-compatible requests, new models should usually be configurable in YAML rather than by adding branches to `llm.py`. Use `reasoning_effort`, `send_thinking`, `temperature`, and `extra_body` for gateway-specific behavior.

## Evaluation notes
Real cached-statement iterations were run on `1223D`, `1661F`, `306C`, `1884E`, `2159D1`, `875D`, `1037F`, `1201D`, `1536F`, and `2020E`.

- No solution/editorial leakage in completed outputs.
- Prompt/gate changes improved time/memory and data-bound retention.
- After the Unicode prompt update, M3 rerun on `1201D` used natural language for the safe-column list instead of producing the earlier wrong endpoint notation.
- M3 still sometimes ignores JSON-only output and returns plain text. The new JSON repair harness addresses that failure mode without relying on provider-enforced structured output.
- This PR does not claim M3 alone is fully reliable for semantic verification; it improves readability and format recovery while keeping retry/fallback behavior.

## Validation
- MiniMax official OpenAI-compatible schema inspected for `thinking` support
- ZenMux Grok 4.5 Free probe: `max` rejected; `xhigh/high/medium/low/empty` accepted
- Live Grok 4.5 Free judge call with `reasoning_effort: "xhigh"` returned `correct: true` and model tag `『∅』`
- Live MiniMax M3 JSON repair test wrapped a plain-text summary into `{ "summary": ... }`
- MiniMax M3 summary rerun on the same 10 cached statements; 8/10 valid JSON first try, the two JSON failures recovered on retry
- `uv run pytest tests/test_shared.py tests/test_commands.py -q` (`161 passed`)
- `uv run pytest -q` (`299 passed`)
