### PR TITLE
Use LLM extraction for CF editorials

### DIFF
--- a/tests/test_cf_tutorial_agent.py
+++ b/tests/test_cf_tutorial_agent.py
@@ -55,25 +55,24 @@ def test_extract_blog_links_prefers_tutorial_text():
     ]
 
 
-def test_agent_selects_high_confidence_candidate(tmp_path):
+def test_agent_extracts_editorial_from_full_blog_body(tmp_path):
     _write_statement(tmp_path)
-
+    target_text = (
+        "Use Kadane dynamic programming. Let dp be the best subarray ending here, "
+        "update it with max(a_i, dp+a_i), and keep the best answer. This matches "
+        "the maximum subarray objective and runs in linear time. " * 2
+    )
     pages = {
         "https://codeforces.com/problemset/problem/1000/B": _problem_page(),
         "https://codeforces.com/blog/entry/2": _blog_page(
-            """
+            f"""
             <h4>A - Other</h4>
             <p>This solves a graph problem.</p>
             <h4>B - Target Problem</h4>
-            <p>Use Kadane dynamic programming. Let dp be the best subarray ending here,
-            update it with max(a_i, dp+a_i), and keep the best answer. This matches
-            the maximum subarray objective and runs in linear time.</p>
+            <p>{target_text}</p>
             """
         ),
-        "https://codeforces.com/blog/entry/1": _blog_page(
-            "<h4>B - Target Problem</h4><p>Authors and preparation.</p>",
-            title="Announcement",
-        ),
+        "https://codeforces.com/blog/entry/1": _blog_page("<p>Contest announcement only.</p>"),
     }
 
     def fake_fetch(url, **_kwargs):
@@ -81,15 +80,19 @@ def test_agent_selects_high_confidence_candidate(tmp_path):
 
     async def fake_chat_completion(messages, **kwargs):
         payload = json.loads(messages[1]["content"])
-        ids = [row["id"] for row in payload["candidates"]]
-        assert ids
+        assert "candidates" not in payload
+        assert payload["blog"]["url"] == "https://codeforces.com/blog/entry/2"
+        assert "A - Other" in payload["blog"]["body"]
+        assert "B - Target Problem" in payload["blog"]["body"]
         return ChatCompletionResult(
             text=json.dumps(
                 {
                     "match": True,
-                    "candidate_id": ids[0],
+                    "section_title": "Target Problem",
+                    "start_text": "Use Kadane dynamic programming.",
+                    "end_text": "runs in linear time.",
                     "confidence": 0.92,
-                    "reason": "candidate discusses maximum subarray DP",
+                    "reason": "blog section matches maximum subarray DP",
                 }
             )
         )
@@ -111,16 +114,109 @@ def test_agent_selects_high_confidence_candidate(tmp_path):
     assert result.bundle["tutorial_url"] == "https://codeforces.com/blog/entry/2"
     assert result.bundle["sections"][0]["label"] == "B"
     assert "Kadane" in result.bundle["sections"][0]["raw_text"]
-    assert result.bundle["agent_meta"]["source_kind"] == "section"
+    assert result.bundle["agent_meta"]["source_kind"] == "llm_blog_extract"
 
 
-def test_agent_rejects_low_confidence(tmp_path):
+def test_agent_tries_next_blog_when_extractor_rejects_first(tmp_path):
     _write_statement(tmp_path)
+    target_text = ("The real solution uses prefix sums and dynamic programming over the array. " * 3) + "This is the unique final prefix marker."
     pages = {
         "https://codeforces.com/problemset/problem/1000/B": _problem_page(),
-        "https://codeforces.com/blog/entry/2": _blog_page(
-            "<h4>B - Target Problem</h4><p>Some unrelated short text.</p>"
-        ),
+        "https://codeforces.com/blog/entry/2": _blog_page("<p>Only schedule and standings.</p>"),
+        "https://codeforces.com/blog/entry/1": _blog_page(f"<p>{target_text}</p>"),
+    }
+
+    def fake_fetch(url, **_kwargs):
+        return pages[url]
+
+    async def fake_chat_completion(messages, **kwargs):
+        payload = json.loads(messages[1]["content"])
+        if payload["blog"]["url"].endswith("/2"):
+            return ChatCompletionResult(text=json.dumps({"match": False, "reason": "announcement only"}))
+        return ChatCompletionResult(
+            text=json.dumps(
+                {
+                    "match": True,
+                    "section_title": "Target Problem",
+                    "start_text": "The real solution uses prefix sums",
+                    "end_text": "unique final prefix marker.",
+                    "confidence": 0.95,
+                    "reason": "second blog has the target tutorial",
+                }
+            )
+        )
+
+    with patch("cf_tutorial_agent.fetch_html", side_effect=fake_fetch), \
+            patch("cf_tutorial_agent.chat_completion", side_effect=fake_chat_completion):
+        result = asyncio.run(
+            agent.run_agent_for_pid(
+                pid="1000B",
+                statements_dir=tmp_path,
+                fetcher="http",
+                blog_limit=2,
+                deadline_sec=10,
+                selector_timeout_sec=5,
+            )
+        )
+
+    assert result.selected_candidate_id == "b2"
+    assert result.bundle["tutorial_url"] == "https://codeforces.com/blog/entry/1"
+    assert "prefix sums" in result.bundle["sections"][0]["solution"]
+
+
+def test_agent_includes_dynamic_fragment_in_blog_body(tmp_path):
+    _write_statement(tmp_path)
+    dynamic_text = ("Dynamic official explanation with enough details about target DP. " * 3) + "This is the unique final dynamic marker."
+    pages = {
+        "https://codeforces.com/problemset/problem/1000/B": _problem_page(),
+        "https://codeforces.com/blog/entry/2": _blog_page("<p>Tutorial is loading...</p>"),
+    }
+
+    def fake_fetch(url, **_kwargs):
+        return pages[url]
+
+    async def fake_chat_completion(messages, **kwargs):
+        payload = json.loads(messages[1]["content"])
+        assert "Tutorial is loading" in payload["blog"]["body"]
+        assert "Codeforces dynamic tutorial fragment" in payload["blog"]["body"]
+        assert dynamic_text.strip() in payload["blog"]["body"]
+        return ChatCompletionResult(
+            text=json.dumps(
+                {
+                    "match": True,
+                    "section_title": "Target Problem",
+                    "start_text": "Dynamic official explanation",
+                    "end_text": "unique final dynamic marker.",
+                    "confidence": 0.93,
+                    "reason": "dynamic fragment contains the target tutorial",
+                }
+            )
+        )
+
+    with patch("cf_tutorial_agent.fetch_html", side_effect=fake_fetch), \
+            patch("cf_tutorial_agent.fetch_dynamic_editorial", return_value=("Target Problem", dynamic_text)), \
+            patch("cf_tutorial_agent.chat_completion", side_effect=fake_chat_completion):
+        result = asyncio.run(
+            agent.run_agent_for_pid(
+                pid="1000B",
+                statements_dir=tmp_path,
+                fetcher="http",
+                blog_limit=1,
+                deadline_sec=10,
+                selector_timeout_sec=5,
+            )
+        )
+
+    assert result.bundle["agent_meta"]["source_kind"] == "llm_blog_extract"
+    assert "Dynamic official explanation" in result.bundle["sections"][0]["solution"]
+
+
+def test_agent_rejects_low_confidence_extraction(tmp_path):
+    _write_statement(tmp_path)
+    uncertain_text = ("Detailed but uncertain explanation with enough copied source text. " * 3) + "This is the unique final uncertain marker."
+    pages = {
+        "https://codeforces.com/problemset/problem/1000/B": _problem_page(),
+        "https://codeforces.com/blog/entry/2": _blog_page(f"<p>{uncertain_text}</p>"),
     }
 
     def fake_fetch(url, **_kwargs):
@@ -131,7 +227,9 @@ def test_agent_rejects_low_confidence(tmp_path):
             text=json.dumps(
                 {
                     "match": True,
-                    "candidate_id": "c1",
+                    "section_title": "Target Problem",
+                    "start_text": "Detailed but uncertain explanation",
+                    "end_text": "unique final uncertain marker.",
                     "confidence": 0.4,
                     "reason": "too little evidence",
                 }
@@ -152,118 +250,90 @@ def test_agent_rejects_low_confidence(tmp_path):
                 )
             )
         except agent.AgentNoMatch as exc:
-            assert "selector_low_confidence" in str(exc)
+            assert "extractor_low_confidence" in str(exc)
         else:
             raise AssertionError("expected low confidence rejection")
 
 
-def test_dynamic_candidate_used_when_static_section_is_placeholder(tmp_path):
-    _write_statement(tmp_path)
-    pages = {
-        "https://codeforces.com/problemset/problem/1000/B": _problem_page(),
-        "https://codeforces.com/blog/entry/2": _blog_page(
-            "<h4>B - Target Problem</h4><p>Tutorial is loading...</p>"
-        ),
-    }
-
-    def fake_fetch(url, **_kwargs):
-        return pages[url]
-
-    async def fake_chat_completion(*_args, **_kwargs):
-        return ChatCompletionResult(
-            text=json.dumps(
-                {
-                    "match": True,
-                    "candidate_id": "c1",
-                    "confidence": 0.9,
-                    "reason": "dynamic tutorial matches",
-                }
-            )
-        )
-
-    with patch("cf_tutorial_agent.fetch_html", side_effect=fake_fetch), \
-            patch("cf_tutorial_agent.fetch_dynamic_editorial", return_value=("Target Problem", "Dynamic official explanation " * 8)), \
-            patch("cf_tutorial_agent.chat_completion", side_effect=fake_chat_completion):
-        result = asyncio.run(
-            agent.run_agent_for_pid(
-                pid="1000B",
-                statements_dir=tmp_path,
-                fetcher="http",
-                blog_limit=1,
-                deadline_sec=10,
-                selector_timeout_sec=5,
-            )
-        )
-
-    assert result.bundle["agent_meta"]["source_kind"] == "dynamic"
-    assert "Dynamic official explanation" in result.bundle["sections"][0]["solution"]
-
-
-
-def test_repair_concatenated_heading_from_old_cf_blog():
-    section = agent.Section(
-        label="C",
-        title="Sereja and SubsequencesIt is clear that we need to calculate the sum of products. " * 3,
-        hint="",
-        solution="",
-        code_blocks=[],
-        raw_text="",
-    )
-
-    repaired = agent._repair_concatenated_heading(section, "Sereja and Subsequences")
-
-    assert repaired.title == "Sereja and Subsequences"
-    assert repaired.solution.startswith("It is clear")
-    assert len(repaired.solution) >= agent.MIN_EDITORIAL_LEN
-
-
-def test_parse_old_problem_sections_handles_problem_headings():
-    text = "Problem A\nEasy text.\n\nPorblem B\n" + ("Target explanation. " * 10) + "\n\nProblem C\nOther text."
-    sections = agent.parse_old_problem_sections(text)
-    labels = [section.label for section in sections]
-    assert "A" in labels
-    assert "B" in labels
-    b = [section for section in sections if section.label == "B"][0]
-    assert "Target explanation" in b.solution
-
-
-def test_selector_disables_reasoning_effort(monkeypatch):
+def test_extractor_uses_json_repair(monkeypatch):
     calls = []
-    candidate = agent.EditorialCandidate(
-        candidate_id="c1",
+    blog = agent.BlogDocument(
+        blog_id="b1",
         tutorial_url="https://codeforces.com/blog/entry/1",
         tutorial_title="Editorial",
-        source_kind="old_problem_section",
-        label="G",
-        title="Problem G",
-        section=agent.Section(
-            label="G",
-            title="Problem G",
-            hint="",
-            solution="Detailed official explanation " * 8,
-            code_blocks=[],
-            raw_text="Detailed official explanation " * 8,
-        ),
+        body=("Detailed official explanation " * 8) + "unique final explanation marker",
     )
 
     async def fake_chat_completion(*args, **kwargs):
         calls.append(kwargs)
-        return ChatCompletionResult(
-            text=json.dumps({"match": True, "candidate_id": "c1", "confidence": 0.9, "reason": "ok"})
-        )
+        return ChatCompletionResult(text='{match: true, section_title: "Target", start_text: "Detailed official explanation", end_text: "unique final explanation marker", confidence: 0.91, reason: "ok"}')
+
+    async def fake_repair(text, **kwargs):
+        assert text.startswith("{match: true")
+        return {
+            "match": True,
+            "section_title": "Target",
+            "start_text": "Detailed official explanation",
+            "end_text": "unique final explanation marker",
+            "confidence": 0.91,
+            "reason": "ok",
+        }, "R"
 
     monkeypatch.setattr(agent, "chat_completion", fake_chat_completion)
+    monkeypatch.setattr(agent, "parse_json_with_llm_repair", fake_repair)
+
     selected, confidence, _reason = asyncio.run(
-        agent.select_candidate(
+        agent.extract_editorial_from_blog(
             pid="39G",
             problem_title="Inverse Function",
             problem_text="statement",
-            candidates=[candidate],
+            blog=blog,
             timeout=5,
             llm_text_limit=1000,
         )
     )
 
-    assert selected.candidate_id == "c1"
+    assert selected.candidate_id == "b1"
+    assert confidence == 0.91
+    assert calls[0]["send_reasoning_effort"] is False
+
+
+def test_extractor_disables_reasoning_effort(monkeypatch):
+    calls = []
+    blog = agent.BlogDocument(
+        blog_id="b1",
+        tutorial_url="https://codeforces.com/blog/entry/1",
+        tutorial_title="Editorial",
+        body=("Detailed official explanation " * 8) + "unique final explanation marker",
+    )
+
+    async def fake_chat_completion(*args, **kwargs):
+        calls.append(kwargs)
+        return ChatCompletionResult(
+            text=json.dumps(
+                {
+                    "match": True,
+                    "section_title": "Inverse Function",
+                    "start_text": "Detailed official explanation",
+                    "end_text": "unique final explanation marker",
+                    "confidence": 0.9,
+                    "reason": "ok",
+                }
+            )
+        )
+
+    monkeypatch.setattr(agent, "chat_completion", fake_chat_completion)
+    selected, confidence, _reason = asyncio.run(
+        agent.extract_editorial_from_blog(
+            pid="39G",
+            problem_title="Inverse Function",
+            problem_text="statement",
+            blog=blog,
+            timeout=5,
+            llm_text_limit=1000,
+        )
+    )
+
+    assert selected.candidate_id == "b1"
     assert confidence == 0.9
     assert calls[0]["send_reasoning_effort"] is False

--- a/tools/cf_tutorial_agent.py
+++ b/tools/cf_tutorial_agent.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Lightweight LLM harness for Codeforces official editorial discovery.
+"""LLM harness for Codeforces official editorial discovery.
 
-This is intentionally not a general web agent. It fetches a small, bounded set
-of Codeforces pages, asks the configured LLM to choose the matching candidate,
-and writes the existing tutorials/{pid}.json schema only for high-confidence
-matches.
+The harness fetches a bounded set of Codeforces blog posts linked from the
+problem page, sends each blog body to the configured general model, and asks it
+to extract the subsection that actually explains the target problem.
 """
 
 from __future__ import annotations
@@ -20,7 +19,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urldefrag, urljoin
 
-from kouhai_bot.handlers.shared import robust_json_parse
+from kouhai_bot.handlers.shared import parse_json_with_llm_repair
 from kouhai_bot.llm import chat_completion
 from kouhai_bot.tutorials import MIN_EDITORIAL_LEN, extract_editorial
 
@@ -33,16 +32,14 @@ from scrape_cf_tutorial import extract_problem_title
 from scrape_cf_tutorial import fetch_dynamic_editorial
 from scrape_cf_tutorial import fetch_html
 from scrape_cf_tutorial import html_to_markdownish
-from scrape_cf_tutorial import parse_legacy_title_sections
 from scrape_cf_tutorial import parse_pid
-from scrape_cf_tutorial import parse_sections
 
 
 DEFAULT_DEADLINE_SEC = 150
 DEFAULT_CANDIDATE_LIMIT = 3
 DEFAULT_CONFIDENCE_THRESHOLD = 0.75
 DEFAULT_SELECTOR_TIMEOUT_SEC = 40
-DEFAULT_LLM_TEXT_LIMIT = 4500
+DEFAULT_LLM_TEXT_LIMIT = 20000
 
 
 class AgentNoMatch(RuntimeError):
@@ -68,6 +65,14 @@ class EditorialCandidate:
         if len(text) <= limit:
             return text
         return text[: limit - 20] + "\n...(已截断)"
+
+
+@dataclass(frozen=True)
+class BlogDocument:
+    blog_id: str
+    tutorial_url: str
+    tutorial_title: str
+    body: str
 
 
 @dataclass(frozen=True)
@@ -151,14 +156,14 @@ def extract_blog_links(problem_html: str, base_url: str, *, limit: int) -> list[
     return [url for _, _, url in scored[: max(1, limit)]]
 
 
-def _section_from_block(label: str, title: str, block: str) -> Section:
+def _section_from_text(label: str, title: str, text: str) -> Section:
     code_blocks = [
         code.strip()
-        for code in re.findall(r"```(?:[^\n`]*)\n([\s\S]*?)\n```", block)
+        for code in re.findall(r"```(?:[^\n`]*)\n([\s\S]*?)\n```", text)
         if code.strip()
     ]
     text_without_code = re.sub(
-        r"```(?:[^\n`]*)\n[\s\S]*?\n```", "", block
+        r"```(?:[^\n`]*)\n[\s\S]*?\n```", "", text
     ).strip()
     return Section(
         label=label,
@@ -166,182 +171,24 @@ def _section_from_block(label: str, title: str, block: str) -> Section:
         hint="",
         solution=text_without_code,
         code_blocks=code_blocks,
-        raw_text=block.strip(),
+        raw_text=text.strip(),
     )
 
 
-def parse_old_problem_sections(markdownish: str) -> list[Section]:
-    heading_re = re.compile(
-        r"(?im)(?:^|\n)\s*(?:Problem|Porblem)\s+([A-Z](?:\d+)?)\b\s*"
-    )
-    matches = list(heading_re.finditer(markdownish))
-    sections: list[Section] = []
-    for idx, match in enumerate(matches):
-        label = match.group(1).upper()
-        title_start = match.end()
-        block_end = matches[idx + 1].start() if idx + 1 < len(matches) else len(markdownish)
-        block = markdownish[title_start:block_end].strip()
-        if not block:
-            continue
-        lines = block.splitlines()
-        first = lines[0].strip() if lines else ""
-        if first and len(first) <= 120 and not first.endswith("."):
-            title = first
-            body = "\n".join(lines[1:]).strip()
-        else:
-            title = f"Problem {label}"
-            body = block
-        sections.append(_section_from_block(label, title, body or block))
-    return sections
+def _clip_for_llm(text: str, limit: int) -> str:
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 30)] + "\n...(blog body truncated)"
 
 
-def _candidate_quality_key(candidate: EditorialCandidate) -> tuple[int, int]:
-    text = candidate.extracted_text()
-    preferred_source = 0 if candidate.source_kind == "dynamic" else 1
-    enough_text = 0 if len(text) >= MIN_EDITORIAL_LEN else 1
-    return (enough_text, preferred_source)
-
-
-def _repair_concatenated_heading(section: Section, problem_title: str) -> Section:
-    if section.raw_text.strip() or section.hint.strip() or section.solution.strip():
-        return section
-    expected_title = (problem_title or "").strip()
-    parsed_title = section.title.strip()
-    if not expected_title or not parsed_title.startswith(expected_title):
-        return section
-    body = parsed_title[len(expected_title):].strip()
-    if len(body) < MIN_EDITORIAL_LEN:
-        return section
-    return Section(
-        label=section.label,
-        title=expected_title,
-        hint="",
-        solution=body,
-        code_blocks=section.code_blocks,
-        raw_text=body,
-    )
-
-
-def collect_candidates_for_blog(
-    *,
-    pid: str,
-    problem_title: str,
-    tutorial_url: str,
-    fetcher: str,
-    pw_wait_ms: int,
-    per_blog_limit: int = 4,
-) -> tuple[str, list[EditorialCandidate]]:
-    _, target_index = parse_pid(pid)
-    target_index = target_index.upper()
-    tutorial_html = fetch_html(tutorial_url, fetcher=fetcher, pw_wait_ms=pw_wait_ms)
-    tutorial_title = extract_page_title(tutorial_html)
-
-    candidates: list[EditorialCandidate] = []
-    dynamic_title, dynamic_text = fetch_dynamic_editorial(
-        tutorial_url=tutorial_url,
-        tutorial_html=tutorial_html,
-        problem_code=pid,
-    )
-    if dynamic_text.strip():
-        candidates.append(
-            EditorialCandidate(
-                candidate_id="",
-                tutorial_url=tutorial_url,
-                tutorial_title=tutorial_title,
-                source_kind="dynamic",
-                label=target_index,
-                title=dynamic_title or problem_title,
-                section=Section(
-                    label=target_index,
-                    title=dynamic_title or problem_title,
-                    hint="",
-                    solution=dynamic_text.strip(),
-                    code_blocks=[],
-                    raw_text=dynamic_text.strip(),
-                ),
-            )
-        )
-
-    body_html = extract_blog_body_html(tutorial_html)
-    markdownish = html_to_markdownish(body_html)
-    try:
-        parsed_sections = parse_sections(markdownish)
-    except ScrapeError:
-        parsed_sections = []
-
-    for section in parsed_sections:
-        if section.label.upper() == target_index:
-            section = _repair_concatenated_heading(section, problem_title)
-            candidates.append(
-                EditorialCandidate(
-                    candidate_id="",
-                    tutorial_url=tutorial_url,
-                    tutorial_title=tutorial_title,
-                    source_kind="section",
-                    label=section.label,
-                    title=section.title,
-                    section=section,
-                )
-            )
-
-    if not candidates:
-        for section in parse_old_problem_sections(markdownish):
-            if section.label.upper() != target_index:
-                continue
-            candidates.append(
-                EditorialCandidate(
-                    candidate_id="",
-                    tutorial_url=tutorial_url,
-                    tutorial_title=tutorial_title,
-                    source_kind="old_problem_section",
-                    label=section.label,
-                    title=section.title,
-                    section=section,
-                )
-            )
-            if len(candidates) >= per_blog_limit:
-                break
-
-    if not candidates:
-        for legacy_title, block in parse_legacy_title_sections(markdownish):
-            candidates.append(
-                EditorialCandidate(
-                    candidate_id="",
-                    tutorial_url=tutorial_url,
-                    tutorial_title=tutorial_title,
-                    source_kind="legacy_section",
-                    label=target_index,
-                    title=legacy_title,
-                    section=_section_from_block(target_index, legacy_title, block),
-                )
-            )
-            if len(candidates) >= per_blog_limit:
-                break
-
-    if not candidates and markdownish.strip():
-        candidates.append(
-            EditorialCandidate(
-                candidate_id="",
-                tutorial_url=tutorial_url,
-                tutorial_title=tutorial_title,
-                source_kind="whole_blog",
-                label=target_index,
-                title=tutorial_title or problem_title,
-                section=_section_from_block(target_index, tutorial_title or problem_title, markdownish),
-            )
-        )
-
-    candidates = sorted(candidates, key=_candidate_quality_key)
-    return tutorial_title, candidates[:per_blog_limit]
-
-
-def collect_candidates(
+def collect_blog_documents(
     *,
     pid: str,
     fetcher: str,
     pw_wait_ms: int,
     blog_limit: int,
-) -> tuple[str, str, list[EditorialCandidate]]:
+) -> tuple[str, str, list[BlogDocument]]:
     problem_url = build_problem_url_from_pid(pid)
     problem_html = fetch_html(problem_url, fetcher=fetcher, pw_wait_ms=pw_wait_ms)
     problem_title = extract_problem_title(problem_html)
@@ -349,102 +196,129 @@ def collect_candidates(
     if not blog_urls:
         raise AgentNoMatch("problem_page_has_no_blog_entry_links")
 
-    all_candidates: list[EditorialCandidate] = []
-    for blog_url in blog_urls:
+    blogs: list[BlogDocument] = []
+    for idx, blog_url in enumerate(blog_urls, start=1):
         try:
-            _, candidates = collect_candidates_for_blog(
-                pid=pid,
-                problem_title=problem_title,
+            tutorial_html = fetch_html(blog_url, fetcher=fetcher, pw_wait_ms=pw_wait_ms)
+            tutorial_title = extract_page_title(tutorial_html)
+            body_html = extract_blog_body_html(tutorial_html)
+            body = html_to_markdownish(body_html)
+            dynamic_title, dynamic_text = fetch_dynamic_editorial(
                 tutorial_url=blog_url,
-                fetcher=fetcher,
-                pw_wait_ms=pw_wait_ms,
+                tutorial_html=tutorial_html,
+                problem_code=pid,
             )
+            if dynamic_text.strip():
+                title = dynamic_title or problem_title or pid
+                body = (
+                    f"{body.strip()}\n\n"
+                    f"[Codeforces dynamic tutorial fragment for {pid} - {title}]\n"
+                    f"{dynamic_text.strip()}"
+                ).strip()
         except ScrapeError:
             continue
-        all_candidates.extend(candidates)
-
-    if not all_candidates:
-        raise AgentNoMatch("no_parseable_candidates_from_blog_entries")
-
-    numbered: list[EditorialCandidate] = []
-    for idx, candidate in enumerate(all_candidates, start=1):
-        numbered.append(
-            EditorialCandidate(
-                candidate_id=f"c{idx}",
-                tutorial_url=candidate.tutorial_url,
-                tutorial_title=candidate.tutorial_title,
-                source_kind=candidate.source_kind,
-                label=candidate.label,
-                title=candidate.title,
-                section=candidate.section,
+        if body.strip():
+            blogs.append(
+                BlogDocument(
+                    blog_id=f"b{idx}",
+                    tutorial_url=blog_url,
+                    tutorial_title=tutorial_title,
+                    body=body,
+                )
             )
-        )
-    return problem_url, problem_title, numbered
+
+    if not blogs:
+        raise AgentNoMatch("no_readable_blog_bodies")
+    return problem_url, problem_title, blogs
 
 
-def _build_selector_messages(
+def _build_extractor_messages(
     *,
     pid: str,
     problem_title: str,
     problem_text: str,
-    candidates: list[EditorialCandidate],
+    blog: BlogDocument,
     llm_text_limit: int,
 ) -> list[dict[str, str]]:
-    rows: list[dict[str, str]] = []
-    for candidate in candidates:
-        rows.append(
-            {
-                "id": candidate.candidate_id,
-                "url": candidate.tutorial_url,
-                "blog_title": candidate.tutorial_title,
-                "source_kind": candidate.source_kind,
-                "section_label": candidate.label,
-                "section_title": candidate.title,
-                "text": candidate.llm_text(llm_text_limit),
-            }
-        )
-
     payload = {
         "pid": pid,
         "problem_title": problem_title,
         "problem": problem_text,
-        "candidates": rows,
+        "blog": {
+            "url": blog.tutorial_url,
+            "title": blog.tutorial_title,
+            "body": _clip_for_llm(blog.body, llm_text_limit),
+        },
     }
     return [
         {
             "role": "system",
             "content": (
-                "你是 Codeforces 官方题解 oncall。你会收到一道题的题面和若干从 "
-                "Codeforces blog 抓到的候选片段。你的任务只是选择哪个候选片段是在讲这道题。"
-                "不要生成题解，不要改写候选内容。"
-                "只输出 JSON 对象："
-                "{\"match\":true,\"candidate_id\":\"c1\",\"confidence\":0.0到1.0,\"reason\":\"...\"} "
-                "或 {\"match\":false,\"reason\":\"...\"}。"
-                "判断时比较题意目标、输入输出、关键变量、算法对象、约束和候选中的结论。"
-                "如果只是同一个题号字母但题意明显不同，必须 match=false。"
-                "如果候选只是代码、作者信息、目录、占位或太短，必须 match=false。"
-                "只有候选足以作为官方题解/教程正文时才 match=true。"
+                "你是 Codeforces 官方题解正文提取器。你会收到一道题的题面，以及一篇 "
+                "Codeforces blog 的主体全文。你的任务不是解题，也不是总结，而是从 blog 主体中"
+                "找出这道题对应的官方题解/教程正文。\n"
+                "只输出 JSON 对象。匹配成功时输出："
+                "{\"match\":true,\"section_title\":\"...\","
+                "\"start_text\":\"...\",\"end_text\":\"...\","
+                "\"confidence\":0.0到1.0,\"reason\":\"...\"}。"
+                "匹配失败时输出：{\"match\":false,\"reason\":\"...\"}。\n"
+                "要求：start_text 和 end_text 必须是从 blog.body 原文中逐字复制的短片段，"
+                "用于标记本题题解正文的开始和结束，且尽量选择唯一、不易混淆的片段；"
+                "不要输出完整题解正文，不要编写新题解，"
+                "不要补全缺失公式，不要夹带其他题目的题解、公告、作者信息、评论或标签。"
+                "如果 blog 中有多题题解，必须用题号、标题、题意、输入输出、变量和算法对象共同判断。"
+                "如果只有占位、公告、榜单、代码片段或无法确认是本题，必须 match=false。"
             ),
         },
         {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
     ]
 
 
-async def select_candidate(
+def _find_excerpt_span(text: str, excerpt: str, *, start: int = 0) -> tuple[int, int] | None:
+    excerpt = (excerpt or "").strip()
+    if not excerpt:
+        return None
+    pos = text.find(excerpt, start)
+    if pos >= 0:
+        return pos, pos + len(excerpt)
+
+    parts = [part for part in re.split(r"\s+", excerpt) if part]
+    if not parts:
+        return None
+    pattern = r"\s+".join(re.escape(part) for part in parts)
+    match = re.search(pattern, text[start:])
+    if not match:
+        return None
+    return start + match.start(), start + match.end()
+
+
+def _extract_body_span(body: str, start_text: str, end_text: str) -> str:
+    start_span = _find_excerpt_span(body, start_text)
+    if not start_span:
+        return ""
+    end_span = _find_excerpt_span(body, end_text, start=start_span[0])
+    if not end_span:
+        return ""
+    if end_span[1] <= start_span[0]:
+        return ""
+    return body[start_span[0]:end_span[1]].strip()
+
+
+async def extract_editorial_from_blog(
     *,
     pid: str,
     problem_title: str,
     problem_text: str,
-    candidates: list[EditorialCandidate],
+    blog: BlogDocument,
     timeout: int,
     llm_text_limit: int,
 ) -> tuple[EditorialCandidate, float, str]:
     result = await chat_completion(
-        _build_selector_messages(
+        _build_extractor_messages(
             pid=pid,
             problem_title=problem_title,
             problem_text=problem_text,
-            candidates=candidates,
+            blog=blog,
             llm_text_limit=llm_text_limit,
         ),
         task="summary",
@@ -454,20 +328,44 @@ async def select_candidate(
         send_reasoning_effort=False,
     )
     if not result.text:
-        raise AgentNoMatch(f"selector_llm_failed:{result.failure_kind}")
-    parsed = robust_json_parse(result.text)
+        raise AgentNoMatch(f"extractor_llm_failed:{result.failure_kind}")
+
+    parsed, _repair_tag = await parse_json_with_llm_repair(
+        result.text,
+        expected_schema=(
+            '{"match": true, "section_title": "...", '
+            '"start_text": "...", "end_text": "...", '
+            '"confidence": 0.0, "reason": "..."}'
+            ' or {"match": false, "reason": "..."}'
+        ),
+        task="summary",
+        timeout=timeout,
+    )
     if parsed.get("match") is not True:
-        raise AgentNoMatch(str(parsed.get("reason") or "selector_no_match"))
-    candidate_id = str(parsed.get("candidate_id") or "").strip()
+        raise AgentNoMatch(str(parsed.get("reason") or "extractor_no_match"))
+
+    start_text = str(parsed.get("start_text") or "").strip()
+    end_text = str(parsed.get("end_text") or "").strip()
+    editorial_text = _extract_body_span(blog.body, start_text, end_text)
+    if len(editorial_text) < MIN_EDITORIAL_LEN:
+        raise AgentNoMatch("extractor_span_not_found_or_too_short")
+
     try:
         confidence = float(parsed.get("confidence"))
     except (TypeError, ValueError):
         confidence = 0.0
     reason = str(parsed.get("reason") or "").strip()
-    by_id = {candidate.candidate_id: candidate for candidate in candidates}
-    candidate = by_id.get(candidate_id)
-    if not candidate:
-        raise AgentNoMatch(f"selector_unknown_candidate:{candidate_id}")
+    section_title = str(parsed.get("section_title") or problem_title or pid).strip()
+    _, target_index = parse_pid(pid)
+    candidate = EditorialCandidate(
+        candidate_id=blog.blog_id,
+        tutorial_url=blog.tutorial_url,
+        tutorial_title=blog.tutorial_title,
+        source_kind="llm_blog_extract",
+        label=target_index.upper(),
+        title=section_title,
+        section=_section_from_text(target_index.upper(), section_title, editorial_text),
+    )
     return candidate, confidence, reason
 
 
@@ -518,25 +416,46 @@ async def run_agent_for_pid(
     problem_text = statement_to_text(stmt)
 
     async def _run() -> AgentResult:
-        problem_url, problem_title, candidates = await asyncio.to_thread(
-            collect_candidates,
+        problem_url, problem_title, blogs = await asyncio.to_thread(
+            collect_blog_documents,
             pid=pid,
             fetcher=fetcher,
             pw_wait_ms=pw_wait_ms,
             blog_limit=blog_limit,
         )
-        selected, confidence, reason = await select_candidate(
-            pid=pid,
-            problem_title=problem_title or str(stmt.get("name") or ""),
-            problem_text=problem_text,
-            candidates=candidates,
-            timeout=selector_timeout_sec,
-            llm_text_limit=llm_text_limit,
-        )
-        if confidence < confidence_threshold:
-            raise AgentNoMatch(
-                f"selector_low_confidence:{confidence:.2f}:{reason or selected.candidate_id}"
-            )
+        failures: list[str] = []
+        selected: EditorialCandidate | None = None
+        confidence = 0.0
+        reason = ""
+        effective_problem_title = problem_title or str(stmt.get("name") or "")
+        for blog in blogs:
+            try:
+                candidate, candidate_confidence, candidate_reason = await extract_editorial_from_blog(
+                    pid=pid,
+                    problem_title=effective_problem_title,
+                    problem_text=problem_text,
+                    blog=blog,
+                    timeout=selector_timeout_sec,
+                    llm_text_limit=llm_text_limit,
+                )
+            except AgentNoMatch as exc:
+                failures.append(f"{blog.blog_id}:{exc}")
+                continue
+            if candidate_confidence < confidence_threshold:
+                failures.append(
+                    f"{blog.blog_id}:extractor_low_confidence:{candidate_confidence:.2f}:"
+                    f"{candidate_reason or candidate.title}"
+                )
+                continue
+            selected = candidate
+            confidence = candidate_confidence
+            reason = candidate_reason
+            break
+
+        if selected is None:
+            detail = "; ".join(failures) if failures else "extractor_no_match"
+            raise AgentNoMatch(detail)
+
         elapsed = time.monotonic() - started
         bundle = build_bundle(
             pid=pid,
@@ -544,7 +463,7 @@ async def run_agent_for_pid(
             selected=selected,
             confidence=confidence,
             reason=reason,
-            candidate_count=len(candidates),
+            candidate_count=len(blogs),
             elapsed_sec=elapsed,
         )
         return AgentResult(
@@ -554,11 +473,10 @@ async def run_agent_for_pid(
             confidence=confidence,
             reason=reason,
             elapsed_sec=elapsed,
-            candidate_count=len(candidates),
+            candidate_count=len(blogs),
         )
 
     try:
         return await asyncio.wait_for(_run(), timeout=max(1, deadline_sec))
     except asyncio.TimeoutError as exc:
         raise AgentNoMatch(f"deadline_exceeded:{deadline_sec}s") from exc
-


### PR DESCRIPTION
## Summary

- Replace template-based Codeforces editorial section parsing with a blog-body extraction harness.
- Ask the general model for short start/end anchors, then slice the editorial text from the original blog body.
- Include Codeforces dynamic tutorial fragments in the same model input and route malformed extractor JSON through the existing repair helper.

## Why

Issue #51 showed that old blog heading variants could make the parser miss an existing official editorial for 201E. The new flow lets the model identify the relevant section from the full blog body while keeping the saved editorial grounded in source text.

## Validation

- `uv run pytest` (299 passed)
- `uv run python tools/tutorial_tools.py agent --pid 201E --statements-dir /home/nerovix/.kouhai-bot/statements --tutorials-dir /tmp/kouhai-tutorial-agent-repair-check --fetcher auto --deadline-sec 180 --selector-timeout-sec 60 --pretty`