### PR TITLE
add multimodal statement support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,8 @@ NapCat (QQ) ──WS──> worker.py
   Group and private help are both delivered as merged-forward cards, with direct text
   only as fallback.
 - **Scheduler current-group config**: `~/.kouhai-bot/scheduler_config.json` stores job list + time overrides for `CURRENT_GROUP`. Jobs are defined in `scheduler/jobs.py`.
-- **Formula VL**: `problems/fetcher.py` handles CF formula images → Qwen-VL → inline LaTeX. Has white-bg preprocessing, hallucination detection, retry.
-- **Stale cache detection**: `picker.py:fetch_statement()` detects caches created before VL pipeline via `_vl_processed` flag. Stale caches with images are re-fetched with Qwen-VL. Problems with non-formula images (tex-graphics / diagrams) are skipped.
+- **Multimodal statements**: `problems/fetcher.py` collects CF `tex-formula` and `tex-graphics` image metadata with statement text. Formula images and diagrams are passed to `llm.multimodal_model` for new-problem summaries and `/clarify`; without that queue, picker logs and skips image-bearing problems.
+- **Stale cache detection**: `picker.py:fetch_statement()` detects caches created before image metadata via `_images_collected`. Stale caches with images are re-fetched so image metadata is available for multimodal tasks.
 - **No hermes cron involvement**: The bot runs its own scheduler loop (`scheduler/engine.py`), not hermes cron jobs.
 - **Single worker runtime**: `worker.py` keeps the NapCat reverse-WS connection, dispatches commands, and owns the scheduler in one process. There is no SQLite event queue, ingress supervisor, worker hot-swap, or auto-update loop.
 - **Friend request auto-approval**: Normal OneBot `post_type="request"` / `request_type="friend"` events are parsed by `napcat/client.py`, routed by `handlers.process_event()`, and approved via `set_friend_add_request`. QQ/NapCat "doubtful" friend requests are not reliably pushed as request events, so `worker.py` also runs `friend_requests.doubt_friend_request_loop()`, which polls `get_doubt_friends_add_request` every 60 seconds and approves with `set_doubt_friends_add_request`. Both paths approve only after the requester is confirmed to be a member of `CURRENT_GROUP`; lookup failure, malformed events, non-friend requests, and non-members are ignored without approving. Requests that were already consumed by another QQ client may not appear in the doubtful-request poll.
@@ -55,9 +55,10 @@ NapCat (QQ) ──WS──> worker.py
   by `CURFEW_START_HOUR` and `CURFEW_DURATION_HOURS`. Other commands (clarify, review,
   scoreboard, etc.) are unaffected. Curfew wraps past midnight correctly (e.g. start=22,
   duration=6 → 22:00–04:00).
-- **LLM fallback**: `llm.py` — providers are tried in list order from one of two
-  independent queues in `config.yaml`: `llm.smart_model` for judge/review and
-  `llm.general_model` for clarify/summary/editorial and other tasks. Each
+- **LLM fallback**: `llm.py` — providers are tried in list order from independent
+  queues in `config.yaml`: `llm.smart_model` for judge/review and
+  `llm.general_model` for pure-text clarify/summary/editorial and other tasks.
+  Optional `llm.multimodal_model` handles image-bearing problem summaries and `/clarify`. Each
   provider is retried internally (`llm.max_retries`) before moving to the next.
   All providers use the OpenAI-compatible `/chat/completions` format.
   DashScope/阿里云百炼 providers are called with HTTP+SSE streaming to avoid the
@@ -112,9 +113,10 @@ All providers use the OpenAI-compatible `/chat/completions` endpoint.
 | `llm.review_timeout_sec` | int | 600 | Review LLM timeout |
 | `llm.summary_timeout_sec` | int | 120 | Summary + editorial translation timeout |
 | `llm.smart_model` | list | — | Ordered fallback provider list for `/submit` judge and `/review` (**required, min 1**) |
-| `llm.general_model` | list | — | Ordered fallback provider list for `/clarify`, summaries, editorial translation, sample-note translation, and other LLM tasks (**required, min 1**) |
+| `llm.general_model` | list | — | Ordered fallback provider list for pure-text `/clarify`, summaries, editorial translation, sample-note translation, and other LLM tasks (**required, min 1**) |
+| `llm.multimodal_model` | list | `[]` | Optional ordered fallback provider list for image-bearing problem summaries and `/clarify` |
 
-Each provider in `llm.smart_model` or `llm.general_model`:
+Each provider in `llm.smart_model`, `llm.general_model`, or `llm.multimodal_model`:
 
 | Key | Default | Description |
 |-----|---------|-------------|
@@ -133,9 +135,9 @@ Each provider in `llm.smart_model` or `llm.general_model`:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `qwen.api_key` | — | Qwen-VL API key |
-| `qwen.base_url` | `https://dashscope.aliyuncs.com/compatible-mode/v1` | Qwen-VL base URL |
-| `qwen.model` | — | Qwen-VL model name (**required**) |
+| `qwen.api_key` | — | Legacy Qwen-VL API key |
+| `qwen.base_url` | `https://dashscope.aliyuncs.com/compatible-mode/v1` | Legacy Qwen-VL base URL |
+| `qwen.model` | `""` | Legacy Qwen-VL model name; no longer required for runtime statement images |
 
 #### `problem` section
 
@@ -601,8 +603,8 @@ commands are rejected in private with a friendly message.
   review as available. It sends a private problem card, preferring the current group's
   cached forward-card payload when the pid is the current group problem. Generated
   private cards must not expose the original CF id, title, contest id, or rating in the
-  card title. If an explicit pid/link fails because the statement fetcher detects
-  non-formula images (`tex-graphics` diagrams), tell the user the bot has limited
+  card title. If an explicit pid/link fails because the statement contains images
+  and no `llm.multimodal_model` queue is configured, tell the user the bot has limited
   ability on image-dependent statements and suggest choosing another problem.
 - `/problem` in private resends the selected private problem card. `/tag`, `/status`,
   `/clear`, `/submit`, `/clarify`, and `/review` all operate on private state and do

--- a/README.md
+++ b/README.md
@@ -63,13 +63,15 @@ cp config.example.yaml config.yaml
 
 ZenMux 上的体验模型也可以作为 OpenAI-compatible provider 配置。示例见 `config.example.yaml`；例如 Grok 4.5 Free 可使用 `model: "x-ai/grok-4.5-free"`、`reasoning_effort: "xhigh"`、`model_tag: "『∅』"`。如果某个网关需要特殊 payload，可在 provider 上配置 `temperature`、`send_thinking` 或 `extra_body`，避免为每个模型在代码里新增分支。
 
-#### 公式识别
+#### 多模态题面
 
 ```
-# ── Qwen-VL (formula image recognition) ──
+# Optional multimodal fallback queue
 ```
 
-bot 需要一个视觉模型才能阅读被渲染成图像的公式。实测 `qwen-vl-max` 效果很好，且阿里云提供了足够的免费额度。你也可以使用其他视觉模型。
+如果希望 bot 选择和澄清包含公式图、示意图的 Codeforces 题面，请配置 `llm.multimodal_model`。带图题的中文题意摘要和 `/clarify` 会走这个队列；未配置时，选题会跳过带图候选，已有带图题的 `/clarify` 会提示当前缺少多模态模型。
+
+旧的 `qwen` / Qwen-VL 公式 OCR 配置不再是运行时必需项，保留只是为了兼容旧工具。
 
 #### 配置群聊
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -82,11 +82,21 @@ llm:
       model: "deepseek-v4-chat"
       model_tag: "『🐳』"
 
-# ── Qwen-VL (formula image recognition) ──
+  # Optional multimodal fallback queue — image-bearing problem summaries and /clarify use this list.
+  multimodal_model:
+    - name: mmx
+      api_key: "..."
+      base_url: "https://zenmux.ai/api/v1"
+      model: "mmx/mmx"
+      model_tag: "『MMx』"
+
+# ── Legacy Qwen-VL (deprecated) ──
+# Runtime statement images now use llm.multimodal_model instead of a separate formula-OCR pass.
+# This section is optional and kept only for compatibility with old local tooling.
 qwen:
   api_key: "..."
   base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1"
-  model: "qwen-vl-max"
+  model: ""
 
 # ── Group ──
 current_group: 0  # your QQ group number

--- a/src/kouhai_bot/config.py
+++ b/src/kouhai_bot/config.py
@@ -109,6 +109,7 @@ class BotConfig:
     # --- LLM fallback ---
     llm_smart_providers: list[LlmProviderConfig] = field(default_factory=list)
     llm_general_providers: list[LlmProviderConfig] = field(default_factory=list)
+    llm_multimodal_providers: list[LlmProviderConfig] = field(default_factory=list)
     llm_max_retries: int = 2
     llm_retry_base_delay_sec: float = 1.0
     llm_retry_max_delay_sec: float = 8.0
@@ -118,7 +119,7 @@ class BotConfig:
     review_timeout_sec: int = 600
     summary_timeout_sec: int = 120
 
-    # --- Qwen-VL ---
+    # --- Legacy Qwen-VL ---
     qwen_api_key: str = ""
     qwen_base_url: str = "https://dashscope.aliyuncs.com/compatible-mode/v1"
     qwen_model: str = ""
@@ -175,6 +176,7 @@ class BotConfig:
         (
             c.llm_smart_providers,
             c.llm_general_providers,
+            c.llm_multimodal_providers,
         ) = build_provider_queues_from_yaml(llm)
         c.llm_max_retries = int(llm.get("max_retries", c.llm_max_retries))
         c.llm_retry_base_delay_sec = float(
@@ -197,15 +199,13 @@ class BotConfig:
             llm.get("summary_timeout_sec", c.summary_timeout_sec)
         )
 
-        # --- Qwen-VL ---
+        # --- Legacy Qwen-VL ---
         qwen = data.get("qwen", {})
         if not isinstance(qwen, dict):
             qwen = {}
         c.qwen_api_key = str(qwen.get("api_key", c.qwen_api_key))
         c.qwen_base_url = str(qwen.get("base_url", c.qwen_base_url))
         c.qwen_model = str(qwen.get("model", ""))
