### PR TITLE
Add poke-triggered problem refresh

### DIFF
--- a/src/kouhai_bot/handlers/__init__.py
+++ b/src/kouhai_bot/handlers/__init__.py
@@ -12,6 +12,7 @@ from .registry import CommandDef
 from ..config import get_config
 from .. import echo
 from ..friend_requests import handle_friend_request_event, is_service_group_member
+from .notice import handle_notice_event
 from ..napcat.client import (
     build_plain_message,
     build_reply,
@@ -111,6 +112,17 @@ async def process_event(
                 name=f"request_{event.get('request_type', 'unknown')}_{event.get('user_id', 0)}",
             )
         await handle_friend_request_event(event)
+        return None
+
+    if event["type"] == "notice":
+        if event.get("notice_type") != "notify" or event.get("sub_type") != "poke":
+            return None
+        if spawn_handlers:
+            return asyncio.create_task(
+                handle_notice_event(event),
+                name=f"notice_poke_{event.get('group_id', 0)}_{event.get('user_id', 0)}",
+            )
+        await handle_notice_event(event)
         return None
 
     if event["type"] != "message":

--- a/src/kouhai_bot/handlers/cmd/newproblem.py
+++ b/src/kouhai_bot/handlers/cmd/newproblem.py
@@ -67,43 +67,48 @@ async def _send_high_difficulty_notice_group(group_id: int, problem: dict | None
         logger.warning("[group_%s] Failed to send high-difficulty notice: %s", group_id, e)
 
 
-async def enqueue_force_new_problem(
+async def enqueue_new_problem(
     group_id: int,
     user_id: int,
-    sender: dict,
+    sender: dict | None,
     message_id: str,
     *,
     command: str,
     force: bool = True,
-) -> None:
-    """Pick and post a new problem (shared by /newproblem and /newproblem --force)."""
+    quiet: bool = False,
+    prefix: str = "刷新了一道新题🌟",
+) -> bool:
+    """Admit, pick, and post a new problem for commands or quiet triggers."""
     cfg = get_config()
-    nickname = _nickname(sender)
+    nickname = _nickname(sender or {})
     lock = _newproblem_lock(group_id)
     if lock.locked():
-        await send_group_msg(group_id, build_plain_message(
-            f"@{nickname} 新的题目正在准备中，别急～"
-        ))
-        return
+        if not quiet:
+            await send_group_msg(group_id, build_plain_message(
+                f"@{nickname} 新的题目正在准备中，别急～"
+            ))
+        return False
 
     await lock.acquire()
     try:
         now = time.monotonic()
         last = _cooldowns.get(group_id, 0)
         if now - last < cfg.newproblem_cooldown:
-            remaining = int(cfg.newproblem_cooldown - (now - last))
-            await send_group_msg(group_id, build_plain_message(
-                f"@{nickname} 刷新太频繁啦，等 {remaining} 秒再试哦～"
-            ))
-            return
+            if not quiet:
+                remaining = int(cfg.newproblem_cooldown - (now - last))
+                await send_group_msg(group_id, build_plain_message(
+                    f"@{nickname} 刷新太频繁啦，等 {remaining} 秒再试哦～"
+                ))
+            return False
 
         if not force and _has_unsolved_problem(group_id):
-            await send_group_msg(group_id, build_plain_message(
-                f"@{nickname} 当前题目还没有人解出来呢～不能直接刷题哦。\n"
-                f"可使用 /problem 查看当前题目。\n"
-                f"如果确定要换题，请发 /newproblem --force"
-            ))
-            return
+            if not quiet:
+                await send_group_msg(group_id, build_plain_message(
+                    f"@{nickname} 当前题目还没有人解出来呢～不能直接刷题哦。\n"
+                    f"可使用 /problem 查看当前题目。\n"
+                    f"如果确定要换题，请发 /newproblem --force"
+                ))
+            return False
 
         logger.info(f"[group_{group_id}] {command} triggered")
 
@@ -117,13 +122,17 @@ async def enqueue_force_new_problem(
         try:
             posted = await _post_new_problem_locked(
                 group_id,
-                prefix="刷新了一道新题🌟",
+                prefix=prefix,
                 notify_group=True,
             )
+        except Exception:
+            logger.exception("[group_%s] %s post failed", group_id, command)
+            posted = False
         finally:
             _newproblem_active.pop(group_id, None)
         if posted:
             _cooldowns[group_id] = time.monotonic()
+        return posted
     finally:
         lock.release()
 
@@ -563,13 +572,13 @@ async def handle(group_id: int, user_id: int, sender: dict,
 
     text = raw_text.lstrip()
     if text == _CMD_NEWPROBLEM_FORCE:
-        await enqueue_force_new_problem(
+        await enqueue_new_problem(
             group_id, user_id, sender, message_id, command="newproblem --force",
         )
         return
 
     if text == _CMD_NEWPROBLEM:
-        await enqueue_force_new_problem(
+        await enqueue_new_problem(
             group_id, user_id, sender, message_id, command="newproblem", force=False,
         )
         return

--- a/src/kouhai_bot/handlers/cmd/newproblem.py
+++ b/src/kouhai_bot/handlers/cmd/newproblem.py
@@ -123,9 +123,11 @@ async def enqueue_new_problem(
             posted = await _post_new_problem_locked(
                 group_id,
                 prefix=prefix,
-                notify_group=True,
+                notify_group=not quiet,
             )
         except Exception:
+            if not quiet:
+                raise
             logger.exception("[group_%s] %s post failed", group_id, command)
             posted = False
         finally:

--- a/src/kouhai_bot/handlers/notice.py
+++ b/src/kouhai_bot/handlers/notice.py
@@ -1,0 +1,64 @@
+"""Handlers for OneBot notice events."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from ..config import get_config
+from ..napcat.client import send_group_poke
+
+logger = logging.getLogger("kouhai-bot.handlers.notice")
+
+
+async def handle_notice_event(event: dict) -> None:
+    """Poke back when the bot is nudged and post a new problem when eligible."""
+    cfg = get_config()
+    if event.get("notice_type") != "notify" or event.get("sub_type") != "poke":
+        return
+
+    group_id = event.get("group_id", 0)
+    user_id = event.get("user_id", 0)
+    target_id = event.get("target_id", 0)
+    if group_id != cfg.current_group or str(target_id) != str(cfg.bot_qq):
+        return
+
+    await send_group_poke(group_id, user_id)
+
+    # Keep command discovery/import timing unchanged until a relevant poke arrives.
+    from .cmd import newproblem
+
+    if newproblem._has_unsolved_problem(group_id):
+        return
+
+    lock = newproblem._newproblem_lock(group_id)
+    if lock.locked():
+        return
+
+    await lock.acquire()
+    try:
+        now = time.monotonic()
+        last = newproblem._cooldowns.get(group_id, 0)
+        if newproblem._has_unsolved_problem(group_id) or now - last < cfg.newproblem_cooldown:
+            return
+
+        logger.info("[group_%s] poke triggered new problem", group_id)
+        newproblem._newproblem_active[group_id] = {
+            "group_id": group_id,
+            "user_id": user_id,
+            "message_id": "",
+            "command": "poke",
+            "admitted_at": now,
+        }
+        try:
+            posted = await newproblem._post_new_problem_locked(
+                group_id,
+                prefix="戳一戳刷新🌟",
+                notify_group=True,
+            )
+        finally:
+            newproblem._newproblem_active.pop(group_id, None)
+        if posted:
+            newproblem._cooldowns[group_id] = time.monotonic()
+    finally:
+        lock.release()

--- a/src/kouhai_bot/handlers/notice.py
+++ b/src/kouhai_bot/handlers/notice.py
@@ -2,13 +2,8 @@
 
 from __future__ import annotations
 
-import logging
-import time
-
 from ..config import get_config
 from ..napcat.client import send_group_poke
-
-logger = logging.getLogger("kouhai-bot.handlers.notice")
 
 
 async def handle_notice_event(event: dict) -> None:
@@ -18,9 +13,17 @@ async def handle_notice_event(event: dict) -> None:
         return
 
     group_id = event.get("group_id", 0)
-    user_id = event.get("user_id", 0)
+    raw_user_id = event.get("user_id")
     target_id = event.get("target_id", 0)
     if group_id != cfg.current_group or str(target_id) != str(cfg.bot_qq):
+        return
+    if isinstance(raw_user_id, bool) or not isinstance(raw_user_id, (int, str)):
+        return
+    try:
+        user_id = int(raw_user_id)
+    except (TypeError, ValueError):
+        return
+    if user_id <= 0 or user_id == int(cfg.bot_qq):
         return
 
     await send_group_poke(group_id, user_id)
@@ -28,37 +31,13 @@ async def handle_notice_event(event: dict) -> None:
     # Keep command discovery/import timing unchanged until a relevant poke arrives.
     from .cmd import newproblem
 
-    if newproblem._has_unsolved_problem(group_id):
-        return
-
-    lock = newproblem._newproblem_lock(group_id)
-    if lock.locked():
-        return
-
-    await lock.acquire()
-    try:
-        now = time.monotonic()
-        last = newproblem._cooldowns.get(group_id, 0)
-        if newproblem._has_unsolved_problem(group_id) or now - last < cfg.newproblem_cooldown:
-            return
-
-        logger.info("[group_%s] poke triggered new problem", group_id)
-        newproblem._newproblem_active[group_id] = {
-            "group_id": group_id,
-            "user_id": user_id,
-            "message_id": "",
-            "command": "poke",
-            "admitted_at": now,
-        }
-        try:
-            posted = await newproblem._post_new_problem_locked(
-                group_id,
-                prefix="戳一戳刷新🌟",
-                notify_group=True,
-            )
-        finally:
-            newproblem._newproblem_active.pop(group_id, None)
-        if posted:
-            newproblem._cooldowns[group_id] = time.monotonic()
-    finally:
-        lock.release()
+    await newproblem.enqueue_new_problem(
+        group_id,
+        user_id,
+        None,
+        "",
+        command="poke",
+        force=False,
+        quiet=True,
+        prefix="戳一戳刷新🌟",
+    )

--- a/src/kouhai_bot/napcat/client.py
+++ b/src/kouhai_bot/napcat/client.py
@@ -86,6 +86,22 @@ async def send_private_msg(user_id: int, message: list[dict]) -> int | None:
         return None
 
 
+async def send_group_poke(group_id: int, user_id: int) -> bool:
+    """Poke a user in a group via NapCat's group_poke action."""
+    try:
+        result = await _http_post("group_poke", {
+            "group_id": int(group_id),
+            "user_id": int(user_id),
+        })
+        if isinstance(result, dict) and str(result.get("status", "") or "").lower() in {"", "ok"}:
+            return True
+        logger.warning("group_poke returned unexpected payload: %s", result)
+        return False
+    except Exception as e:
+        logger.error("group_poke failed: %s", e, exc_info=True)
+        return False
+
+
 async def send_private_forward_msg(user_id: int, messages: list[dict]) -> int | None:
     """Forward messages as a merged card to a private chat."""
     try:
@@ -274,6 +290,10 @@ def _parse_notice(event: dict) -> dict:
     return {
         "type": "notice",
         "notice_type": event.get("notice_type", ""),
+        "sub_type": event.get("sub_type", ""),
+        "group_id": event.get("group_id", 0),
+        "user_id": event.get("user_id", 0),
+        "target_id": event.get("target_id", 0),
         "raw": event,
     }
 

--- a/tests/test_napcat.py
+++ b/tests/test_napcat.py
@@ -9,6 +9,7 @@ from kouhai_bot.napcat.client import (
     build_text,
     get_doubt_friends_add_requests,
     parse_event,
+    send_group_poke,
     set_doubt_friends_add_request,
 )
 
@@ -31,6 +32,21 @@ def test_parse_meta_event():
     event = parse_event(raw)
     assert event is not None
     assert event["type"] == "meta"
+
+
+def test_parse_poke_notice_preserves_routing_fields():
+    raw = (
+        '{"post_type":"notice","notice_type":"notify","sub_type":"poke",'
+        '"group_id":123,"user_id":456,"target_id":789}'
+    )
+    event = parse_event(raw)
+    assert event is not None
+    assert event["type"] == "notice"
+    assert event["notice_type"] == "notify"
+    assert event["sub_type"] == "poke"
+    assert event["group_id"] == 123
+    assert event["user_id"] == 456
+    assert event["target_id"] == 789
 
 
 def test_build_plain_message():
@@ -106,3 +122,18 @@ def test_set_doubt_friends_add_request(monkeypatch):
 
     assert asyncio.run(set_doubt_friends_add_request("uid-flag", approve=True)) is True
     assert calls == [("set_doubt_friends_add_request", {"flag": "uid-flag", "approve": True})]
+
+
+def test_send_group_poke(monkeypatch):
+    calls = []
+
+    async def fake_http_post(action, data):
+        calls.append((action, data))
+        return {"status": "ok", "data": None}
+
+    monkeypatch.setattr("kouhai_bot.napcat.client._http_post", fake_http_post)
+
+    import asyncio
+
+    assert asyncio.run(send_group_poke(123, 456)) is True
+    assert calls == [("group_poke", {"group_id": 123, "user_id": 456})]

--- a/tests/test_notice.py
+++ b/tests/test_notice.py
@@ -1,0 +1,154 @@
+"""Tests for QQ notice-event handling."""
+
+import asyncio
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from kouhai_bot.handlers import process_event
+
+
+GROUP_ID = 123
+BOT_QQ = 789
+USER_ID = 456
+
+
+def _cfg(cooldown: int = 300) -> SimpleNamespace:
+    return SimpleNamespace(
+        bot_qq=BOT_QQ,
+        current_group=GROUP_ID,
+        newproblem_cooldown=cooldown,
+    )
+
+
+def _poke_event(**overrides) -> dict:
+    event = {
+        "type": "notice",
+        "notice_type": "notify",
+        "sub_type": "poke",
+        "group_id": GROUP_ID,
+        "user_id": USER_ID,
+        "target_id": BOT_QQ,
+        "raw": {},
+    }
+    event.update(overrides)
+    return event
+
+
+def _reset_newproblem_runtime():
+    from kouhai_bot.handlers.cmd import newproblem
+
+    newproblem._cooldowns.clear()
+    newproblem._newproblem_active.clear()
+    newproblem._newproblem_locks.clear()
+    return newproblem
+
+
+def test_bot_poke_is_returned_and_posts_when_eligible(monkeypatch):
+    newproblem = _reset_newproblem_runtime()
+    pokes = []
+    posts = []
+
+    async def fake_poke(group_id, user_id):
+        pokes.append((group_id, user_id))
+        return True
+
+    async def fake_post(group_id, *, prefix="", notify_group=False):
+        posts.append((group_id, prefix, notify_group))
+        return True
+
+    monkeypatch.setattr("kouhai_bot.handlers.notice.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.handlers.notice.send_group_poke", fake_poke)
+    monkeypatch.setattr(newproblem, "_has_unsolved_problem", lambda _gid: False)
+    monkeypatch.setattr(newproblem, "_post_new_problem_locked", fake_post)
+
+    asyncio.run(process_event(_poke_event(), spawn_handlers=False))
+
+    assert pokes == [(GROUP_ID, USER_ID)]
+    assert posts == [(GROUP_ID, "戳一戳刷新🌟", True)]
+    assert GROUP_ID in newproblem._cooldowns
+
+
+def test_bot_poke_only_pokes_back_when_problem_is_unsolved(monkeypatch):
+    newproblem = _reset_newproblem_runtime()
+    pokes = []
+    posts = []
+
+    async def fake_poke(group_id, user_id):
+        pokes.append((group_id, user_id))
+        return True
+
+    async def fake_post(*args, **kwargs):
+        posts.append((args, kwargs))
+        return True
+
+    monkeypatch.setattr("kouhai_bot.handlers.notice.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.handlers.notice.send_group_poke", fake_poke)
+    monkeypatch.setattr(newproblem, "_has_unsolved_problem", lambda _gid: True)
+    monkeypatch.setattr(newproblem, "_post_new_problem_locked", fake_post)
+
+    asyncio.run(process_event(_poke_event(), spawn_handlers=False))
+
+    assert pokes == [(GROUP_ID, USER_ID)]
+    assert posts == []
+
+
+def test_bot_poke_only_pokes_back_during_cooldown(monkeypatch):
+    newproblem = _reset_newproblem_runtime()
+    pokes = []
+    posts = []
+    newproblem._cooldowns[GROUP_ID] = 100.0
+
+    async def fake_poke(group_id, user_id):
+        pokes.append((group_id, user_id))
+        return True
+
+    async def fake_post(*args, **kwargs):
+        posts.append((args, kwargs))
+        return True
+
+    monkeypatch.setattr("kouhai_bot.handlers.notice.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.handlers.notice.send_group_poke", fake_poke)
+    monkeypatch.setattr(newproblem, "_has_unsolved_problem", lambda _gid: False)
+    monkeypatch.setattr(newproblem, "_post_new_problem_locked", fake_post)
+    monkeypatch.setattr("kouhai_bot.handlers.notice.time.monotonic", lambda: 200.0)
+
+    asyncio.run(process_event(_poke_event(), spawn_handlers=False))
+
+    assert pokes == [(GROUP_ID, USER_ID)]
+    assert posts == []
+
+
+def test_pokes_outside_service_group_or_not_targeting_bot_are_ignored(monkeypatch):
+    _reset_newproblem_runtime()
+    pokes = []
+
+    async def fake_poke(group_id, user_id):
+        pokes.append((group_id, user_id))
+        return True
+
+    monkeypatch.setattr("kouhai_bot.handlers.notice.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.handlers.notice.send_group_poke", fake_poke)
+
+    asyncio.run(process_event(_poke_event(group_id=999), spawn_handlers=False))
+    asyncio.run(process_event(_poke_event(target_id=999), spawn_handlers=False))
+
+    assert pokes == []
+
+
+def test_non_poke_notice_is_ignored(monkeypatch):
+    _reset_newproblem_runtime()
+    pokes = []
+
+    async def fake_poke(group_id, user_id):
+        pokes.append((group_id, user_id))
+        return True
+
+    monkeypatch.setattr("kouhai_bot.handlers.notice.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.handlers.notice.send_group_poke", fake_poke)
+
+    asyncio.run(process_event(_poke_event(sub_type="lucky_king"), spawn_handlers=False))
+
+    assert pokes == []

--- a/tests/test_notice.py
+++ b/tests/test_notice.py
@@ -74,8 +74,87 @@ def test_bot_poke_is_returned_and_posts_when_eligible(monkeypatch):
     asyncio.run(process_event(_poke_event(), spawn_handlers=False))
 
     assert pokes == [(GROUP_ID, USER_ID)]
-    assert posts == [(GROUP_ID, "戳一戳刷新🌟", True)]
+    assert posts == [(GROUP_ID, "戳一戳刷新🌟", False)]
     assert GROUP_ID in newproblem._cooldowns
+
+
+def test_quiet_poke_picker_failure_sends_no_group_message(monkeypatch, tmp_path):
+    newproblem = _reset_newproblem_runtime()
+    group_messages = []
+    pick_attempts = 0
+
+    cfg = SimpleNamespace(
+        bot_qq=BOT_QQ,
+        current_group=GROUP_ID,
+        newproblem_cooldown=300,
+        data_dir=str(tmp_path),
+        min_rating=2000,
+        max_rating=3000,
+    )
+
+    class FakeProcess:
+        def __init__(self, returncode, stdout=b"", stderr=b""):
+            self.returncode = returncode
+            self._result = (stdout, stderr)
+
+        async def communicate(self):
+            return self._result
+
+    async def fake_poke(_group_id, _user_id):
+        return True
+
+    async def fake_send_group_msg(group_id, message):
+        group_messages.append((group_id, message))
+        return True
+
+    async def fake_subprocess(*args, **_kwargs):
+        nonlocal pick_attempts
+        if "reveal" in args:
+            return FakeProcess(0)
+        if "pick-json" in args:
+            pick_attempts += 1
+            return FakeProcess(1, stderr=b"SSL EOF")
+        raise AssertionError(f"unexpected subprocess: {args}")
+
+    async def no_sleep(_delay):
+        return None
+
+    monkeypatch.setattr("kouhai_bot.handlers.notice.get_config", lambda: cfg)
+    monkeypatch.setattr(newproblem, "get_config", lambda: cfg)
+    monkeypatch.setattr("kouhai_bot.handlers.notice.send_group_poke", fake_poke)
+    monkeypatch.setattr(newproblem, "_has_unsolved_problem", lambda _gid: False)
+    monkeypatch.setattr(newproblem, "send_group_msg", fake_send_group_msg)
+    monkeypatch.setattr(newproblem.asyncio, "create_subprocess_exec", fake_subprocess)
+    monkeypatch.setattr(newproblem.asyncio, "sleep", no_sleep)
+
+    asyncio.run(process_event(_poke_event(), spawn_handlers=False))
+
+    assert pick_attempts == 3
+    assert group_messages == []
+    assert GROUP_ID not in newproblem._cooldowns
+
+
+def test_command_post_exception_is_not_swallowed(monkeypatch):
+    newproblem = _reset_newproblem_runtime()
+
+    async def failing_post(*_args, **_kwargs):
+        raise RuntimeError("posting failed")
+
+    monkeypatch.setattr(newproblem, "_has_unsolved_problem", lambda _gid: False)
+    monkeypatch.setattr(newproblem, "_post_new_problem_locked", failing_post)
+
+    with pytest.raises(RuntimeError, match="posting failed"):
+        asyncio.run(newproblem.enqueue_new_problem(
+            GROUP_ID,
+            USER_ID,
+            {"nickname": "tester"},
+            "message-id",
+            command="newproblem --force",
+        ))
+
+    assert GROUP_ID not in newproblem._newproblem_active
+    assert not newproblem._newproblem_lock(GROUP_ID).locked()
+    assert GROUP_ID not in newproblem._cooldowns
 
 
 def test_bot_poke_only_pokes_back_when_problem_is_unsolved(monkeypatch):

--- a/tests/test_notice.py
+++ b/tests/test_notice.py
@@ -5,6 +5,8 @@ import os
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from kouhai_bot.handlers import process_event
@@ -46,6 +48,12 @@ def _reset_newproblem_runtime():
     return newproblem
 
 
+@pytest.fixture(autouse=True)
+def _patch_config(monkeypatch):
+    monkeypatch.setattr("kouhai_bot.handlers.notice.get_config", _cfg)
+    monkeypatch.setattr("kouhai_bot.handlers.cmd.newproblem.get_config", _cfg)
+
+
 def test_bot_poke_is_returned_and_posts_when_eligible(monkeypatch):
     newproblem = _reset_newproblem_runtime()
     pokes = []
@@ -59,7 +67,6 @@ def test_bot_poke_is_returned_and_posts_when_eligible(monkeypatch):
         posts.append((group_id, prefix, notify_group))
         return True
 
-    monkeypatch.setattr("kouhai_bot.handlers.notice.get_config", _cfg)
     monkeypatch.setattr("kouhai_bot.handlers.notice.send_group_poke", fake_poke)
     monkeypatch.setattr(newproblem, "_has_unsolved_problem", lambda _gid: False)
     monkeypatch.setattr(newproblem, "_post_new_problem_locked", fake_post)
@@ -84,7 +91,6 @@ def test_bot_poke_only_pokes_back_when_problem_is_unsolved(monkeypatch):
         posts.append((args, kwargs))
         return True
 
-    monkeypatch.setattr("kouhai_bot.handlers.notice.get_config", _cfg)
     monkeypatch.setattr("kouhai_bot.handlers.notice.send_group_poke", fake_poke)
     monkeypatch.setattr(newproblem, "_has_unsolved_problem", lambda _gid: True)
     monkeypatch.setattr(newproblem, "_post_new_problem_locked", fake_post)
@@ -109,11 +115,10 @@ def test_bot_poke_only_pokes_back_during_cooldown(monkeypatch):
         posts.append((args, kwargs))
         return True
 
-    monkeypatch.setattr("kouhai_bot.handlers.notice.get_config", _cfg)
     monkeypatch.setattr("kouhai_bot.handlers.notice.send_group_poke", fake_poke)
     monkeypatch.setattr(newproblem, "_has_unsolved_problem", lambda _gid: False)
     monkeypatch.setattr(newproblem, "_post_new_problem_locked", fake_post)
-    monkeypatch.setattr("kouhai_bot.handlers.notice.time.monotonic", lambda: 200.0)
+    monkeypatch.setattr("kouhai_bot.handlers.cmd.newproblem.time.monotonic", lambda: 200.0)
 
     asyncio.run(process_event(_poke_event(), spawn_handlers=False))
 
@@ -129,13 +134,96 @@ def test_pokes_outside_service_group_or_not_targeting_bot_are_ignored(monkeypatc
         pokes.append((group_id, user_id))
         return True
 
-    monkeypatch.setattr("kouhai_bot.handlers.notice.get_config", _cfg)
     monkeypatch.setattr("kouhai_bot.handlers.notice.send_group_poke", fake_poke)
 
     asyncio.run(process_event(_poke_event(group_id=999), spawn_handlers=False))
     asyncio.run(process_event(_poke_event(target_id=999), spawn_handlers=False))
 
     assert pokes == []
+
+
+def test_invalid_and_self_pokes_are_ignored(monkeypatch):
+    _reset_newproblem_runtime()
+    pokes = []
+
+    async def fake_poke(group_id, user_id):
+        pokes.append((group_id, user_id))
+        return True
+
+    monkeypatch.setattr("kouhai_bot.handlers.notice.send_group_poke", fake_poke)
+
+    missing_user = _poke_event()
+    missing_user.pop("user_id")
+    asyncio.run(process_event(missing_user, spawn_handlers=False))
+    asyncio.run(process_event(_poke_event(user_id=None), spawn_handlers=False))
+    asyncio.run(process_event(_poke_event(user_id="invalid"), spawn_handlers=False))
+    asyncio.run(process_event(_poke_event(user_id=True), spawn_handlers=False))
+    asyncio.run(process_event(_poke_event(user_id=1.5), spawn_handlers=False))
+    asyncio.run(process_event(_poke_event(user_id=0), spawn_handlers=False))
+    asyncio.run(process_event(_poke_event(user_id=-1), spawn_handlers=False))
+    asyncio.run(process_event(_poke_event(user_id=BOT_QQ), spawn_handlers=False))
+
+    assert pokes == []
+
+
+def test_poke_post_failure_does_not_escape_detached_task(monkeypatch, caplog):
+    newproblem = _reset_newproblem_runtime()
+
+    async def fake_poke(_group_id, _user_id):
+        return True
+
+    async def failing_post(*_args, **_kwargs):
+        raise RuntimeError("posting failed")
+
+    async def run():
+        task = await process_event(_poke_event(), spawn_handlers=True)
+        assert task is not None
+        await task
+
+    monkeypatch.setattr("kouhai_bot.handlers.notice.send_group_poke", fake_poke)
+    monkeypatch.setattr(newproblem, "_has_unsolved_problem", lambda _gid: False)
+    monkeypatch.setattr(newproblem, "_post_new_problem_locked", failing_post)
+
+    asyncio.run(run())
+
+    assert "poke post failed" in caplog.text
+    assert GROUP_ID not in newproblem._newproblem_active
+    assert not newproblem._newproblem_lock(GROUP_ID).locked()
+    assert GROUP_ID not in newproblem._cooldowns
+
+
+def test_concurrent_pokes_start_only_one_refresh(monkeypatch):
+    newproblem = _reset_newproblem_runtime()
+    pokes = []
+    posts = []
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_poke(group_id, user_id):
+        pokes.append((group_id, user_id))
+        return True
+
+    async def fake_post(group_id, **_kwargs):
+        posts.append(group_id)
+        started.set()
+        await release.wait()
+        return True
+
+    async def run():
+        first = asyncio.create_task(process_event(_poke_event(), spawn_handlers=False))
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        await process_event(_poke_event(user_id=USER_ID + 1), spawn_handlers=False)
+        release.set()
+        await asyncio.wait_for(first, timeout=1.0)
+
+    monkeypatch.setattr("kouhai_bot.handlers.notice.send_group_poke", fake_poke)
+    monkeypatch.setattr(newproblem, "_has_unsolved_problem", lambda _gid: False)
+    monkeypatch.setattr(newproblem, "_post_new_problem_locked", fake_post)
+
+    asyncio.run(run())
+
+    assert pokes == [(GROUP_ID, USER_ID), (GROUP_ID, USER_ID + 1)]
+    assert posts == [GROUP_ID]
 
 
 def test_non_poke_notice_is_ignored(monkeypatch):
@@ -146,7 +234,6 @@ def test_non_poke_notice_is_ignored(monkeypatch):
         pokes.append((group_id, user_id))
         return True
 
-    monkeypatch.setattr("kouhai_bot.handlers.notice.get_config", _cfg)
     monkeypatch.setattr("kouhai_bot.handlers.notice.send_group_poke", fake_poke)
 
     asyncio.run(process_event(_poke_event(sub_type="lucky_king"), spawn_handlers=False))


### PR DESCRIPTION
## What changed

- Preserve poke routing fields when parsing OneBot notice events.
- Add a NapCat `group_poke` HTTP action helper.
- Route bot-targeted pokes in the configured service group through a dedicated notice handler.
- Poke the sender back, then post a new problem with `戳一戳刷新🌟` only when the current problem is solved (or absent), the cooldown has elapsed, and no competing new-problem post holds the group lock.
- Add parsing, API payload, filtering, cooldown, and eligibility tests.

## Why

NapCat poke notices were previously normalized without the fields needed to identify the group, sender, subtype, or target, and notice events were not dispatched by the bot.

## User impact

Poking the bot now receives an immediate poke-back. When a normal `/newproblem` refresh is eligible, the same poke also starts a new problem post without sending a separate reaction or poke-specific text message.

## Validation

- `uv run pytest tests/test_napcat.py tests/test_notice.py` — 18 passed.
- `uv run pytest` — 322 passed, 4 failed. The same four failures reproduce on untouched `master` (315 passed, 4 failed) and depend on the shared fallback statement cache for Codeforces 542D; they are unrelated to this change.
- `git diff --check` — passed.