### PR TITLE
Strip leaked LLM think blocks

### DIFF
--- a/src/kouhai_bot/handlers/cmd/newproblem.py
+++ b/src/kouhai_bot/handlers/cmd/newproblem.py
@@ -26,6 +26,7 @@ from ..shared import (
 from ...config import get_config
 from ...context import append_group_ctx
 from ...editorial_followup import schedule_prefetch_editorial
+from ...llm import strip_leaked_thinking
 from ...user_groups import settle_dynamic_submit_wait_for_problem
 from ...napcat.client import (
     build_plain_message,
@@ -305,7 +306,7 @@ async def _build_notes_message(stmt: dict) -> str:
     except Exception as e:
         logger.warning("Notes translation failed, skipping notes node: %s", e)
         return ""
-    final_notes = (translated_notes or normalized_notes).strip()
+    final_notes = strip_leaked_thinking(translated_notes or normalized_notes)
     if not final_notes:
         return ""
     return f"样例解释：\n{final_notes}"

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
@@ -13,6 +14,9 @@ import aiohttp
 from .config import get_config
 
 logger = logging.getLogger("kouhai-bot.llm")
+
+_THINK_BLOCK_RE = re.compile(r"<think\b[^>]*>.*?</think\s*>", re.IGNORECASE | re.DOTALL)
+_THINK_TAG_RE = re.compile(r"</?think\b[^>]*>", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -48,10 +52,19 @@ def _chat_completions_url(base_url: str) -> str:
     return f"{base}/chat/completions"
 
 
+def strip_leaked_thinking(text: str) -> str:
+    """Remove provider-leaked thinking tags from user-visible content."""
+    if not text:
+        return ""
+    text = _THINK_BLOCK_RE.sub("", text)
+    text = _THINK_TAG_RE.sub("", text)
+    return text.strip()
+
+
 def _message_content_text(message: dict) -> str:
     content = message.get("content", "")
     if isinstance(content, str):
-        return content.strip()
+        return strip_leaked_thinking(content)
     if isinstance(content, list):
         parts: list[str] = []
         for item in content:
@@ -60,10 +73,10 @@ def _message_content_text(message: dict) -> str:
             text = item.get("text", "")
             if isinstance(text, str):
                 parts.append(text)
-        return "".join(parts).strip()
+        return strip_leaked_thinking("".join(parts))
     if content is None:
         return ""
-    return str(content).strip()
+    return strip_leaked_thinking(str(content))
 
 
 def _provider_uses_stream(
@@ -274,6 +287,7 @@ async def _read_streaming_chat_completion(
     usage: dict | None = None
 
     def finish(text: str) -> _ChatCompletionAttempt:
+        text = strip_leaked_thinking(text)
         if not text:
             logger.warning(
                 "%s API stream returned no text finish_reason=%s usage=%s",
@@ -443,8 +457,17 @@ async def _post_chat_completion_once(
                     failure_kind="service_unavailable",
                 )
             message = choices[0].get("message", {})
+            content_text = _message_content_text(message)
+            if not content_text:
+                logger.warning("%s API returned no text after cleanup", provider_name)
+                return _ChatCompletionAttempt(
+                    text=None,
+                    retryable=True,
+                    retry_after_sec=None,
+                    failure_kind="service_unavailable",
+                )
             return _ChatCompletionAttempt(
-                text=_message_content_text(message),
+                text=content_text,
                 retryable=False,
                 retry_after_sec=None,
                 failure_kind=None,

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -17,6 +17,7 @@ from typing import Any
 import cloudscraper
 
 from .config import get_config
+from .llm import strip_leaked_thinking
 from .handlers.shared import (
     get_problem_summary,
     get_today_problem,
@@ -536,7 +537,7 @@ async def _build_notes_message(stmt: dict) -> str:
         translated, _tag = await translate_sample_notes(raw_notes)
     except Exception:
         translated = ""
-    text = (translated or raw_notes).strip()
+    text = strip_leaked_thinking(translated or raw_notes)
     return f"样例解释：\n{text}" if text else ""
 
 

--- a/tests/test_newproblem_notes.py
+++ b/tests/test_newproblem_notes.py
@@ -44,12 +44,17 @@ def test_build_notes_message_falls_back_to_normalized_original():
     asyncio.run(_run())
 
 
-def test_build_notes_message_keeps_model_output_verbatim():
+def test_build_notes_message_strips_leaked_thinking_without_rewriting_text():
     from kouhai_bot.handlers.cmd import newproblem
 
     async def _run():
         stmt = {"notes": "placeholder"}
         raw = (
+            "<think>internal translation notes</think>"
+            "A \\xrightarrow[l=1,\\,r=6]{} B, and x \\lt y \\gt z, "
+            "with p \\leq q \\ge r and s \\oplus t."
+        )
+        expected = (
             "A \\xrightarrow[l=1,\\,r=6]{} B, and x \\lt y \\gt z, "
             "with p \\leq q \\ge r and s \\oplus t."
         )
@@ -59,7 +64,7 @@ def test_build_notes_message_keeps_model_output_verbatim():
             AsyncMock(return_value=(raw, "")),
         ):
             result = await newproblem._build_notes_message(stmt)
-        assert result == f"样例解释：\n{raw}"
+        assert result == f"样例解释：\n{expected}"
 
     asyncio.run(_run())
 

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -998,6 +998,59 @@ def test_dashscope_stream_payload_requests_usage_without_token_caps():
     assert forbidden.isdisjoint(calls[0])
 
 
+def test_non_streaming_chat_completion_strips_leaked_thinking():
+    response = _DummyResponse(json_data={
+        "choices": [
+            {
+                "message": {
+                    "content": "<think>hidden reasoning</think>Visible answer"
+                }
+            }
+        ]
+    })
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="openai",
+        base_url="https://api.openai.com/v1",
+        headers={},
+        payload={},
+        timeout=120,
+    ))
+
+    assert result.text == "Visible answer"
+    assert result.retryable is False
+
+
+def test_non_streaming_chat_completion_retries_when_only_leaked_thinking(caplog):
+    caplog.set_level("WARNING", logger="kouhai-bot.llm")
+    response = _DummyResponse(json_data={
+        "choices": [
+            {
+                "message": {
+                    "content": "<think>hidden reasoning</think>"
+                }
+            }
+        ]
+    })
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="openai",
+        base_url="https://api.openai.com/v1",
+        headers={},
+        payload={},
+        timeout=120,
+    ))
+
+    assert result.text is None
+    assert result.retryable is True
+    assert result.failure_kind == "service_unavailable"
+    assert "returned no text after cleanup" in caplog.text
+
+
 def test_streaming_chat_completion_reads_sse_delta_chunks(caplog):
     caplog.set_level("INFO", logger="kouhai-bot.llm")
     response = _DummyResponse(lines=[
@@ -1026,6 +1079,32 @@ def test_streaming_chat_completion_reads_sse_delta_chunks(caplog):
     assert result.retryable is False
     assert session.calls[0][1]["json"] == {"stream": True}
     assert "reasoning_content chars=8" in caplog.text
+
+
+def test_streaming_chat_completion_strips_leaked_thinking_blocks():
+    response = _DummyResponse(lines=[
+        'data: {"choices":[{"delta":{"content":"<think>hidden"}}]}\n',
+        '\n',
+        'data: {"choices":[{"delta":{"content":" reasoning</think>Visible"}}]}\n',
+        '\n',
+        'data: {"choices":[{"delta":{"content":" answer"}}]}\n',
+        '\n',
+        'data: [DONE]\n',
+        '\n',
+    ])
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="qwen",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        headers={},
+        payload={"stream": True},
+        timeout=120,
+    ))
+
+    assert result.text == "Visible answer"
+    assert result.retryable is False
 
 
 def test_streaming_chat_completion_empty_after_reasoning_is_not_retried(caplog):


### PR DESCRIPTION
## Summary
- strip provider-leaked `<think>...</think>` blocks from non-streaming and streaming LLM responses before callers see them
- reuse the same sanitizer when building group and private sample explanation cards
- update tests for leaked thinking in LLM transport and sample notes formatting

## Root cause
The latest group problem's cached CF notes were clean, but the sample-note translation response included a raw `<think>...</think>` block. `_build_notes_message()` trusted that translated text verbatim, so the thinking block was saved into the forward-card payload.

## Validation
- `uv run pytest tests/test_shared.py tests/test_newproblem_notes.py`
- `uv run pytest`