-        if not c.qwen_model:
-            raise RuntimeError("config.yaml: qwen.model is required")
 
         # --- Group ---
         if "current_group" not in data:

--- a/src/kouhai_bot/handlers/cmd/newproblem.py
+++ b/src/kouhai_bot/handlers/cmd/newproblem.py
@@ -303,7 +303,7 @@ async def _build_notes_message(stmt: dict) -> str:
     if not normalized_notes:
         return ""
     try:
-        translated_notes, _model_tag = await translate_sample_notes(normalized_notes)
+        translated_notes, _model_tag = await translate_sample_notes(normalized_notes, statement_images(stmt))
     except Exception as e:
         logger.warning("Notes translation failed, skipping notes node: %s", e)
         return ""

--- a/src/kouhai_bot/handlers/cmd/newproblem.py
+++ b/src/kouhai_bot/handlers/cmd/newproblem.py
@@ -19,6 +19,7 @@ from ..shared import (
     save_problem_card_ref,
     save_problem_summary,
     save_scoreboard,
+    statement_images,
     snake_replace,
     summarize_problem,
     translate_sample_notes,
@@ -466,10 +467,11 @@ async def _post_new_problem_locked(
             sample_messages = _build_sample_messages(stmt)
             notes_message = await _build_notes_message(stmt)
 
-        summary, model_tag = await summarize_problem(stmt_text, input_text, limits_text)
+        images = statement_images(stmt)
+        summary, model_tag = await summarize_problem(stmt_text, input_text, limits_text, images)
         if not summary:
             logger.warning(f"[group_{group_id}] Summary 1st attempt failed, retrying...")
-            summary, model_tag = await summarize_problem(stmt_text, input_text, limits_text)
+            summary, model_tag = await summarize_problem(stmt_text, input_text, limits_text, images)
         if summary:
             desc = summary.strip()
             save_problem_summary(group_id, pid, desc)

--- a/src/kouhai_bot/handlers/cmd/setproblem.py
+++ b/src/kouhai_bot/handlers/cmd/setproblem.py
@@ -121,12 +121,12 @@ async def handle(group_id: int, user_id: int, sender: dict,
         except NonFormulaImageProblem:
             if from_quoted_card:
                 await send_private_msg(user_id, build_plain_message(
-                    "这道题的题面里包含非公式图片，我现在对这类题目的处理能力有限，"
+                    "这道题的题面里包含图片，但当前没有配置多模态模型，"
                     "可能看不完整题意。建议先换一道题～"
                 ))
             else:
                 await send_private_msg(user_id, build_plain_message(
-                    f"CF{pid} 的题面里包含非公式图片，我现在对这类题目的处理能力有限，"
+                    f"CF{pid} 的题面里包含图片，但当前没有配置多模态模型，"
                     "可能看不完整题意。建议先换一道题～"
                 ))
             return

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -921,7 +921,7 @@ class GroupCoordinator:
             f"群友的问题：\n{req.payload}"
         )
         user_content: str | list[dict] = (
-            build_multimodal_user_content(user_prompt, images)
+            await build_multimodal_user_content(user_prompt, images)
             if images
             else user_prompt
         )

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -23,6 +23,7 @@ from .. import registry
 from ..registry import CommandDef
 from ..shared import (
     build_scoreboard_entries,
+    build_multimodal_user_content,
     call_chat_completion_result,
     clear_user_problem_submissions,
     fetch_group_member_nickname_map,
@@ -34,13 +35,16 @@ from ..shared import (
     load_known_problem_ratings,
     load_scoreboard,
     load_problem_statement,
+    load_problem_statement_json,
     load_user_submissions,
+    multimodal_model_configured,
     rating_to_points,
     remember_problem_rating,
     parse_json_with_llm_repair,
     save_scoreboard,
     save_user_submission,
     second_judge_submission_result,
+    statement_images,
 )
 from ...config import get_config
 from ...context import get_display_name, load_group_ctx
@@ -896,27 +900,37 @@ class GroupCoordinator:
         pid = req.target_pid
         if not pid:
             return {"kind": "no_problem"}
+        stmt = load_problem_statement_json(pid)
         problem_text = load_problem_statement(pid)
         if not problem_text:
             return {"kind": "no_statement", "pid": pid}
 
         cfg = get_config()
+        images = statement_images(stmt)
+        if images and not multimodal_model_configured():
+            return {"kind": "image_unsupported", "pid": pid}
         summary = (
             get_problem_summary(req.group_id, pid)
             if req.is_private
             else _load_latest_group_summary(req.group_id)
         )
         await _react_req(req, random.choice(["128064", "289"]))
+        user_prompt = (
+            f"题目中文简述：\n{summary[:2000] if summary else '(暂无简述)'}\n\n"
+            f"题目英文原文：\n{problem_text[:5000]}\n\n"
+            f"群友的问题：\n{req.payload}"
+        )
+        user_content: str | list[dict] = (
+            build_multimodal_user_content(user_prompt, images)
+            if images
+            else user_prompt
+        )
         result = await _call_llm_limited(
             [
                 {"role": "system", "content": CLARIFY_PROMPT},
-                {"role": "user", "content": (
-                    f"题目中文简述：\n{summary[:2000] if summary else '(暂无简述)'}\n\n"
-                    f"题目英文原文：\n{problem_text[:5000]}\n\n"
-                    f"群友的问题：\n{req.payload}"
-                )},
+                {"role": "user", "content": user_content},
             ],
-            task="clarify",
+            task="multimodal_clarify" if images else "clarify",
             timeout=cfg.clarify_timeout_sec,
             response_format={"type": "json_object"},
             thinking={"type": "enabled"},
@@ -1314,6 +1328,15 @@ class GroupCoordinator:
             await self._save_context_record(
                 req,
                 _context_record(req, result="no_statement", problem=result.get("pid", "")),
+            )
+            await self._finish_request(req)
+            return
+        if kind == "image_unsupported":
+            self._log_finished(req, "image_unsupported", problem=result.get("pid", ""))
+            await _send_req_plain(req, "这道题包含图片，当前没有配置多模态模型，暂时没法可靠澄清题面～")
+            await self._save_context_record(
+                req,
+                _context_record(req, result="image_unsupported", problem=result.get("pid", "")),
             )
             await self._finish_request(req)
             return

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -345,6 +345,14 @@ def build_multimodal_user_content(text: str, images: list[dict]) -> list[dict]:
     return content
 
 
+def _usable_statement_images(images: list[dict] | None) -> list[dict]:
+    return [item for item in images or [] if isinstance(item, dict) and item.get("src")]
+
+
+def _multimodal_content_or_text(text: str, images: list[dict]) -> str | list[dict]:
+    return build_multimodal_user_content(text, images) if images else text
+
+
 # ── Today's problem ─────────────────────────────────────────────────────
 
 def _today_state_file(group_id: int) -> str:
@@ -1291,16 +1299,12 @@ async def summarize_problem(
     Returns (summary_text, model_tag). model_tag is empty if the LLM call failed.
     """
     cfg = get_config()
-    image_items = [item for item in images or [] if isinstance(item, dict) and item.get("src")]
+    image_items = _usable_statement_images(images)
     if image_items and not multimodal_model_configured():
         logger.warning("summary requested for image statement without llm.multimodal_model")
         return None, ""
     user_prompt = _build_summary_prompt(stmt_text, input_text, limits_text)
-    user_content: str | list[dict] = (
-        build_multimodal_user_content(user_prompt, image_items)
-        if image_items
-        else user_prompt
-    )
+    user_content = _multimodal_content_or_text(user_prompt, image_items)
     messages = [
         {"role": "system", "content": _summary_system_prompt()},
         {"role": "user", "content": user_content},
@@ -1356,12 +1360,19 @@ async def summarize_problem(
     return repaired, repaired_json_tag or repair_result.model_tag
 
 
-async def translate_sample_notes(notes_text: str) -> tuple[str | None, str]:
+async def translate_sample_notes(
+    notes_text: str,
+    images: list[dict] | None = None,
+) -> tuple[str | None, str]:
     """Translate sample notes/explanations into concise Chinese plain text."""
     content = (notes_text or "").strip()
     if not content:
         return None, ""
     cfg = get_config()
+    image_items = _usable_statement_images(images)
+    if image_items and not multimodal_model_configured():
+        logger.warning("sample notes translation requested with images without llm.multimodal_model")
+        image_items = []
     prompt = (
         "下面是题目中与样例相关的解释（Notes）。\n"
         "请把它忠实翻译为自然、准确的中文；只做翻译，不要总结、点评、补充解释、改写成题解，"
@@ -1390,9 +1401,9 @@ async def translate_sample_notes(notes_text: str) -> tuple[str | None, str]:
                     "你必须输出纯文本；LaTeX 只在不用会失真时保留，普通下标和幂次优先使用 Unicode 角标。"
                 ),
             },
-            {"role": "user", "content": prompt},
+            {"role": "user", "content": _multimodal_content_or_text(prompt, image_items)},
         ],
-        task="summary",
+        task="multimodal_summary" if image_items else "summary",
         timeout=cfg.summary_timeout_sec,
     )
     return result.text, result.model_tag
@@ -1402,6 +1413,7 @@ async def translate_editorial_to_zh(
     editorial_text: str,
     pid: str = "",
     problem_text: str = "",
+    images: list[dict] | None = None,
 ) -> tuple[str | None, str, bool | None]:
     """Validate and translate a Codeforces editorial to Chinese for group delivery.
 
@@ -1422,6 +1434,11 @@ async def translate_editorial_to_zh(
         "official_editorial": body,
     }
     cfg = get_config()
+    image_items = _usable_statement_images(images)
+    if image_items and not multimodal_model_configured():
+        logger.warning("editorial translation requested with images without llm.multimodal_model")
+        image_items = []
+    user_prompt = json.dumps(prompt_payload, ensure_ascii=False)
     result = await call_chat_completion_result(
         [
             {
@@ -1456,9 +1473,9 @@ async def translate_editorial_to_zh(
                     "只有复杂求和、递推、分式、多重下标、精确定义用中文或 Unicode 会失真时，才保留最少必要 LaTeX。"
                 ),
             },
-            {"role": "user", "content": json.dumps(prompt_payload, ensure_ascii=False)},
+            {"role": "user", "content": _multimodal_content_or_text(user_prompt, image_items)},
         ],
-        task="summary",
+        task="multimodal_summary" if image_items else "summary",
         timeout=600,
         response_format={"type": "json_object"},
         thinking={"type": "enabled"},

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -13,6 +13,7 @@ import os
 import random
 import re
 import time
+import urllib.request
 from pathlib import Path
 
 from ..config import get_config
@@ -240,15 +241,32 @@ async def parse_json_with_llm_repair(
 
 # ── Problem statement loading ───────────────────────────────────────────
 
-def load_problem_statement(pid: str) -> str:
-    """Load full problem statement from cache, formatted for LLM."""
+_MAX_MULTIMODAL_IMAGES = 8
+
+
+def multimodal_model_configured() -> bool:
+    return bool(get_config().llm_multimodal_providers)
+
+
+def load_problem_statement_json(pid: str) -> dict:
+    """Load raw problem statement cache JSON."""
     cfg = get_config()
     stmt_path = os.path.join(cfg.data_dir, "statements", f"{pid}.json")
     if not os.path.exists(stmt_path):
-        return ""
+        return {}
 
-    with open(stmt_path) as f:
-        stmt = json.load(f)
+    try:
+        with open(stmt_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def format_problem_statement_for_llm(stmt: dict) -> str:
+    """Format statement cache JSON as text for LLM context."""
+    if not isinstance(stmt, dict):
+        return ""
 
     parts = []
     if stmt.get("name"):
@@ -280,6 +298,49 @@ def load_problem_statement(pid: str) -> str:
         parts.append(f"\nNote:\n{notes}")
 
     return "\n".join(parts)
+
+
+def load_problem_statement(pid: str) -> str:
+    """Load full problem statement from cache, formatted for LLM."""
+    return format_problem_statement_for_llm(load_problem_statement_json(pid))
+
+
+def statement_images(stmt: dict) -> list[dict]:
+    images = stmt.get("images", []) if isinstance(stmt, dict) else []
+    return [item for item in images if isinstance(item, dict) and item.get("src")]
+
+
+def _download_image_data_url(url: str) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        data = resp.read()
+        content_type = str(resp.headers.get("Content-Type") or "").split(";", 1)[0]
+    mime = content_type if content_type.startswith("image/") else "image/png"
+    import base64
+
+    return f"data:{mime};base64,{base64.b64encode(data).decode()}"
+
+
+def build_multimodal_user_content(text: str, images: list[dict]) -> list[dict]:
+    """Build OpenAI-compatible text+image content parts."""
+    content: list[dict] = [{"type": "text", "text": text}]
+    for idx, image in enumerate(images[:_MAX_MULTIMODAL_IMAGES], 1):
+        src = str(image.get("src", "") or "").strip()
+        if not src:
+            continue
+        kind = str(image.get("kind", "") or "image")
+        context = str(image.get("context", "") or "").strip()
+        label = f"题面图片 {idx}（{kind}）"
+        if context:
+            label += f"，附近文本：{context[:500]}"
+        content.append({"type": "text", "text": "\n\n" + label})
+        try:
+            image_url = _download_image_data_url(src)
+        except Exception as e:
+            logger.warning("failed to download statement image %s: %s", src, e)
+            image_url = src
+        content.append({"type": "image_url", "image_url": {"url": image_url}})
+    return content
 
 
 # ── Today's problem ─────────────────────────────────────────────────────
@@ -1217,19 +1278,34 @@ def _build_summary_repair_prompt(
     )
 
 
-async def summarize_problem(stmt_text: str, input_text: str, limits_text: str) -> tuple[str | None, str]:
+async def summarize_problem(
+    stmt_text: str,
+    input_text: str,
+    limits_text: str,
+    images: list[dict] | None = None,
+) -> tuple[str | None, str]:
     """Generate Chinese summary of a problem via the configured chat provider.
 
     Returns (summary_text, model_tag). model_tag is empty if the LLM call failed.
     """
     cfg = get_config()
+    image_items = [item for item in images or [] if isinstance(item, dict) and item.get("src")]
+    if image_items and not multimodal_model_configured():
+        logger.warning("summary requested for image statement without llm.multimodal_model")
+        return None, ""
+    user_prompt = _build_summary_prompt(stmt_text, input_text, limits_text)
+    user_content: str | list[dict] = (
+        build_multimodal_user_content(user_prompt, image_items)
+        if image_items
+        else user_prompt
+    )
     messages = [
         {"role": "system", "content": _summary_system_prompt()},
-        {"role": "user", "content": _build_summary_prompt(stmt_text, input_text, limits_text)},
+        {"role": "user", "content": user_content},
     ]
     result = await call_chat_completion_result(
         messages,
-        task="summary",
+        task="multimodal_summary" if image_items else "summary",
         temperature=0.4,
         timeout=cfg.summary_timeout_sec,
         response_format={"type": "json_object"},

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -321,27 +321,107 @@ def _download_image_data_url(url: str) -> str:
     return f"data:{mime};base64,{base64.b64encode(data).decode()}"
 
 
-def build_multimodal_user_content(text: str, images: list[dict]) -> list[dict]:
+async def _download_image_data_url_async(url: str) -> str:
+    if url.startswith("data:"):
+        return url
+    import aiohttp
+    import base64
+
+    timeout = aiohttp.ClientTimeout(total=15)
+    headers = {"User-Agent": "Mozilla/5.0"}
+    async with aiohttp.ClientSession(timeout=timeout, headers=headers) as session:
+        async with session.get(url) as resp:
+            resp.raise_for_status()
+            data = await resp.read()
+            content_type = str(resp.headers.get("Content-Type") or "").split(";", 1)[0]
+    mime = content_type if content_type.startswith("image/") else "image/png"
+    return f"data:{mime};base64,{base64.b64encode(data).decode()}"
+
+
+def _image_marker(image: dict, fallback_idx: int) -> str:
+    return str(image.get("marker", "") or f"IMAGE_{fallback_idx}")
+
+
+def _image_kind(image: dict) -> str:
+    return str(image.get("kind", "") or "image")
+
+
+def _image_placeholder(image: dict, fallback_idx: int) -> str:
+    marker = _image_marker(image, fallback_idx)
+    kind = _image_kind(image)
+    return str(image.get("placeholder", "") or f"[[{marker}: {kind}]]")
+
+
+def _image_has_text_fallback(image: dict) -> bool:
+    return _image_kind(image).lower() == "formula" and bool(str(image.get("alt", "") or "").strip())
+
+
+def _select_images_for_attachment(images: list[dict]) -> tuple[list[dict], list[dict]]:
+    usable = [
+        (idx, image)
+        for idx, image in enumerate(images)
+        if isinstance(image, dict) and str(image.get("src", "") or "").strip()
+    ]
+    if len(usable) <= _MAX_MULTIMODAL_IMAGES:
+        return [image for _, image in usable], []
+
+    ranked = sorted(
+        usable,
+        key=lambda item: (1 if _image_has_text_fallback(item[1]) else 0, item[0]),
+    )
+    selected_indexes = {idx for idx, _ in ranked[:_MAX_MULTIMODAL_IMAGES]}
+    selected = [image for idx, image in usable if idx in selected_indexes]
+    omitted = [image for idx, image in usable if idx not in selected_indexes]
+    return selected, omitted
+
+
+def _omitted_image_note(omitted: list[dict]) -> str:
+    refs = [
+        _image_placeholder(image, idx)[:180]
+        for idx, image in enumerate(omitted, 1)
+    ]
+    shown = "；".join(refs[:12])
+    if len(refs) > 12:
+        shown += f"；另有 {len(refs) - 12} 张"
+    return (
+        "多模态附件上限为 8 张，已优先附加缺少文本替代的示意图或公式图。"
+        f"以下题面图片未随请求发送：{shown}。"
+        "若这些占位符本身包含公式或 alt 文本，请依据题面文字；不要假设未附图中存在额外信息。"
+    )
+
+
+async def _build_image_content_parts(display_idx: int, image: dict) -> list[dict]:
+    src = str(image.get("src", "") or "").strip()
+    kind = _image_kind(image)
+    marker = _image_marker(image, display_idx)
+    placeholder = _image_placeholder(image, display_idx)
+    context = str(image.get("context", "") or "").strip()
+    label = f"题面图片 {marker}（{kind}），对应原文占位符：{placeholder}"
+    if context:
+        label += f"，附近文本：{context[:500]}"
+    try:
+        image_url = await _download_image_data_url_async(src)
+    except Exception as e:
+        logger.warning("failed to download statement image %s: %s", src, e)
+        image_url = src
+    return [
+        {"type": "text", "text": "\n\n" + label},
+        {"type": "image_url", "image_url": {"url": image_url}},
+    ]
+
+
+async def build_multimodal_user_content(text: str, images: list[dict]) -> list[dict]:
     """Build OpenAI-compatible text+image content parts."""
     content: list[dict] = [{"type": "text", "text": text}]
-    for idx, image in enumerate(images[:_MAX_MULTIMODAL_IMAGES], 1):
-        src = str(image.get("src", "") or "").strip()
-        if not src:
-            continue
-        kind = str(image.get("kind", "") or "image")
-        marker = str(image.get("marker", "") or f"IMAGE_{idx}")
-        placeholder = str(image.get("placeholder", "") or f"[[{marker}: {kind}]]")
-        context = str(image.get("context", "") or "").strip()
-        label = f"题面图片 {marker}（{kind}），对应原文占位符：{placeholder}"
-        if context:
-            label += f"，附近文本：{context[:500]}"
-        content.append({"type": "text", "text": "\n\n" + label})
-        try:
-            image_url = _download_image_data_url(src)
-        except Exception as e:
-            logger.warning("failed to download statement image %s: %s", src, e)
-            image_url = src
-        content.append({"type": "image_url", "image_url": {"url": image_url}})
+    selected, omitted = _select_images_for_attachment(images)
+    image_parts = await asyncio.gather(*[
+        _build_image_content_parts(idx, image)
+        for idx, image in enumerate(selected, 1)
+    ])
+    for parts in image_parts:
+        content.extend(parts)
+    if omitted:
+        content.append({"type": "text", "text": "\n\n" + _omitted_image_note(omitted)})
     return content
 
 
@@ -349,8 +429,8 @@ def _usable_statement_images(images: list[dict] | None) -> list[dict]:
     return [item for item in images or [] if isinstance(item, dict) and item.get("src")]
 
 
-def _multimodal_content_or_text(text: str, images: list[dict]) -> str | list[dict]:
-    return build_multimodal_user_content(text, images) if images else text
+async def _multimodal_content_or_text(text: str, images: list[dict]) -> str | list[dict]:
+    return await build_multimodal_user_content(text, images) if images else text
 
 
 # ── Today's problem ─────────────────────────────────────────────────────
@@ -1304,7 +1384,7 @@ async def summarize_problem(
         logger.warning("summary requested for image statement without llm.multimodal_model")
         return None, ""
     user_prompt = _build_summary_prompt(stmt_text, input_text, limits_text)
-    user_content = _multimodal_content_or_text(user_prompt, image_items)
+    user_content = await _multimodal_content_or_text(user_prompt, image_items)
     messages = [
         {"role": "system", "content": _summary_system_prompt()},
         {"role": "user", "content": user_content},
@@ -1401,7 +1481,7 @@ async def translate_sample_notes(
                     "你必须输出纯文本；LaTeX 只在不用会失真时保留，普通下标和幂次优先使用 Unicode 角标。"
                 ),
             },
-            {"role": "user", "content": _multimodal_content_or_text(prompt, image_items)},
+            {"role": "user", "content": await _multimodal_content_or_text(prompt, image_items)},
         ],
         task="multimodal_summary" if image_items else "summary",
         timeout=cfg.summary_timeout_sec,
@@ -1473,7 +1553,7 @@ async def translate_editorial_to_zh(
                     "只有复杂求和、递推、分式、多重下标、精确定义用中文或 Unicode 会失真时，才保留最少必要 LaTeX。"
                 ),
             },
-            {"role": "user", "content": _multimodal_content_or_text(user_prompt, image_items)},
+            {"role": "user", "content": await _multimodal_content_or_text(user_prompt, image_items)},
         ],
         task="multimodal_summary" if image_items else "summary",
         timeout=600,

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -329,8 +329,10 @@ def build_multimodal_user_content(text: str, images: list[dict]) -> list[dict]:
         if not src:
             continue
         kind = str(image.get("kind", "") or "image")
+        marker = str(image.get("marker", "") or f"IMAGE_{idx}")
+        placeholder = str(image.get("placeholder", "") or f"[[{marker}: {kind}]]")
         context = str(image.get("context", "") or "").strip()
-        label = f"题面图片 {idx}（{kind}）"
+        label = f"题面图片 {marker}（{kind}），对应原文占位符：{placeholder}"
         if context:
             label += f"，附近文本：{context[:500]}"
         content.append({"type": "text", "text": "\n\n" + label})

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -533,6 +533,8 @@ async def chat_completion(
     task_name = (task or "").strip().lower()
     if task_name in {"judge", "review"}:
         providers = cfg.llm_smart_providers
+    elif task_name in {"multimodal", "multimodal_summary", "multimodal_clarify"}:
+        providers = cfg.llm_multimodal_providers
     else:
         providers = cfg.llm_general_providers
     if provider_name:

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -31,6 +31,7 @@ _THINK_BLOCK_RE = re.compile(
     rf"<\s*(?P<tag>{_THINK_TAG_NAMES_RE})\b[^>]*>.*?</\s*(?P=tag)\s*>",
     re.IGNORECASE | re.DOTALL,
 )
+_THINK_OPEN_RE = re.compile(rf"<\s*{_ORPHAN_TAG_NAMES_RE}\b[^>]*>", re.IGNORECASE)
 _THINK_TAG_RE = re.compile(rf"</?\s*{_ORPHAN_TAG_NAMES_RE}\b[^>]*>", re.IGNORECASE)
 
 
@@ -72,6 +73,9 @@ def strip_leaked_thinking(text: str) -> str:
     if not text:
         return ""
     text = _THINK_BLOCK_RE.sub("", text)
+    open_match = _THINK_OPEN_RE.search(text)
+    if open_match:
+        text = text[:open_match.start()]
     text = _THINK_TAG_RE.sub("", text)
     return text.strip()
 

--- a/src/kouhai_bot/llm_config.py
+++ b/src/kouhai_bot/llm_config.py
@@ -127,11 +127,19 @@ def _build_provider_list(raw: Any, *, section_name: str) -> list[LlmProviderConf
 
 def build_provider_queues_from_yaml(
     llm_section: dict[str, Any],
-) -> tuple[list[LlmProviderConfig], list[LlmProviderConfig]]:
-    """Build smart/general provider fallback queues from the YAML ``llm`` section.
+) -> tuple[
+    list[LlmProviderConfig],
+    list[LlmProviderConfig],
+    list[LlmProviderConfig],
+]:
+    """Build provider fallback queues from the YAML ``llm`` section.
 
-    Raises RuntimeError if either queue is empty or required fields are missing.
+    Raises RuntimeError if required queues are empty or required fields are missing.
+    ``multimodal_model`` is optional; an empty/missing section disables image tasks.
     """
+    multimodal_raw = llm_section.get("multimodal_model", [])
+    if multimodal_raw in (None, ""):
+        multimodal_raw = []
     return (
         _build_provider_list(
             llm_section.get("smart_model", []),
@@ -140,5 +148,13 @@ def build_provider_queues_from_yaml(
         _build_provider_list(
             llm_section.get("general_model", []),
             section_name="general_model",
+        ),
+        (
+            _build_provider_list(
+                multimodal_raw,
+                section_name="multimodal_model",
+            )
+            if multimodal_raw
+            else []
         ),
     )

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -537,7 +537,7 @@ async def _build_notes_message(stmt: dict) -> str:
     if not raw_notes:
         return ""
     try:
-        translated, _tag = await translate_sample_notes(raw_notes)
+        translated, _tag = await translate_sample_notes(raw_notes, statement_images(stmt))
     except Exception:
         translated = ""
     text = strip_leaked_thinking(translated or raw_notes)

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -23,9 +23,11 @@ from .handlers.shared import (
     get_today_problem,
     high_difficulty_notice,
     load_scoreboard,
+    multimodal_model_configured,
     save_problem_summary,
     save_problem_card_ref,
     sanitize_cached_problem_card_payload,
+    statement_images,
     summarize_problem,
     translate_sample_notes,
 )
@@ -59,7 +61,7 @@ _CONTEST_PATH_RE = re.compile(
 
 
 class NonFormulaImageProblem(RuntimeError):
-    """Raised when a statement is unavailable because it depends on diagrams/images."""
+    """Raised when a statement is unavailable because image context is unsupported."""
 
 
 def _data_dir() -> Path:
@@ -404,12 +406,12 @@ def _ensure_statement(problem: dict) -> dict:
     stmt = picker.fetch_statement(problem)
     if isinstance(stmt, dict):
         return stmt
-    if _has_non_formula_images(problem):
+    if _has_images(problem) and not multimodal_model_configured():
         raise NonFormulaImageProblem(_problem_id(problem) or "unknown")
     return {}
 
 
-def _has_non_formula_images(problem: dict) -> bool:
+def _has_images(problem: dict) -> bool:
     from .problems import picker
 
     contest_id = problem.get("contestId")
@@ -420,13 +422,13 @@ def _has_non_formula_images(problem: dict) -> bool:
         result = picker.cf_statement.process_problem(contest_id, index, vl_backend="none")
     except Exception as e:
         logger.warning(
-            "failed to inspect non-formula images for %s%s: %s",
+            "failed to inspect statement images for %s%s: %s",
             contest_id,
             index,
             e,
         )
         return False
-    return bool(result.get("has_non_formula_images"))
+    return bool(result.get("formulas_found", 0) or result.get("graphics_found", 0))
 
 
 def resolve_problem_by_pid(pid: str) -> dict:
@@ -550,7 +552,12 @@ async def _problem_summary(group_id: int, pid: str, stmt: dict) -> str:
     input_text = stmt.get("input", "") or ""
     tl = stmt.get("time_limit", "?")
     ml = stmt.get("memory_limit", "?")
-    result, model_tag = await summarize_problem(stmt_text, input_text, f"Time: {tl}, Memory: {ml}")
+    result, model_tag = await summarize_problem(
+        stmt_text,
+        input_text,
+        f"Time: {tl}, Memory: {ml}",
+        statement_images(stmt),
+    )
     summary = (result or "").strip()
     if summary:
         if model_tag:

--- a/src/kouhai_bot/problems/fetcher.py
+++ b/src/kouhai_bot/problems/fetcher.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-cf_statement.py — Fetch CF problem statement, handle formula images via VL.
+cf_statement.py — Fetch CF problem statement and collect image metadata.
 
 Usage:
   python cf_statement.py 542 D                    # contestId + index
@@ -13,7 +13,8 @@ VL backends (set via --vl-backend or CF_VL_BACKEND env):
   - none     Dry-run only
 
 Returns:
-  - has_non_formula_images: True if problem contains tex-graphics diagrams → filter out
+  - images: tex-formula / tex-graphics metadata for multimodal consumers
+  - has_non_formula_images: True if problem contains tex-graphics diagrams
 """
 
 import argparse
@@ -24,6 +25,7 @@ import re
 import sys
 import urllib.request
 from io import BytesIO
+from urllib.parse import urljoin
 
 import cloudscraper
 from PIL import Image
@@ -107,11 +109,21 @@ def extract_problem_statement(html: str) -> str | None:
 
 # ── Find formula / graphics images ──────────────────────────────────────
 
+def normalize_image_src(src: str) -> str:
+    """Return an absolute Codeforces image URL."""
+    value = (src or "").strip()
+    if not value:
+        return ""
+    if value.startswith("//"):
+        return "https:" + value
+    return urljoin("https://codeforces.com", value)
+
+
 def find_all_tex_images(ps_html: str) -> tuple[list[dict], list[dict]]:
     """Find all tex-formula and tex-graphics images.
     Returns (formulas, graphics) — each a list of {tag, src, class, start, end}.
-    tex-formula = math formula images (should convert to LaTeX)
-    tex-graphics = diagrams/charts/drawings (should filter out the problem)
+    tex-formula = math formula images.
+    tex-graphics = diagrams/charts/drawings.
     """
     formulas = []
     graphics = []
@@ -125,7 +137,7 @@ def find_all_tex_images(ps_html: str) -> tuple[list[dict], list[dict]]:
         cls = cls_m.group(1) if cls_m else ""
         entry = {
             "tag": tag,
-            "src": src_m.group(1) if src_m else "",
+            "src": normalize_image_src(src_m.group(1) if src_m else ""),
             "class": cls,
             "start": m.start(),
             "end": m.end(),
@@ -352,7 +364,7 @@ def process_problem(
       - pid, url, text, text_length
       - formulas_found, formulas_processed
       - formula_details: list of {src, latex}
-      - has_non_formula_images: True if tex-graphics (diagrams) found → filter out
+      - has_non_formula_images: True if tex-graphics (diagrams) found
       - formulas_failed: number of formulas that couldn't be converted after retries
     """
     html, pid = fetch_problem_html(contest_id, index)
@@ -367,7 +379,7 @@ def process_problem(
           file=sys.stderr)
 
     if has_non_formula_images:
-        print(f"  [{pid}] ⚠ contains tex-graphics (diagrams) — will be filtered",
+        print(f"  [{pid}] ⚠ contains tex-graphics (diagrams)",
               file=sys.stderr)
 
     # Process formula images
@@ -418,7 +430,7 @@ def process_problem(
     for gm in graphics:
         formula_results.append({
             "src": gm["src"],
-            "latex": "[DIAGRAM — non-formula image]",
+            "latex": "[DIAGRAM IMAGE]",
         })
 
     # Replace all image tags with their text representation (reverse order)
@@ -450,6 +462,15 @@ def process_problem(
         "formulas_processed": len(formulas) - formulas_failed,
         "formulas_failed": formulas_failed,
         "formula_details": formula_results,
+        "images": [
+            {
+                "src": item["src"],
+                "kind": "formula" if item in formulas else "graphic",
+                "class": item.get("class", ""),
+                "context": extract_context(ps_html, item["start"], item["end"]),
+            }
+            for item in formulas + graphics
+        ],
         "text": plain_text,
         "text_length": len(plain_text),
     }
@@ -520,7 +541,7 @@ def main():
         print(f"URL: {result['url']}")
         print(f"Formulas: {result['formulas_found']} found, {result['formulas_processed']} processed")
         if result["has_non_formula_images"]:
-            print("⚠ Contains non-formula images (diagrams) — recommend filtering")
+            print("⚠ Contains statement images (diagrams) — requires multimodal model")
         if result["formulas_failed"]:
             print(f"⚠ {result['formulas_failed']} formula(s) failed")
         for fr in result.get("formula_details", []):

--- a/src/kouhai_bot/problems/fetcher.py
+++ b/src/kouhai_bot/problems/fetcher.py
@@ -19,6 +19,7 @@ Returns:
 
 import argparse
 import base64
+import html as html_lib
 import json
 import os
 import re
@@ -134,11 +135,13 @@ def find_all_tex_images(ps_html: str) -> tuple[list[dict], list[dict]]:
         tag = m.group(0)
         src_m = re.search(r'src="([^"]+)"', tag)
         cls_m = re.search(r'class="([^"]+)"', tag)
+        alt_m = re.search(r'alt="([^"]*)"', tag)
         cls = cls_m.group(1) if cls_m else ""
         entry = {
             "tag": tag,
             "src": normalize_image_src(src_m.group(1) if src_m else ""),
             "class": cls,
+            "alt": html_lib.unescape(alt_m.group(1)).strip() if alt_m else "",
             "start": m.start(),
             "end": m.end(),
         }
@@ -346,6 +349,7 @@ def call_vl_with_retry(
 def html_to_text(ps_html: str) -> str:
     """Strip HTML tags, normalize whitespace."""
     text = re.sub(r"<[^>]+>", "", ps_html)
+    text = html_lib.unescape(text)
     text = re.sub(r"\s+", " ", text).strip()
     text = re.sub(r"\$\$\$|\$\$|\$", "", text)
     return text
@@ -441,19 +445,26 @@ def process_problem(
     for i, item in enumerate(ordered_images, 1):
         kind = "formula" if item in formulas else "graphic"
         marker = f"IMAGE_{i}"
+        alt = str(item.get("alt", "") or "").strip()
+        inline_hint = f": {alt}" if kind == "formula" and 0 < len(alt) <= 500 else ""
         image_entries.append({
             "src": item["src"],
             "kind": kind,
             "class": item.get("class", ""),
+            "alt": alt,
             "context": extract_context(ps_html, item["start"], item["end"]),
             "marker": marker,
-            "placeholder": f"[[{marker}: {kind}]]",
+            "placeholder": f"[[{marker}: {kind}{inline_hint}]]",
             "start": item["start"],
             "end": item["end"],
         })
 
     for img_entry in sorted(image_entries, key=lambda x: x["start"], reverse=True):
-        replacement = f'<span class="tex-formula-text">{img_entry["placeholder"]}</span>'
+        replacement = (
+            '<span class="tex-formula-text">'
+            f'{html_lib.escape(img_entry["placeholder"])}'
+            '</span>'
+        )
         result_html = (
             result_html[:img_entry["start"]] + replacement + result_html[img_entry["end"]:]
         )

--- a/src/kouhai_bot/problems/fetcher.py
+++ b/src/kouhai_bot/problems/fetcher.py
@@ -433,20 +433,27 @@ def process_problem(
             "latex": "[DIAGRAM IMAGE]",
         })
 
-    # Replace all image tags with their text representation (reverse order)
+    # Replace image tags with stable inline markers, so multimodal consumers can
+    # align each image with its exact location in the statement text.
     result_html = ps_html
-    all_images = sorted(formulas + graphics, key=lambda x: x["start"], reverse=True)
-    all_results_iter = iter(sorted(
-        formula_results,
-        key=lambda x: _find_match_index(x["src"], formulas + graphics),
-        reverse=True,
-    ))
+    ordered_images = sorted(formulas + graphics, key=lambda x: x["start"])
+    image_entries: list[dict] = []
+    for i, item in enumerate(ordered_images, 1):
+        kind = "formula" if item in formulas else "graphic"
+        marker = f"IMAGE_{i}"
+        image_entries.append({
+            "src": item["src"],
+            "kind": kind,
+            "class": item.get("class", ""),
+            "context": extract_context(ps_html, item["start"], item["end"]),
+            "marker": marker,
+            "placeholder": f"[[{marker}: {kind}]]",
+            "start": item["start"],
+            "end": item["end"],
+        })
 
-    for img_entry in all_images:
-        # Find matching result by src URL
-        matching = [r for r in formula_results if r["src"] == img_entry["src"]]
-        latex = matching[0]["latex"] if matching else "[IMAGE]"
-        replacement = f'<span class="tex-formula-text">({latex})</span>'
+    for img_entry in sorted(image_entries, key=lambda x: x["start"], reverse=True):
+        replacement = f'<span class="tex-formula-text">{img_entry["placeholder"]}</span>'
         result_html = (
             result_html[:img_entry["start"]] + replacement + result_html[img_entry["end"]:]
         )
@@ -463,25 +470,12 @@ def process_problem(
         "formulas_failed": formulas_failed,
         "formula_details": formula_results,
         "images": [
-            {
-                "src": item["src"],
-                "kind": "formula" if item in formulas else "graphic",
-                "class": item.get("class", ""),
-                "context": extract_context(ps_html, item["start"], item["end"]),
-            }
-            for item in formulas + graphics
+            {k: v for k, v in item.items() if k not in {"start", "end"}}
+            for item in image_entries
         ],
         "text": plain_text,
         "text_length": len(plain_text),
     }
-
-
-def _find_match_index(src: str, items: list[dict]) -> int:
-    """Find index of item with matching src, or -1."""
-    for i, item in enumerate(items):
-        if item["src"] == src:
-            return i
-    return -1
 
 
 # ── CLI ─────────────────────────────────────────────────────────────────

--- a/src/kouhai_bot/problems/picker.py
+++ b/src/kouhai_bot/problems/picker.py
@@ -14,7 +14,7 @@ import random
 import re
 import sys
 
-# Import cf_statement for VL-powered formula processing
+# Import cf_statement for Codeforces statement/image extraction
 sys.path.insert(0, os.path.dirname(__file__))
 import fetcher as cf_statement
 import time
@@ -116,6 +116,15 @@ def _load_solved_problem_ids() -> set[str]:
 
 def _problem_id(p: dict) -> str:
     return f"{p['contestId']}{p['index']}"
+
+
+def _multimodal_model_configured() -> bool:
+    try:
+        from ..config import get_config
+
+        return bool(get_config().llm_multimodal_providers)
+    except Exception:
+        return False
 
 
 # ── Selection ───────────────────────────────────────────────────────────
@@ -239,10 +248,11 @@ def _normalize_samples(samples: list[dict]) -> tuple[list[dict], bool]:
 
 def fetch_statement(problem: dict) -> object:
     """
-    Fetch full problem statement from Codeforces using cf_statement with Qwen-VL.
-    Formula images are converted to LaTeX text via VL; non-formula diagrams are filtered.
+    Fetch full problem statement from Codeforces.
+    Image metadata is preserved for multimodal summary/clarify. If images are
+    present but no multimodal model queue is configured, the problem is skipped.
     Returns dict with keys: name, time_limit, memory_limit, description,
-    input, samples, notes. Or None on failure / diagram problem.
+    input, samples, notes, images. Or None on failure / unsupported image problem.
     Caches locally so we only process each problem once.
     """
     contest_id = problem.get("contestId")
@@ -262,20 +272,22 @@ def fetch_statement(problem: dict) -> object:
             if changed:
                 cached["samples"] = normalized_samples
                 cached_changed = True
-        # Detect stale cache (created before VL pipeline existed) —
-        # dry-run to check for images, re-process with VL if needed
-        if not cached.get("_vl_processed"):
+        # Detect stale cache (created before image metadata was cached) —
+        # dry-run to check for images, re-process if needed.
+        if not cached.get("_images_collected"):
             try:
                 dry = cf_statement.process_problem(contest_id, index, vl_backend="none")
                 has_images = dry.get("formulas_found", 0) + dry.get("graphics_found", 0) > 0
                 if has_images:
-                    print(f"[{pid}] stale cache (no VL), re-fetching with Qwen-VL",
+                    print(f"[{pid}] stale cache (no image metadata), re-fetching",
                           file=sys.stderr)
                     os.remove(cache_file)
                     # Fall through to re-process below
                 else:
-                    # Text-only problem, mark as processed and use as-is
+                    # Text-only problem, mark as processed and use as-is.
+                    cached["_images_collected"] = True
                     cached["_vl_processed"] = True
+                    cached.setdefault("images", [])
                     with open(cache_file, "w") as f:
                         json.dump(cached, f, ensure_ascii=False)
                     return cached
@@ -289,24 +301,27 @@ def fetch_statement(problem: dict) -> object:
             if cached_changed:
                 with open(cache_file, "w") as f:
                     json.dump(cached, f, ensure_ascii=False)
+            if cached.get("images") and not _multimodal_model_configured():
+                print(
+                    f"Warning: {pid} cached statement has image(s), but llm.multimodal_model is not configured; skipping",
+                    file=sys.stderr,
+                )
+                return None
             return cached
 
-    # Step 1: Process problem with Qwen-VL for formula recognition
-    cf_result = cf_statement.process_problem(contest_id, index, vl_backend="qwen")
+    # Step 1: Process problem text and collect image metadata.
+    cf_result = cf_statement.process_problem(contest_id, index, vl_backend="none")
 
     if "error" in cf_result:
         print(f"Warning: {pid} cf_statement error: {cf_result['error']}", file=sys.stderr)
         return None
 
-    # Filter: skip problems with non-formula images (diagrams)
-    if cf_result.get("has_non_formula_images"):
-        print(f"Warning: {pid} has non-formula images (diagrams), skipping", file=sys.stderr)
-        return None
-
-    # Filter: skip if any formula failed after retries
-    if cf_result.get("formulas_failed", 0) > 0:
-        print(f"Warning: {pid} has {cf_result['formulas_failed']} failed formula(s), skipping",
-              file=sys.stderr)
+    images = cf_result.get("images", [])
+    if images and not _multimodal_model_configured():
+        print(
+            f"Warning: {pid} has {len(images)} image(s), but llm.multimodal_model is not configured; skipping",
+            file=sys.stderr,
+        )
         return None
 
     # Step 2: Fetch raw HTML for metadata (title, limits, samples)
@@ -335,9 +350,11 @@ def fetch_statement(problem: dict) -> object:
     if m:
         result["memory_limit"] = m.group(1) + "MB"
 
-    # Description: use VL-processed text (formulas converted to LaTeX inline)
+    # Description: text with image placeholders; image metadata is stored separately.
     desc = cf_result.get("text", "")
     result["description"] = desc
+    result["images"] = images if isinstance(images, list) else []
+    result["has_images"] = bool(result["images"])
 
     # Extract Input spec from raw HTML
     inp_m = re.search(
@@ -387,6 +404,7 @@ def fetch_statement(problem: dict) -> object:
 
     # Cache and return
     result["_vl_processed"] = True
+    result["_images_collected"] = True
     with open(cache_file, "w") as f:
         json.dump(result, f, ensure_ascii=False)
 

--- a/src/kouhai_bot/tutorials.py
+++ b/src/kouhai_bot/tutorials.py
@@ -140,6 +140,19 @@ def _load_problem_statement_for_editorial(pid: str) -> str:
     return "\n".join(parts)
 
 
+def _load_problem_images_for_editorial(pid: str) -> list[dict]:
+    path = os.path.join(get_config().data_dir, "statements", f"{pid}.json")
+    if not os.path.isfile(path):
+        return []
+    try:
+        with open(path, encoding="utf-8") as f:
+            stmt = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+    images = stmt.get("images", []) if isinstance(stmt, dict) else []
+    return [item for item in images if isinstance(item, dict) and item.get("src")]
+
+
 def load_tutorial(pid: str) -> dict | None:
     path = os.path.join(get_config().data_dir, "tutorials", f"{pid}.json")
     if not os.path.isfile(path):
@@ -357,10 +370,12 @@ async def get_editorial_zh_for_group(editorial: OfficialEditorial, pid: str) -> 
         return _load_cached_translation(pid), ""
 
     problem_text = _load_problem_statement_for_editorial(pid)
+    problem_images = _load_problem_images_for_editorial(pid)
     translated, model_tag, matched = await translate_editorial_to_zh(
         editorial.text,
         pid=pid,
         problem_text=problem_text,
+        images=problem_images,
     )
     if matched is False:
         mark_no_official_editorial(pid)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2031,7 +2031,7 @@ def test_clarify_image_statement_uses_multimodal_model():
 
     with _all_patches(), \
             patch("kouhai_bot.handlers.cmd.submit.multimodal_model_configured", return_value=True), \
-            patch("kouhai_bot.handlers.shared._download_image_data_url", return_value="data:image/png;base64,abc"):
+            patch("kouhai_bot.handlers.shared._download_image_data_url_async", AsyncMock(return_value="data:image/png;base64,abc")):
         from kouhai_bot.handlers.cmd.clarify import handle
         asyncio.run(handle(**_kwargs(_make_event("/clarify 图是什么意思？"))))
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2013,6 +2013,63 @@ def test_private_clarify_uses_private_problem_summary():
     print("✅ private clarify: uses pid-specific summary")
 
 
+def test_clarify_image_statement_uses_multimodal_model():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _write_statement(PID, {
+        "name": "A. Image Problem",
+        "time_limit": "1s",
+        "memory_limit": "256MB",
+        "description": "Statement refers to the diagram.",
+        "input": "n",
+        "output": "answer",
+        "samples": [{"input": "1", "output": "1"}],
+        "images": [{"src": "https://codeforces.com/image.png", "kind": "graphic"}],
+    })
+    global _deepseek_response
+    _deepseek_response = '{"reply": "图中边表示可走关系。", "reaction": ""}'
+
+    with _all_patches(), \
+            patch("kouhai_bot.handlers.cmd.submit.multimodal_model_configured", return_value=True), \
+            patch("kouhai_bot.handlers.shared._download_image_data_url", return_value="data:image/png;base64,abc"):
+        from kouhai_bot.handlers.cmd.clarify import handle
+        asyncio.run(handle(**_kwargs(_make_event("/clarify 图是什么意思？"))))
+
+    clarify_calls = [call for call in _deepseek_calls if call.get("task") == "multimodal_clarify"]
+    assert clarify_calls, _deepseek_calls
+    content = clarify_calls[-1]["messages"][-1]["content"]
+    assert isinstance(content, list), content
+    assert any(part.get("type") == "image_url" for part in content), content
+    assert "图中边" in _last_text(), _last_text()
+    _cleanup()
+    print("✅ clarify: image statement uses multimodal model")
+
+
+def test_clarify_image_statement_without_multimodal_model_does_not_call_llm():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _write_statement(PID, {
+        "name": "A. Image Problem",
+        "time_limit": "1s",
+        "memory_limit": "256MB",
+        "description": "Statement refers to the diagram.",
+        "input": "n",
+        "output": "answer",
+        "samples": [{"input": "1", "output": "1"}],
+        "images": [{"src": "https://codeforces.com/image.png", "kind": "graphic"}],
+    })
+
+    with _all_patches(), \
+            patch("kouhai_bot.handlers.cmd.submit.multimodal_model_configured", return_value=False):
+        from kouhai_bot.handlers.cmd.clarify import handle
+        asyncio.run(handle(**_kwargs(_make_event("/clarify 图是什么意思？"))))
+
+    assert not _deepseek_calls, _deepseek_calls
+    assert "多模态模型" in _last_text(), _last_text()
+    _cleanup()
+    print("✅ clarify: image statement without multimodal model skips LLM")
+
+
 def test_clarify_llm_failure_shows_admin_message():
     _reset_state()
     _setup_problem()
@@ -4155,21 +4212,21 @@ def test_private_setproblem_non_formula_image_hint():
         from kouhai_bot.handlers.cmd.setproblem import handle
         from kouhai_bot.private_judge import NonFormulaImageProblem
 
-        with patch(
-            "kouhai_bot.handlers.cmd.setproblem.resolve_problem_by_pid",
-            side_effect=NonFormulaImageProblem("1065C"),
-        ):
+        async def _raise_image_problem(func, *args):
+            raise NonFormulaImageProblem("1065C")
+
+        with patch("kouhai_bot.handlers.cmd.setproblem.asyncio.to_thread", _raise_image_problem):
             asyncio.run(handle(**_kwargs(_make_private_event("/setproblem 1065C"))))
 
     private_text = "\n".join(
         " ".join(seg.get("data", {}).get("text", "") for seg in item["message"] if seg.get("type") == "text")
         for item in _private_sent
     )
-    assert "非公式图片" in private_text, private_text
-    assert "处理能力有限" in private_text, private_text
+    assert "包含图片" in private_text, private_text
+    assert "多模态模型" in private_text, private_text
     assert "换一道题" in private_text, private_text
     _cleanup()
-    print("✅ private setproblem: explains non-formula image limitation")
+    print("✅ private setproblem: explains missing multimodal image support")
 
 
 def test_build_problem_card_payload_revalidates_cached_statement():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,11 +80,27 @@ def test_config_requires_general_model_queue(monkeypatch, tmp_path):
         _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
 
 
-def test_config_requires_qwen_model(monkeypatch, tmp_path):
+def test_config_allows_missing_qwen_model(monkeypatch, tmp_path):
     data = yaml.safe_load(_make_yaml())
     data["qwen"]["model"] = ""
-    with pytest.raises(RuntimeError, match="qwen.model"):
-        _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
+    cfg = _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
+    assert cfg.qwen_model == ""
+
+
+def test_config_loads_optional_multimodal_model_queue(monkeypatch, tmp_path):
+    data = yaml.safe_load(_make_yaml())
+    data["llm"]["multimodal_model"] = [
+        {
+            "name": "mmx",
+            "api_key": "sk-mm",
+            "base_url": "http://localhost:8080/v1",
+            "model": "mmx-vision",
+            "model_tag": "『MMx』",
+        }
+    ]
+    cfg = _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
+    assert [p.name for p in cfg.llm_multimodal_providers] == ["mmx"]
+    assert cfg.llm_multimodal_providers[0].model == "mmx-vision"
 
 
 def test_config_requires_provider_name(monkeypatch, tmp_path):

--- a/tests/test_fetcher_config.py
+++ b/tests/test_fetcher_config.py
@@ -24,3 +24,30 @@ def test_qwen_config_uses_yaml_config_when_env_missing(monkeypatch):
         "https://dashscope.example/v1",
         "qwen-vl-test",
     )
+
+
+def test_process_problem_marks_inline_image_position(monkeypatch):
+    problem_html = (
+        '<div class="problem-statement">'
+        '<p>Choose x <img class="tex-formula" src="/predownloaded/a.png"> such that y.</p>'
+        "</div><script>"
+    )
+    monkeypatch.setattr(
+        fetcher,
+        "fetch_problem_html",
+        lambda contest_id, index: (problem_html, f"{contest_id}{index}"),
+    )
+
+    result = fetcher.process_problem(1, "A", vl_backend="none")
+
+    assert "Choose x [[IMAGE_1: formula]] such that y." in result["text"]
+    assert result["images"] == [
+        {
+            "src": "https://codeforces.com/predownloaded/a.png",
+            "kind": "formula",
+            "class": "tex-formula",
+            "context": "Choose x such that y.",
+            "marker": "IMAGE_1",
+            "placeholder": "[[IMAGE_1: formula]]",
+        }
+    ]

--- a/tests/test_fetcher_config.py
+++ b/tests/test_fetcher_config.py
@@ -29,7 +29,7 @@ def test_qwen_config_uses_yaml_config_when_env_missing(monkeypatch):
 def test_process_problem_marks_inline_image_position(monkeypatch):
     problem_html = (
         '<div class="problem-statement">'
-        '<p>Choose x <img class="tex-formula" src="/predownloaded/a.png"> such that y.</p>'
+        '<p>Choose x <img class="tex-formula" src="/predownloaded/a.png" alt="a_i &lt; b_i"> such that y.</p>'
         "</div><script>"
     )
     monkeypatch.setattr(
@@ -40,14 +40,15 @@ def test_process_problem_marks_inline_image_position(monkeypatch):
 
     result = fetcher.process_problem(1, "A", vl_backend="none")
 
-    assert "Choose x [[IMAGE_1: formula]] such that y." in result["text"]
+    assert "Choose x [[IMAGE_1: formula: a_i < b_i]] such that y." in result["text"]
     assert result["images"] == [
         {
             "src": "https://codeforces.com/predownloaded/a.png",
             "kind": "formula",
             "class": "tex-formula",
+            "alt": "a_i < b_i",
             "context": "Choose x such that y.",
             "marker": "IMAGE_1",
-            "placeholder": "[[IMAGE_1: formula]]",
+            "placeholder": "[[IMAGE_1: formula: a_i < b_i]]",
         }
     ]

--- a/tests/test_newproblem_notes.py
+++ b/tests/test_newproblem_notes.py
@@ -18,7 +18,7 @@ def test_build_notes_message_translates_and_formats():
         ) as mocked_translate:
             result = await newproblem._build_notes_message(stmt)
         assert result == "样例解释：\n第一行\n第二行"
-        mocked_translate.assert_awaited_once_with("Line A\nLine B")
+        mocked_translate.assert_awaited_once_with("Line A\nLine B", [])
 
     asyncio.run(_run())
 

--- a/tests/test_picker_selection.py
+++ b/tests/test_picker_selection.py
@@ -90,6 +90,60 @@ def test_select_problem_raises_when_every_candidate_is_solved(monkeypatch, tmp_p
         picker.select_problem()
 
 
+def test_fetch_statement_skips_image_statement_without_multimodal_model(monkeypatch, tmp_path):
+    _configure_picker_tmp(tmp_path)
+
+    monkeypatch.setattr(picker, "_multimodal_model_configured", lambda: False)
+    monkeypatch.setattr(picker.cf_statement, "process_problem", lambda contest_id, index, vl_backend="none": {
+        "pid": f"{contest_id}{index}",
+        "text": "Statement [DIAGRAM]",
+        "formulas_found": 0,
+        "graphics_found": 1,
+        "images": [{"src": "https://codeforces.com/image.png", "kind": "graphic"}],
+    })
+
+    assert picker.fetch_statement(_problem(1, "A")) is None
+
+
+def test_fetch_statement_caches_image_metadata_with_multimodal_model(monkeypatch, tmp_path):
+    _configure_picker_tmp(tmp_path)
+
+    monkeypatch.setattr(picker, "_multimodal_model_configured", lambda: True)
+    monkeypatch.setattr(picker.cf_statement, "process_problem", lambda contest_id, index, vl_backend="none": {
+        "pid": f"{contest_id}{index}",
+        "text": "Statement [DIAGRAM]",
+        "formulas_found": 0,
+        "graphics_found": 1,
+        "images": [{"src": "https://codeforces.com/image.png", "kind": "graphic"}],
+    })
+
+    class _Resp:
+        text = (
+            '<div class="problem-statement">'
+            '<div class="title">A. Image</div>'
+            '<div class="time-limit">1 second</div>'
+            '<div class="memory-limit">256 megabytes</div>'
+            '<div class="section-title">Input</div>n'
+            '<pre>1</pre><pre>1</pre>'
+            "</div><script"
+        )
+
+        def raise_for_status(self):
+            return None
+
+    class _Scraper:
+        def get(self, url, timeout=30):
+            return _Resp()
+
+    monkeypatch.setattr(picker, "_get_scraper", lambda: _Scraper())
+
+    stmt = picker.fetch_statement(_problem(1, "A"))
+
+    assert stmt["images"] == [{"src": "https://codeforces.com/image.png", "kind": "graphic"}]
+    assert stmt["has_images"] is True
+    assert stmt["_images_collected"] is True
+
+
 def test_picker_cli_reveal_reads_configured_data_dir(tmp_path):
     data_dir = tmp_path / "custom-data"
     group_dir = data_dir / "groups" / "g1"

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -280,6 +280,78 @@ def test_general_model_tasks_preserve_provider_model_tag():
     assert calls[0]["model"] == "general"
 
 
+def test_multimodal_task_uses_multimodal_provider_and_preserves_image_content():
+    provider = LlmProviderConfig(
+        name="mmx",
+        api_key="sk-test",
+        base_url="http://localhost:8080/v1",
+        model="mmx-vision",
+        model_tag="『MMx』",
+    )
+    cfg = _openai_cfg(llm_multimodal_providers=[provider])
+    content = [
+        {"type": "text", "text": "Read this statement."},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+    ]
+    calls = []
+
+    async def fake_once(session, **kwargs):
+        calls.append(kwargs["payload"].copy())
+        return _ChatCompletionAttempt(text="OK", retryable=False, retry_after_sec=None)
+
+    with patch("kouhai_bot.llm.get_config", return_value=cfg), \
+            patch("kouhai_bot.llm.aiohttp.ClientSession", _DummySession), \
+            patch("kouhai_bot.llm._post_chat_completion_once", side_effect=fake_once):
+        result = asyncio.run(call_chat_completion_result(
+            [{"role": "user", "content": content}],
+            task="multimodal_clarify",
+        ))
+
+    assert result.text == "OK"
+    assert result.model == "mmx-vision"
+    assert result.model_tag == "『MMx』"
+    assert calls[0]["messages"][0]["content"] == content
+    assert "max_tokens" not in calls[0]
+    assert "max_completion_tokens" not in calls[0]
+
+
+def test_summarize_problem_with_images_uses_multimodal_task():
+    provider = LlmProviderConfig(
+        name="mmx",
+        api_key="sk-test",
+        base_url="http://localhost:8080/v1",
+        model="mmx-vision",
+        model_tag="『MMx』",
+    )
+    cfg = _openai_cfg(llm_multimodal_providers=[provider], summary_timeout_sec=123)
+    calls = []
+
+    async def fake_call(messages, **kwargs):
+        calls.append({"messages": messages, **kwargs})
+        return ChatCompletionResult(
+            text=json.dumps({"summary": "带图题意"}),
+            model_tag="『MMx』",
+        )
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared._download_image_data_url", return_value="data:image/png;base64,abc"), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call):
+        summary, tag = asyncio.run(summarize_problem(
+            "stmt",
+            "input",
+            "limits",
+            [{"src": "https://codeforces.com/p.png", "kind": "graphic"}],
+        ))
+
+    assert summary == "带图题意"
+    assert tag == "『MMx』"
+    assert calls[0]["task"] == "multimodal_summary"
+    content = calls[0]["messages"][1]["content"]
+    assert isinstance(content, list)
+    assert content[0]["type"] == "text"
+    assert content[-1] == {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}}
+
+
 def test_task_entrypoints_are_blackbox_except_model_class_and_tag():
     smart_provider = LlmProviderConfig(
         name="deepseek-smart",

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -1152,6 +1152,31 @@ def test_non_streaming_chat_completion_strips_leaked_thinking_tag():
     assert result.retryable is False
 
 
+def test_non_streaming_chat_completion_drops_unclosed_leaked_thinking():
+    response = _DummyResponse(json_data={
+        "choices": [
+            {
+                "message": {
+                    "content": "Visible prefix\n<think>hidden reasoning without close"
+                }
+            }
+        ]
+    })
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="openai",
+        base_url="https://api.openai.com/v1",
+        headers={},
+        payload={},
+        timeout=120,
+    ))
+
+    assert result.text == "Visible prefix"
+    assert result.retryable is False
+
+
 def test_non_streaming_chat_completion_retries_when_only_leaked_thinking(caplog):
     caplog.set_level("WARNING", logger="kouhai-bot.llm")
     response = _DummyResponse(json_data={
@@ -1259,6 +1284,32 @@ def test_streaming_chat_completion_strips_leaked_thinking_blocks():
     ))
 
     assert result.text == "Visible answer"
+    assert result.retryable is False
+
+
+def test_streaming_chat_completion_drops_unclosed_leaked_thinking_block():
+    response = _DummyResponse(lines=[
+        'data: {"choices":[{"delta":{"content":"Visible prefix"}}]}\n',
+        '\n',
+        'data: {"choices":[{"delta":{"content":"<think>hidden"}}]}\n',
+        '\n',
+        'data: {"choices":[{"delta":{"content":" reasoning without close"}}]}\n',
+        '\n',
+        'data: [DONE]\n',
+        '\n',
+    ])
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="qwen",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        headers={},
+        payload={"stream": True},
+        timeout=120,
+    ))
+
+    assert result.text == "Visible prefix"
     assert result.retryable is False
 
 

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -10,6 +10,7 @@ from kouhai_bot.config import BotConfig
 from kouhai_bot.llm_config import LlmProviderConfig
 from kouhai_bot.handlers.shared import (
     build_judge_messages,
+    build_multimodal_user_content,
     build_second_judge_messages,
     _build_summary_prompt,
     _build_summary_repair_prompt,
@@ -334,7 +335,7 @@ def test_summarize_problem_with_images_uses_multimodal_task():
         )
 
     with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
-            patch("kouhai_bot.handlers.shared._download_image_data_url", return_value="data:image/png;base64,abc"), \
+            patch("kouhai_bot.handlers.shared._download_image_data_url_async", AsyncMock(return_value="data:image/png;base64,abc")), \
             patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call):
         summary, tag = asyncio.run(summarize_problem(
             "stmt",
@@ -368,7 +369,7 @@ def test_translate_sample_notes_with_images_uses_multimodal_task():
         return ChatCompletionResult(text="样例图解释", model_tag="『MMx』")
 
     with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
-            patch("kouhai_bot.handlers.shared._download_image_data_url", return_value="data:image/png;base64,abc"), \
+            patch("kouhai_bot.handlers.shared._download_image_data_url_async", AsyncMock(return_value="data:image/png;base64,abc")), \
             patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call):
         text, tag = asyncio.run(translate_sample_notes(
             "The diagram is [[IMAGE_1: graphic]].",
@@ -403,7 +404,7 @@ def test_translate_editorial_with_images_uses_multimodal_task():
         )
 
     with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
-            patch("kouhai_bot.handlers.shared._download_image_data_url", return_value="data:image/png;base64,abc"), \
+            patch("kouhai_bot.handlers.shared._download_image_data_url_async", AsyncMock(return_value="data:image/png;base64,abc")), \
             patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call):
         translated, tag, matched = asyncio.run(translate_editorial_to_zh(
             "Official editorial",
@@ -420,6 +421,58 @@ def test_translate_editorial_with_images_uses_multimodal_task():
     assert isinstance(content, list)
     assert "official_editorial" in content[0]["text"]
     assert "IMAGE_1" in content[1]["text"]
+
+
+def test_multimodal_content_prioritizes_images_without_text_fallback():
+    images = [
+        {
+            "src": f"https://codeforces.com/{idx}.png",
+            "kind": "formula",
+            "marker": f"IMAGE_{idx}",
+            "placeholder": f"[[IMAGE_{idx}: formula: x_{idx}]]",
+            "alt": f"x_{idx}",
+        }
+        for idx in range(1, 9)
+    ] + [
+        {
+            "src": "https://codeforces.com/9.png",
+            "kind": "graphic",
+            "marker": "IMAGE_9",
+            "placeholder": "[[IMAGE_9: graphic]]",
+        },
+        {
+            "src": "https://codeforces.com/10.png",
+            "kind": "formula",
+            "marker": "IMAGE_10",
+            "placeholder": "[[IMAGE_10: formula]]",
+        },
+    ]
+
+    with patch(
+        "kouhai_bot.handlers.shared._download_image_data_url_async",
+        AsyncMock(side_effect=lambda url: f"data:image/png;base64,{url.rsplit('/', 1)[-1]}"),
+    ) as download:
+        content = asyncio.run(build_multimodal_user_content("statement", images))
+
+    image_parts = [part for part in content if part.get("type") == "image_url"]
+    attached_labels = "\n".join(
+        content[idx]["text"]
+        for idx in range(1, len(content) - 1, 2)
+        if content[idx].get("type") == "text"
+    )
+    omitted_note = content[-1]["text"]
+    downloaded_urls = {call.args[0] for call in download.call_args_list}
+
+    assert len(image_parts) == 8
+    assert "IMAGE_9" in attached_labels
+    assert "IMAGE_10" in attached_labels
+    assert "IMAGE_7" not in attached_labels
+    assert "IMAGE_8" not in attached_labels
+    assert "IMAGE_7" in omitted_note
+    assert "IMAGE_8" in omitted_note
+    assert "未随请求发送" in omitted_note
+    assert "https://codeforces.com/7.png" not in downloaded_urls
+    assert "https://codeforces.com/8.png" not in downloaded_urls
 
 
 def test_task_entrypoints_are_blackbox_except_model_class_and_tag():

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -352,6 +352,76 @@ def test_summarize_problem_with_images_uses_multimodal_task():
     assert content[-1] == {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}}
 
 
+def test_translate_sample_notes_with_images_uses_multimodal_task():
+    provider = LlmProviderConfig(
+        name="mmx",
+        api_key="sk-test",
+        base_url="http://localhost:8080/v1",
+        model="mmx-vision",
+        model_tag="『MMx』",
+    )
+    cfg = _openai_cfg(llm_multimodal_providers=[provider], summary_timeout_sec=123)
+    calls = []
+
+    async def fake_call(messages, **kwargs):
+        calls.append({"messages": messages, **kwargs})
+        return ChatCompletionResult(text="样例图解释", model_tag="『MMx』")
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared._download_image_data_url", return_value="data:image/png;base64,abc"), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call):
+        text, tag = asyncio.run(translate_sample_notes(
+            "The diagram is [[IMAGE_1: graphic]].",
+            [{"src": "https://codeforces.com/p.png", "kind": "graphic", "marker": "IMAGE_1"}],
+        ))
+
+    assert text == "样例图解释"
+    assert tag == "『MMx』"
+    assert calls[0]["task"] == "multimodal_summary"
+    content = calls[0]["messages"][1]["content"]
+    assert isinstance(content, list)
+    assert "IMAGE_1" in content[1]["text"]
+    assert content[-1] == {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}}
+
+
+def test_translate_editorial_with_images_uses_multimodal_task():
+    provider = LlmProviderConfig(
+        name="mmx",
+        api_key="sk-test",
+        base_url="http://localhost:8080/v1",
+        model="mmx-vision",
+        model_tag="『MMx』",
+    )
+    cfg = _openai_cfg(llm_multimodal_providers=[provider], summary_timeout_sec=123)
+    calls = []
+
+    async def fake_call(messages, **kwargs):
+        calls.append({"messages": messages, **kwargs})
+        return ChatCompletionResult(
+            text=json.dumps({"matched": "yes", "result": "中文题解"}),
+            model_tag="『MMx』",
+        )
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared._download_image_data_url", return_value="data:image/png;base64,abc"), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call):
+        translated, tag, matched = asyncio.run(translate_editorial_to_zh(
+            "Official editorial",
+            pid="1A",
+            problem_text="Problem uses [[IMAGE_1: formula]].",
+            images=[{"src": "https://codeforces.com/f.png", "kind": "formula", "marker": "IMAGE_1"}],
+        ))
+
+    assert translated == "中文题解"
+    assert tag == "『MMx』"
+    assert matched is True
+    assert calls[0]["task"] == "multimodal_summary"
+    content = calls[0]["messages"][1]["content"]
+    assert isinstance(content, list)
+    assert "official_editorial" in content[0]["text"]
+    assert "IMAGE_1" in content[1]["text"]
+
+
 def test_task_entrypoints_are_blackbox_except_model_class_and_tag():
     smart_provider = LlmProviderConfig(
         name="deepseek-smart",
@@ -379,6 +449,12 @@ def test_task_entrypoints_are_blackbox_except_model_class_and_tag():
         text = "OK"
         if payload.get("response_format") == {"type": "json_object"}:
             user_content = payload["messages"][-1]["content"]
+            if isinstance(user_content, list):
+                user_content = "".join(
+                    item.get("text", "")
+                    for item in user_content
+                    if isinstance(item, dict)
+                )
             system_content = payload["messages"][0]["content"]
             if "official_editorial" in user_content:
                 text = json.dumps({"matched": "yes", "result": "中文题解"})


### PR DESCRIPTION
## Summary
- add optional `llm.multimodal_model` provider queue for image-bearing problem summaries and `/clarify`
- preserve Codeforces statement image metadata instead of requiring Qwen-VL formula OCR or skipping diagrams unconditionally
- route text-only summaries/clarify through existing general providers, and image tasks through multimodal providers
- make legacy Qwen-VL config optional and update docs/config examples

## Validation
- `/home/nerovix/kouhai-bot/.venv/bin/python -m compileall -q src tests`
- `/home/nerovix/kouhai-bot/.venv/bin/python -m pytest -q tests/test_config.py tests/test_fetcher_config.py tests/test_shared.py tests/test_picker_selection.py tests/test_picker_samples.py tests/test_commands.py::test_clarify_with_problem tests/test_commands.py::test_private_clarify_uses_private_problem_summary tests/test_commands.py::test_clarify_image_statement_uses_multimodal_model tests/test_commands.py::test_clarify_image_statement_without_multimodal_model_does_not_call_llm tests/test_commands.py::test_build_problem_card_payload_revalidates_cached_statement tests/test_commands.py::test_private_setproblem_non_formula_image_hint`