### PR TITLE
Handle empty DashScope reasoning streams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,22 @@
 
 Instructions for AI coding assistants working on this codebase.
 
+
+## Operational Constraints
+
+- Code changes must be prepared on a branch and merged by PR. Do not make direct
+  code/config edits on the live `master` checkout.
+- The live service checkout must remain on `master`. Do not use `uv run restart`
+  or otherwise change live service state unless explicitly asked. Running tests is
+  allowed.
+- Judge and review tasks must use the configured highest reasoning capability. Do
+  not lower `reasoning_effort`, disable thinking, or switch to a weaker effort to
+  work around latency/cost.
+- Do not set client-side output token caps, `max_tokens`, or
+  `max_completion_tokens` for judge/review requests. For DashScope/百炼 thinking
+  models only, set `thinking_budget=100000` so reasoning cannot consume the
+  entire upstream output window before `content` starts.
+
 ## Architecture
 
 ```

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -873,7 +873,7 @@ class GroupCoordinator:
                             "second_judge": True,
                         }
                 logger.warning(
-                    "[group_%s] second judge unavailable or malformed for %s seq=%s provider=%s model=%s failure=%s has_text=%s; blocking first-pass correct verdict",
+                    "[group_%s] second judge unavailable or malformed for %s seq=%s provider=%s model=%s failure=%s has_text=%s; falling back to first-pass correct verdict",
                     req.group_id,
                     pid,
                     req.seq,
@@ -882,7 +882,13 @@ class GroupCoordinator:
                     second.failure_kind,
                     bool(second.text),
                 )
-                return {"kind": second.failure_kind or "service_unavailable", "pid": pid}
+                return {
+                    "kind": "judge",
+                    "pid": pid,
+                    "result": parsed,
+                    "model_tag": result.model_tag,
+                    "second_judge_failure": second.failure_kind or "service_unavailable",
+                }
         return {"kind": "judge", "pid": pid, "result": parsed, "model_tag": result.model_tag}
 
 

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -30,6 +30,9 @@ class _ChatCompletionAttempt:
     retryable: bool
     retry_after_sec: float | None
     failure_kind: str | None = None
+    finish_reason: str | None = None
+    reasoning_chars: int = 0
+    usage: dict | None = None
 
 
 def _chat_completions_url(base_url: str) -> str:
@@ -267,21 +270,52 @@ async def _read_streaming_chat_completion(
     parts: list[str] = []
     event_lines: list[str] = []
     reasoning_chars = 0
+    finish_reason: str | None = None
+    usage: dict | None = None
 
     def finish(text: str) -> _ChatCompletionAttempt:
         if not text:
-            logger.warning("%s API stream returned no text", provider_name)
+            logger.warning(
+                "%s API stream returned no text finish_reason=%s usage=%s",
+                provider_name,
+                finish_reason,
+                usage,
+            )
         if reasoning_chars:
             logger.info(
                 "%s API stream returned reasoning_content chars=%s",
                 provider_name,
                 reasoning_chars,
             )
+        if finish_reason or usage:
+            logger.info(
+                "%s API stream finished finish_reason=%s usage=%s",
+                provider_name,
+                finish_reason,
+                usage,
+            )
+        empty_after_reasoning = not text and reasoning_chars > 0
+        length_stopped = not text and finish_reason == "length"
         return _ChatCompletionAttempt(
             text=text or None,
-            retryable=not bool(text),
+            retryable=(
+                not bool(text)
+                and not empty_after_reasoning
+                and not length_stopped
+            ),
             retry_after_sec=None,
-            failure_kind=None if text else "service_unavailable",
+            failure_kind=(
+                None
+                if text
+                else "length"
+                if length_stopped
+                else "empty_content_after_reasoning"
+                if empty_after_reasoning
+                else "service_unavailable"
+            ),
+            finish_reason=finish_reason,
+            reasoning_chars=reasoning_chars,
+            usage=usage,
         )
 
     def stream_failure(reason: str) -> _ChatCompletionAttempt:
@@ -291,10 +325,13 @@ async def _read_streaming_chat_completion(
             retryable=True,
             retry_after_sec=None,
             failure_kind="service_unavailable",
+            finish_reason=finish_reason,
+            reasoning_chars=reasoning_chars,
+            usage=usage,
         )
 
     def handle_event(raw_data: str) -> tuple[bool, _ChatCompletionAttempt | None]:
-        nonlocal reasoning_chars
+        nonlocal finish_reason, reasoning_chars, usage
         data_text = raw_data.strip()
         if not data_text:
             return False, None
@@ -306,6 +343,12 @@ async def _read_streaming_chat_completion(
             return False, stream_failure("invalid json")
 
         reasoning_chars += len(_stream_event_reasoning_text(data))
+        event_usage = data.get("usage")
+        if isinstance(event_usage, dict):
+            usage = event_usage
+        for choice in data.get("choices", []) or []:
+            if isinstance(choice, dict) and choice.get("finish_reason") is not None:
+                finish_reason = str(choice.get("finish_reason"))
         text, valid_event, error_message = _stream_event_text(data)
         if error_message:
             return False, stream_failure(error_message)
@@ -496,17 +539,21 @@ async def chat_completion(
                 payload["thinking"] = thinking
                 if _provider_is_dashscope(provider.name, provider.base_url):
                     payload["enable_thinking"] = True
+                    payload.setdefault("thinking_budget", 100000)
             reasoning_effort = provider.reasoning_effort.strip().lower()
             if reasoning_effort and send_reasoning_effort:
                 payload["reasoning_effort"] = reasoning_effort
             if provider.extra_body:
                 payload.update(provider.extra_body)
-            if _provider_uses_stream(
+            uses_stream = _provider_uses_stream(
                 provider.name,
                 provider.base_url,
                 explicit_stream=provider.stream,
-            ):
+            )
+            if uses_stream:
                 payload["stream"] = True
+                if _provider_is_dashscope(provider.name, provider.base_url):
+                    payload.setdefault("stream_options", {"include_usage": True})
 
             for attempt in range(max_retries + 1):
                 result = await _post_chat_completion_once(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -686,7 +686,7 @@ def test_submit_second_judge_overturns_correct_verdict():
     print("✅ submit: second judge can overturn correct verdict")
 
 
-def test_submit_second_judge_failure_blocks_first_correct_verdict():
+def test_submit_second_judge_failure_falls_back_to_first_correct_verdict():
     _reset_state()
     _setup_problem()
     _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
@@ -715,12 +715,14 @@ def test_submit_second_judge_failure_blocks_first_correct_verdict():
     with open(os.path.join(_data_dir(), "groups", str(GID), "scoreboard.json")) as f:
         saved = json.load(f)
     assert len(_second_judge_calls) == 1
-    assert saved["solves"] == []
+    assert len(saved["solves"]) == 1
+    assert saved["solves"][0]["user_id"] == UID
     records = saved["user_submissions"][str(UID)]
-    assert records[-1]["result"] == "service_unavailable"
-    assert "模型服务出故障了" in _last_text()
+    assert records[-1]["result"] == "correct"
+    assert records[-1]["reason"] == "first pass accepted"
+    assert "模型服务出故障了" not in _last_text()
     _cleanup()
-    print("✅ submit: second judge failure blocks first correct verdict")
+    print("✅ submit: second judge failure falls back to first correct verdict")
 
 
 def test_submit_correct_uses_fresh_top5_nicknames_and_points():

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -753,6 +753,7 @@ def test_zenmux_minimax_m3_payload_accepts_adaptive_thinking():
     assert calls[0]["model"] == "minimax/minimax-m3"
     assert calls[0]["thinking"] == {"type": "adaptive"}
     assert "enable_thinking" not in calls[0]
+    assert "thinking_budget" not in calls[0]
     assert "reasoning_effort" not in calls[0]
 
 
@@ -796,6 +797,7 @@ def test_provider_payload_options_control_thinking_temperature_and_extra_body():
     assert calls[0]["service_tier"] == "priority"
     assert "thinking" not in calls[0]
     assert "enable_thinking" not in calls[0]
+    assert "thinking_budget" not in calls[0]
     assert "stream" not in calls[0]
 
 
@@ -829,6 +831,7 @@ def test_zenmux_grok45free_payload_uses_xhigh_reasoning_and_tag():
     assert calls[0]["model"] == "x-ai/grok-4.5-free"
     assert calls[0]["reasoning_effort"] == "xhigh"
     assert calls[0]["thinking"] == {"type": "enabled"}
+    assert "thinking_budget" not in calls[0]
 
 
 def test_non_dashscope_provider_payload_does_not_enable_stream():
@@ -955,6 +958,46 @@ def test_non_streaming_chat_completion_does_not_use_sock_read_idle_timeout():
     assert timeout.sock_read is None
 
 
+def test_dashscope_stream_payload_requests_usage_without_token_caps():
+    provider = LlmProviderConfig(
+        name="glm52",
+        api_key="sk-test",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        model="glm-5.2",
+        reasoning_effort="max",
+    )
+    cfg = _openai_cfg(llm_smart_providers=[provider])
+    calls = []
+
+    async def fake_once(session, **kwargs):
+        calls.append(kwargs["payload"].copy())
+        return _ChatCompletionAttempt(text="OK", retryable=False, retry_after_sec=None)
+
+    with patch("kouhai_bot.llm.get_config", return_value=cfg), \
+            patch("kouhai_bot.llm.aiohttp.ClientSession", _DummySession), \
+            patch("kouhai_bot.llm._post_chat_completion_once", side_effect=fake_once):
+        result = asyncio.run(call_chat_completion_result(
+            [{"role": "user", "content": "Reply OK."}],
+            task="judge",
+            response_format={"type": "json_object"},
+            thinking={"type": "enabled"},
+        ))
+
+    assert result.text == "OK"
+    assert calls[0]["stream"] is True
+    assert calls[0]["stream_options"] == {"include_usage": True}
+    assert calls[0]["enable_thinking"] is True
+    assert calls[0]["thinking_budget"] == 100000
+    assert calls[0]["reasoning_effort"] == "max"
+    forbidden = {
+        "max_tokens",
+        "max_completion_tokens",
+        "max_output_tokens",
+        "reasoning_budget",
+    }
+    assert forbidden.isdisjoint(calls[0])
+
+
 def test_streaming_chat_completion_reads_sse_delta_chunks(caplog):
     caplog.set_level("INFO", logger="kouhai-bot.llm")
     response = _DummyResponse(lines=[
@@ -983,6 +1026,36 @@ def test_streaming_chat_completion_reads_sse_delta_chunks(caplog):
     assert result.retryable is False
     assert session.calls[0][1]["json"] == {"stream": True}
     assert "reasoning_content chars=8" in caplog.text
+
+
+def test_streaming_chat_completion_empty_after_reasoning_is_not_retried(caplog):
+    caplog.set_level("INFO", logger="kouhai-bot.llm")
+    response = _DummyResponse(lines=[
+        'data: {"choices":[{"delta":{"reasoning_content":"thinking"}}]}\n',
+        '\n',
+        'data: {"choices":[{"delta":{},"finish_reason":"length"}],"usage":{"completion_tokens_details":{"reasoning_tokens":1}}}\n',
+        '\n',
+        'data: [DONE]\n',
+        '\n',
+    ])
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="glm52",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        headers={},
+        payload={"stream": True},
+        timeout=120,
+    ))
+
+    assert result.text is None
+    assert result.retryable is False
+    assert result.failure_kind == "length"
+    assert result.finish_reason == "length"
+    assert result.reasoning_chars == 8
+    assert result.usage == {"completion_tokens_details": {"reasoning_tokens": 1}}
+    assert "finish_reason=length" in caplog.text
 
 
 def test_streaming_chat_completion_ignores_metadata_events():


### PR DESCRIPTION
## Summary
- add DashScope-only thinking_budget=100000 for thinking requests so reasoning leaves room for final content
- keep judge/review at highest configured reasoning; do not add max_tokens or max_completion_tokens
- log streaming finish_reason, usage, and reasoning character counts for DashScope/OpenAI-compatible streams
- request DashScope stream usage telemetry via stream_options.include_usage without adding output caps
- stop retrying the same provider when a stream ends with no content after reasoning, including finish_reason=length
- if second judge transport/formatting fails after first judge accepted, fall back to the first-pass correct verdict instead of returning service_unavailable
- record project constraints in AGENTS.md: changes by PR, live checkout stays master, no uv run restart unless requested

## Root Cause
DashScope thinking streams emit reasoning_content before content, and reasoning shares the upstream output window with the final answer. With max reasoning and JSON mode, GLM-5.2 can spend the response budget or stall before content appears; current code discarded finish_reason/usage and classified empty content as retryable service_unavailable, so it could repeat the same expensive failure. The submit path also discarded a completed first-pass correct verdict when second judge failed.

## Historical Replay
Using the PR request shape against pinned DashScope `glm52` with `thinking_budget=100000` and no `max_tokens`/`max_completion_tokens`:
- 2045J first judge seq1, previously `reasoning_content chars=201735` then empty content: returned JSON content in 282.2s (`correct=false`)
- 2045J first judge seq3, previous long-reasoning correct path: returned JSON content in 322.3s (`correct=true`)
- 633D second judge, previously `reasoning_content chars=115506` then JSON-mode 400: returned JSON content in 225.1s (`correct=true`)

## Validation
- /home/nerovix/kouhai-bot/.venv/bin/python -m pytest tests/test_shared.py -k 'dashscope_stream_payload_requests_usage_without_token_caps or provider_payload_options_control_thinking_temperature_and_extra_body or zenmux_grok45free_payload_uses_xhigh_reasoning_and_tag or minimax_m3' tests/test_commands.py -k second_judge
- /home/nerovix/kouhai-bot/.venv/bin/python -m pytest
