### PR TITLE
Fix leaked thinking tag stripping

### DIFF
--- a/src/kouhai_bot/handlers/cmd/stubs.py
+++ b/src/kouhai_bot/handlers/cmd/stubs.py
@@ -10,6 +10,7 @@ from ..shared import (
     high_difficulty_notice,
     is_already_solved,
     load_scoreboard,
+    sanitize_cached_problem_card_payload,
 )
 from ...napcat.client import (
     build_plain_message,
@@ -107,6 +108,7 @@ async def handle_problem(group_id: int, user_id: int, sender: dict,
             pid = str(daily_msg.get("pid", "") or "")
             if pid != current_pid:
                 raise ValueError(f"stale daily_msg pid={pid}, current={current_pid}")
+            daily_msg = sanitize_cached_problem_card_payload(daily_msg)[0]
             msg_id = daily_msg.get("msg_id")
             if msg_id:
                 fwd_nodes = [{"type": "node", "data": {"id": str(msg_id)}}]
@@ -145,7 +147,7 @@ async def handle_problem(group_id: int, user_id: int, sender: dict,
                         save_problem_card_ref(group_id, fwd_resp, pid, "problem_resend")
                     daily_msg.update(node_payload)
                     daily_msg["fwd_message_id"] = fwd_resp
-                    with open(daily_msg_path, "w") as f:
+                    with open(daily_msg_path, "w", encoding="utf-8") as f:
                         json.dump(daily_msg, f, ensure_ascii=False, indent=2)
                     await _send_high_difficulty_notice_group(group_id, current_problem)
                     await _send_solved_problem_hint(group_id, nickname)

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -384,14 +384,17 @@ def get_problem_summary(group_id: int, pid: str) -> str:
     data = load_problem_summaries(group_id)
     item = data.get(pid)
     if isinstance(item, dict):
-        return item.get("summary_zh", "") or ""
+        return strip_leaked_thinking(item.get("summary_zh", "") or "")
     if isinstance(item, str):
-        return item
+        return strip_leaked_thinking(item)
     return ""
 
 
 def save_problem_summary(group_id: int, pid: str, summary_zh: str) -> None:
     if not pid or not summary_zh:
+        return
+    summary_zh = strip_leaked_thinking(summary_zh)
+    if not summary_zh:
         return
     data = load_problem_summaries(group_id)
     data[pid] = {
@@ -399,6 +402,30 @@ def save_problem_summary(group_id: int, pid: str, summary_zh: str) -> None:
     }
     with open(_problem_summary_file(group_id), "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def sanitize_cached_problem_card_payload(data: dict) -> tuple[dict, bool]:
+    """Scrub cached LLM text before rebuilding user-visible problem cards.
+
+    If any cached text changes, stale message-node ids must not be reused because
+    forwarding them would resend the original unsanitized message body.
+    """
+    if not isinstance(data, dict):
+        return {}, False
+    cleaned = dict(data)
+    changed = False
+    for key in ("post_msg", "notes_message"):
+        value = cleaned.get(key)
+        if not isinstance(value, str):
+            continue
+        stripped = strip_leaked_thinking(value)
+        if stripped != value:
+            cleaned[key] = stripped
+            changed = True
+    if changed:
+        for key in ("msg_id", "sample_msg_ids", "note_msg_id", "snake_msg_id", "fwd_message_id"):
+            cleaned.pop(key, None)
+    return cleaned, changed
 
 
 def load_problem_card_refs(group_id: int) -> dict[str, dict]:

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -16,7 +16,7 @@ import time
 from pathlib import Path
 
 from ..config import get_config
-from ..llm import ChatCompletionResult, chat_completion
+from ..llm import ChatCompletionResult, chat_completion, strip_leaked_thinking
 
 logger = logging.getLogger("kouhai-bot.shared")
 
@@ -102,6 +102,7 @@ def robust_json_parse(text: str) -> dict:
     """Parse JSON, handling markdown fences, trailing commas, and more."""
     if not text:
         return {}
+    text = strip_leaked_thinking(text)
     # Strip markdown fences
     text = re.sub(r'^```(?:json)?\s*\n?', '', text.strip())
     text = re.sub(r'\n?```\s*$', '', text.strip())
@@ -142,6 +143,16 @@ _JSON_REPAIR_MAX_ATTEMPTS = 3
 _JSON_REPAIR_MAX_CHARS = 12000
 
 
+def _strip_leaked_thinking_from_json(value):
+    if isinstance(value, str):
+        return strip_leaked_thinking(value)
+    if isinstance(value, dict):
+        return {k: _strip_leaked_thinking_from_json(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_strip_leaked_thinking_from_json(v) for v in value]
+    return value
+
+
 def _json_repair_prompt(text: str, expected_schema: str, parse_note: str) -> str:
     payload = {
         "expected_schema": expected_schema or "JSON object",
@@ -171,10 +182,10 @@ async def parse_json_with_llm_repair(
     Returns (parsed_object, repair_model_tag). repair_model_tag is non-empty only
     when a repair model response was used.
     """
-    current = (text or "").strip()
+    current = strip_leaked_thinking(text or "")
     parsed = robust_json_parse(current)
     if parsed:
-        return parsed, ""
+        return _strip_leaked_thinking_from_json(parsed), ""
     if not current:
         return {}, ""
 
@@ -212,10 +223,10 @@ async def parse_json_with_llm_repair(
         if not result.text:
             parse_note = f"repair model returned no text ({result.failure_kind or 'unknown failure'})"
             continue
-        current = result.text.strip()
+        current = strip_leaked_thinking(result.text)
         parsed = robust_json_parse(current)
         if parsed:
-            return parsed, last_tag
+            return _strip_leaked_thinking_from_json(parsed), last_tag
         parse_note = "repair output was still not valid JSON"
 
     logger.warning(

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -16,11 +16,12 @@ from .config import get_config
 logger = logging.getLogger("kouhai-bot.llm")
 
 _THINK_TAG_NAMES_RE = r"(?:think(?:ing)?|thoughts?|reasoning|analysis|cot|chain[-_]?of[-_]?thought)"
+_ORPHAN_THINK_TAG_NAMES_RE = r"(?:think(?:ing)?)"
 _THINK_BLOCK_RE = re.compile(
     rf"<\s*(?P<tag>{_THINK_TAG_NAMES_RE})\b[^>]*>.*?</\s*(?P=tag)\s*>",
     re.IGNORECASE | re.DOTALL,
 )
-_THINK_TAG_RE = re.compile(rf"</?\s*{_THINK_TAG_NAMES_RE}\b[^>]*>", re.IGNORECASE)
+_THINK_TAG_RE = re.compile(rf"</?\s*{_ORPHAN_THINK_TAG_NAMES_RE}\b[^>]*>", re.IGNORECASE)
 
 
 @dataclass(frozen=True)

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -15,13 +15,23 @@ from .config import get_config
 
 logger = logging.getLogger("kouhai-bot.llm")
 
-_THINK_TAG_NAMES_RE = r"(?:think(?:ing)?|thoughts?|reasoning|analysis|cot|chain[-_]?of[-_]?thought)"
-_ORPHAN_THINK_TAG_NAMES_RE = r"(?:think(?:ing)?)"
+# Known thinking-tag names that may leak from LLM providers.
+# _THINK_BLOCK_RE strips matched <tag>...</tag> pairs for ALL names.
+# _THINK_TAG_RE strips unmatched orphan tags only for the most common
+# leak variants (think/thinking) to avoid false positives on words
+# like "analysis" or "reasoning" that appear in normal text.
+_THINK_TAG_NAMES = (
+    "think", "thinking", "thought", "thoughts",
+    "reasoning", "analysis", "cot", "chain-of-thought", "chain_of_thought",
+)
+_THINK_TAG_NAMES_RE = "|".join(_THINK_TAG_NAMES)
+_ORPHAN_TAG_NAMES_RE = "think(?:ing)?"
+
 _THINK_BLOCK_RE = re.compile(
     rf"<\s*(?P<tag>{_THINK_TAG_NAMES_RE})\b[^>]*>.*?</\s*(?P=tag)\s*>",
     re.IGNORECASE | re.DOTALL,
 )
-_THINK_TAG_RE = re.compile(rf"</?\s*{_ORPHAN_THINK_TAG_NAMES_RE}\b[^>]*>", re.IGNORECASE)
+_THINK_TAG_RE = re.compile(rf"</?\s*{_ORPHAN_TAG_NAMES_RE}\b[^>]*>", re.IGNORECASE)
 
 
 @dataclass(frozen=True)

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -15,8 +15,12 @@ from .config import get_config
 
 logger = logging.getLogger("kouhai-bot.llm")
 
-_THINK_BLOCK_RE = re.compile(r"<think\b[^>]*>.*?</think\s*>", re.IGNORECASE | re.DOTALL)
-_THINK_TAG_RE = re.compile(r"</?think\b[^>]*>", re.IGNORECASE)
+_THINK_TAG_NAMES_RE = r"(?:think(?:ing)?|thoughts?|reasoning|analysis|cot|chain[-_]?of[-_]?thought)"
+_THINK_BLOCK_RE = re.compile(
+    rf"<\s*(?P<tag>{_THINK_TAG_NAMES_RE})\b[^>]*>.*?</\s*(?P=tag)\s*>",
+    re.IGNORECASE | re.DOTALL,
+)
+_THINK_TAG_RE = re.compile(rf"</?\s*{_THINK_TAG_NAMES_RE}\b[^>]*>", re.IGNORECASE)
 
 
 @dataclass(frozen=True)

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -25,6 +25,7 @@ from .handlers.shared import (
     load_scoreboard,
     save_problem_summary,
     save_problem_card_ref,
+    sanitize_cached_problem_card_payload,
     summarize_problem,
     translate_sample_notes,
 )
@@ -589,7 +590,7 @@ def load_current_group_card_payload(group_id: int, pid: str) -> dict | None:
         return None
     if not isinstance(data, dict) or str(data.get("pid", "") or "") != str(pid or ""):
         return None
-    return data
+    return sanitize_cached_problem_card_payload(data)[0]
 
 
 async def _send_forward_nodes_private(user_id: int, node_ids: list[str]) -> int | None:

--- a/src/kouhai_bot/tutorials.py
+++ b/src/kouhai_bot/tutorials.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from .config import get_config
 from .handlers.shared import translate_editorial_to_zh
+from .llm import strip_leaked_thinking
 
 MIN_EDITORIAL_LEN = 80
 _REVIEW_EDITORIAL_MAX_LEN = 12000
@@ -273,12 +274,13 @@ def _load_cached_translation(pid: str) -> str:
         return ""
     try:
         with open(path, encoding="utf-8") as f:
-            return f.read().strip()
+            return strip_leaked_thinking(f.read().strip())
     except OSError:
         return ""
 
 
 def _save_cached_translation(pid: str, text: str) -> None:
+    text = strip_leaked_thinking(text)
     path = _translation_cache_path(pid)
     with open(path, "w", encoding="utf-8") as f:
         f.write(text)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2179,6 +2179,44 @@ def test_problem_rebuilds_forward_card_when_node_ids_are_stale():
     print("✅ problem: rebuilds stale forward card")
 
 
+def test_problem_rebuilds_forward_card_when_cached_text_has_thinking_tags():
+    _reset_state()
+    _setup_problem()
+    _write_group_file(GID, "daily_msg.json", {
+        "msg_id": 1111,
+        "note_msg_id": 1112,
+        "pid": PID,
+        "post_msg": "题目正文\n<thinking>internal summary</thinking>可见摘要",
+        "sample_messages": ["样例 1\nInput:\n1\n\nOutput:\n2"],
+        "notes_message": "样例解释：\n<analysis>hidden note</analysis>可见解释",
+        "snake_enabled": True,
+    })
+
+    with _all_patches(), patch("kouhai_bot.handlers.cmd.newproblem.asyncio.sleep", AsyncMock()):
+        from kouhai_bot.handlers.cmd.stubs import handle_problem
+        asyncio.run(handle_problem(**_kwargs(_make_event("/problem"))))
+
+    assert _forwarded, f"Expected rebuilt forward card, got {_forwarded}"
+    forwarded_ids = [
+        node.get("data", {}).get("id")
+        for node in _forwarded[0]["messages"]
+        if isinstance(node, dict)
+    ]
+    assert "1111" not in forwarded_ids and "1112" not in forwarded_ids, _forwarded
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent)
+    assert "internal summary" not in private_text
+    assert "hidden note" not in private_text
+    assert "可见摘要" in private_text
+    assert "可见解释" in private_text
+    with open(os.path.join(_data_dir(), "groups", str(GID), "daily_msg.json"), encoding="utf-8") as f:
+        saved = json.load(f)
+    assert "thinking" not in saved["post_msg"]
+    assert "analysis" not in saved["notes_message"]
+    assert saved["msg_id"] != 1111
+    _cleanup()
+    print("✅ problem: sanitizes cached thinking tags before resend")
+
+
 def test_problem_ignores_stale_daily_msg_pid():
     _reset_state()
     _setup_problem_for(GID, PID)
@@ -4205,6 +4243,41 @@ def test_private_problem_card_hides_original_problem_identity():
     assert "2600" not in post_msg and "rating" not in post_msg, post_msg
     _cleanup()
     print("✅ private problem card: hides original identity")
+
+
+def test_private_problem_card_strips_cached_problem_summary_thinking_tags():
+    _reset_state()
+    _write_statement(PID, {
+        "name": "D. Superhero's Job",
+        "time_limit": "2s",
+        "memory_limit": "256MB",
+        "description": "Statement text",
+        "input": "n",
+        "output": "answer",
+        "samples": [],
+    })
+    _write_group_file(GID, "problem_summaries.json", {
+        PID: {"summary_zh": "<reasoning>hidden cached summary</reasoning>SUMMARY_ONLY"},
+    })
+
+    with _all_patches():
+        from kouhai_bot.private_judge import build_problem_card_payload
+
+        payload = asyncio.run(build_problem_card_payload(GID, {
+            "today": PID,
+            "contestId": 542,
+            "index": "D",
+            "name": "Superhero's Job",
+            "rating": 2600,
+            "tags": [],
+        }))
+
+    post_msg = payload["post_msg"]
+    assert "SUMMARY_ONLY" in post_msg, post_msg
+    assert "hidden cached summary" not in post_msg, post_msg
+    assert "reasoning" not in post_msg, post_msg
+    _cleanup()
+    print("✅ private problem card: strips cached summary thinking tags")
 
 
 def test_private_problem_card_high_difficulty_warns_after_card():

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -24,7 +24,12 @@ from kouhai_bot.handlers.shared import (
     translate_editorial_to_zh,
     translate_sample_notes,
 )
-from kouhai_bot.llm import ChatCompletionResult, _ChatCompletionAttempt, _post_chat_completion_once
+from kouhai_bot.llm import (
+    ChatCompletionResult,
+    _ChatCompletionAttempt,
+    _post_chat_completion_once,
+    strip_leaked_thinking,
+)
 
 
 def test_judge_prompt_rejects_repaired_greedy_and_unbatched_simulation():
@@ -526,6 +531,27 @@ def test_parse_json_with_llm_repair_retries_until_valid_json():
     assert outputs == []
 
 
+def test_parse_json_with_llm_repair_strips_leaked_thinking_inside_valid_json():
+    raw = json.dumps({
+        "reply": "<thinking>hidden chain of thought</thinking>可以回答这个边界。",
+        "reaction": "",
+        "nested": ["<reasoning>internal</reasoning>visible"],
+    }, ensure_ascii=False)
+
+    parsed, tag = asyncio.run(parse_json_with_llm_repair(
+        raw,
+        expected_schema='{ "reply": string, "reaction": string }',
+        max_attempts=0,
+    ))
+
+    assert parsed == {
+        "reply": "可以回答这个边界。",
+        "reaction": "",
+        "nested": ["visible"],
+    }
+    assert tag == ""
+
+
 def test_judge_submission_repairs_malformed_json_response():
     async def fake_judge_result(*args, **kwargs):
         return ChatCompletionResult(text='正确，应判 true', model_tag="『J』")
@@ -1023,6 +1049,37 @@ def test_non_streaming_chat_completion_strips_leaked_thinking():
     assert result.retryable is False
 
 
+def test_strip_leaked_thinking_strips_common_thinking_tag_variants():
+    assert strip_leaked_thinking("<thinking>hidden reasoning</thinking>Visible answer") == "Visible answer"
+    assert strip_leaked_thinking("<analysis>hidden</analysis>Visible") == "Visible"
+    assert strip_leaked_thinking("<chain-of-thought>hidden</chain-of-thought>Visible") == "Visible"
+
+
+def test_non_streaming_chat_completion_strips_leaked_thinking_tag():
+    response = _DummyResponse(json_data={
+        "choices": [
+            {
+                "message": {
+                    "content": "<thinking>hidden reasoning</thinking>Visible answer"
+                }
+            }
+        ]
+    })
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="claude_gateway",
+        base_url="https://api.example.com/v1",
+        headers={},
+        payload={},
+        timeout=120,
+    ))
+
+    assert result.text == "Visible answer"
+    assert result.retryable is False
+
+
 def test_non_streaming_chat_completion_retries_when_only_leaked_thinking(caplog):
     caplog.set_level("WARNING", logger="kouhai-bot.llm")
     response = _DummyResponse(json_data={
@@ -1081,11 +1138,37 @@ def test_streaming_chat_completion_reads_sse_delta_chunks(caplog):
     assert "reasoning_content chars=8" in caplog.text
 
 
-def test_streaming_chat_completion_strips_leaked_thinking_blocks():
+def test_streaming_chat_completion_strips_leaked_thinking_tag_blocks():
     response = _DummyResponse(lines=[
         'data: {"choices":[{"delta":{"content":"<think>hidden"}}]}\n',
         '\n',
         'data: {"choices":[{"delta":{"content":" reasoning</think>Visible"}}]}\n',
+        '\n',
+        'data: {"choices":[{"delta":{"content":" answer"}}]}\n',
+        '\n',
+        'data: [DONE]\n',
+        '\n',
+    ])
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="qwen",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        headers={},
+        payload={"stream": True},
+        timeout=120,
+    ))
+
+    assert result.text == "Visible answer"
+    assert result.retryable is False
+
+
+def test_streaming_chat_completion_strips_leaked_thinking_blocks():
+    response = _DummyResponse(lines=[
+        'data: {"choices":[{"delta":{"content":"<thinking>hidden"}}]}\n',
+        '\n',
+        'data: {"choices":[{"delta":{"content":" reasoning</thinking>Visible"}}]}\n',
         '\n',
         'data: {"choices":[{"delta":{"content":" answer"}}]}\n',
         '\n',

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -213,6 +213,38 @@ def test_get_editorial_zh_for_group_revalidates_unverified_cache(tmp_path, monke
     assert (cache_dir / "317C.verified").is_file()
 
 
+def test_get_editorial_zh_for_group_strips_verified_cache_thinking_tags(tmp_path, monkeypatch):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    cache_dir = tmp_path / "tutorial_translations"
+    cache_dir.mkdir()
+    (cache_dir / "542D.txt").write_text(
+        ("<thinking>hidden cached editorial</thinking>中文题解。" * 20),
+        encoding="utf-8",
+    )
+    (cache_dir / "542D.verified").write_text("", encoding="utf-8")
+    editorial = OfficialEditorial(
+        text=_long_text("english-"),
+        tutorial_url="https://example.com/e",
+        tutorial_title="T",
+    )
+    translate = AsyncMock(return_value=("不应重新翻译。" * 20, "", True))
+
+    async def _run():
+        with patch("kouhai_bot.tutorials.translate_editorial_to_zh", translate):
+            return await get_editorial_zh_for_group(editorial, "542D")
+
+    zh, tag = asyncio.run(_run())
+    assert zh is not None
+    assert "中文题解" in zh
+    assert "hidden cached editorial" not in zh
+    assert "thinking" not in zh
+    assert tag == ""
+    translate.assert_not_awaited()
+
+
 def test_prefetch_editorial_zh_recovers_after_rescrape(tmp_path, monkeypatch):
     import json
     from kouhai_bot.config import BotConfig


### PR DESCRIPTION
## Summary
- expand leaked-thinking cleanup to remove <thinking>, <reasoning>, <analysis>, and related tag variants in addition to <think>
- strip leaked thinking before JSON repair parsing and recursively from parsed JSON string fields
- add regression coverage for <thinking> leaks in non-streaming, streaming, and JSON response paths

Fixes #61.

## Tests
- uv run pytest