### PR TITLE
Add semantic double-check for problem summaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,16 @@ NapCat (QQ) ──WS──> worker.py
   `reasoning_effort`, `thinking`, temperature override, and provider-specific
   extra body fields are controlled per provider; unsupported fields may be ignored
   or rejected by upstream APIs.
+- **Summary semantic double-check**: every generated problem summary is audited against
+  the original statement/input/limits by a second structured request through
+  `llm.general_model`. The checker treats symbol scope, index arithmetic, object counts,
+  loop endpoints, operations, and constraints as semantic facts. Before that request, a
+  deterministic source-aware gate also rejects unambiguous outside-addition → nested-index
+  transcription errors such as `p_i+1` → `pᵢ₊₁`, and preserves explicit source conventions
+  whose omission would make a definition ambiguous (for example, an isolated vertex also
+  counting as having only incoming edges). A failed gate or audit triggers one targeted
+  repair followed by another audit; indeterminate or repeatedly failing audits reject the
+  summary so the caller can retry instead of posting it.
 - **Official CF tutorials**: Scraped editorials live under `{data_dir}/tutorials/{pid}.json`
   (see `tools/cf_tutorial_agent.py`; low-level CF HTML helpers live in `tools/scrape_cf_tutorial.py`). Runtime extraction is in `tutorials.py`. On the
   On **new problem** (`/newproblem`), `schedule_prefetch_editorial(pid)`
@@ -654,7 +664,9 @@ newer AC can silently retarget an older review request.
 2. Pick a candidate problem via `picker.py pick-json --with-statement`; this marks used
    problems and caches statements but does **not** write `state.json`
 3. Generate Chinese summary via `summarize_problem()` → `llm.general_model` queue,
-   timeout from `llm.summary_timeout_sec`
+   timeout from `llm.summary_timeout_sec`; after the local format/limit/symbol-scope gate,
+   run the general-model semantic double-check. A mismatch is repaired from structured
+   issues and checked again before the summary can be posted.
 4. Self-send summary text; self-send each sample as an independent node; if statement has
    `notes`, translate it to Chinese and append a dedicated `样例解释` node (with LaTeX/Markdown
    artifacts normalized to readable symbols such as `→`, `≤`, `<`, `>`); then append snake
@@ -1010,6 +1022,16 @@ command testing. The suite covers submit, clarify, review, problem, tag, scorebo
 newproblem, annotation export, napcat parsing, registry discovery, and
 `tutorials.py` extraction/translation (`tests/test_tutorials.py`; submit/review
 editorial paths in `tests/test_commands.py`).
+
+To audit the current group's saved summary against its cached statement with the
+configured `llm.general_model` queue (read-only; no group message or runtime-data write):
+
+```bash
+KOUHAI_CONFIG=/path/to/config.yaml uv run python tools/summary_doublecheck.py
+```
+
+Use `--expect inaccurate` for a regression fixture that is supposed to be rejected,
+or `--pid <pid> --summary-file <path>` to check another candidate.
 
 ## GitHub CI
 

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -1353,7 +1353,9 @@ _SUMMARY_SUBSCRIPT_CHARS = {
 }
 _SUMMARY_SUBSCRIPT_DIGITS = str.maketrans("0123456789", "₀₁₂₃₄₅₆₇₈₉")
 _SOURCE_INDEXED_VALUE_PLUS_RE = re.compile(
-    r"(?<![\w{])(?P<name>[A-Za-z])_(?P<index>[A-Za-z])\s*\+\s*(?P<amount>\d+)"
+    r"(?<!\w)(?P<name>[A-Za-z])_"
+    r"(?:\{\s*(?P<braced_index>[A-Za-z])\s*\}|(?P<plain_index>[A-Za-z]))"
+    r"\s*\+\s*(?P<amount>\d+)"
 )
 
 
@@ -1365,7 +1367,7 @@ def _summary_symbol_scope_issues(source_text: str, summary: str) -> list[str]:
     seen: set[tuple[str, str, str]] = set()
     for match in _SOURCE_INDEXED_VALUE_PLUS_RE.finditer(source):
         name = match.group("name")
-        index = match.group("index")
+        index = match.group("braced_index") or match.group("plain_index")
         amount = match.group("amount")
         key = (name, index, amount)
         if key in seen:
@@ -1381,8 +1383,22 @@ def _summary_symbol_scope_issues(source_text: str, summary: str) -> list[str]:
         if nested_source_re.search(source):
             # The source contains both forms, so the Unicode occurrence is ambiguous.
             continue
-        wrong = f"{name}{index_char}₊{amount.translate(_SUMMARY_SUBSCRIPT_DIGITS)}"
-        if wrong not in candidate:
+        subscript_amount = amount.translate(_SUMMARY_SUBSCRIPT_DIGITS)
+        wrong_unicode_forms = [f"{name}{index_char}₊{subscript_amount}"]
+        subscript_name = _SUMMARY_SUBSCRIPT_CHARS.get(name.lower())
+        if subscript_name:
+            # Also catch the same scope loss inside a flattened multilevel
+            # subscript, e.g. a_{p_i+1} -> aₚᵢ₊₁.
+            wrong_unicode_forms.append(f"{subscript_name}{index_char}₊{subscript_amount}")
+        wrong_latex_re = re.compile(
+            rf"{re.escape(name)}_\{{\s*{re.escape(index)}\s*\+\s*"
+            rf"{re.escape(amount)}\s*\}}"
+        )
+        wrong = next((form for form in wrong_unicode_forms if form in candidate), "")
+        if not wrong:
+            wrong_latex = wrong_latex_re.search(candidate)
+            wrong = wrong_latex.group(0) if wrong_latex else ""
+        if not wrong:
             continue
         correct = f"{name}{index_char}+{amount}"
         issues.append(
@@ -1395,11 +1411,13 @@ def _summary_symbol_scope_issues(source_text: str, summary: str) -> list[str]:
 
 def _summary_required_convention_issues(source_text: str, summary: str) -> list[str]:
     """Catch explicit conventions whose omission makes a definition ambiguous."""
-    source = (source_text or "").lower()
+    source = " ".join((source_text or "").lower().split())
     candidate = summary or ""
-    no_edge_is_incoming_only = (
-        "vertex that has no edges is considered to have only incoming edges" in source
-        or "vertex with no edges is considered to have only incoming edges" in source
+    no_edge_is_incoming_only = re.search(
+        r"\b(?:(?:a|the)\s+)?vert(?:ex|ices)\s+"
+        r"(?:(?:that|which)\s+ha(?:s|ve)|with)\s+no\s+edges?\s+"
+        r"(?:is|are)\s+(?:also\s+)?considered\s+to\s+have\s+only\s+incoming\s+edges\b",
+        source,
     )
     if not no_edge_is_incoming_only:
         return []
@@ -1518,17 +1536,23 @@ def _normalize_summary_doublecheck_issues(value: object) -> tuple[dict[str, str]
     for item in value:
         if not isinstance(item, dict):
             return None
-        severity = str(item.get("severity", "major") or "major").strip().lower()
+        raw_severity = item.get("severity", "major")
+        if not isinstance(raw_severity, str):
+            return None
+        severity = raw_severity.strip().lower() or "major"
         if severity not in {"critical", "major", "minor"}:
             severity = "major"
-        issue = {
-            "severity": severity,
-            "summary_claim": str(item.get("summary_claim", "") or "").strip(),
-            "source_fact": str(item.get("source_fact", "") or "").strip(),
-            "explanation": str(item.get("explanation", "") or "").strip(),
-        }
-        if not any(issue[key] for key in ("summary_claim", "source_fact", "explanation")):
+        details: dict[str, str] = {}
+        for key in ("summary_claim", "source_fact", "explanation"):
+            raw = item.get(key, "")
+            if not isinstance(raw, str):
+                return None
+            details[key] = raw.strip()
+        if not details["explanation"] or not (
+            details["summary_claim"] or details["source_fact"]
+        ):
             return None
+        issue = {"severity": severity, **details}
         normalized.append(issue)
     return tuple(normalized)
 
@@ -1568,7 +1592,7 @@ async def doublecheck_problem_summary(
             model=result.model,
         )
 
-    parsed, repair_tag = await parse_json_with_llm_repair(
+    parsed, _repair_tag = await parse_json_with_llm_repair(
         result.text,
         expected_schema=(
             '{"accurate": boolean, "issues": [{"severity": string, '
@@ -1581,21 +1605,24 @@ async def doublecheck_problem_summary(
     issues = _normalize_summary_doublecheck_issues(
         parsed.get("issues") if isinstance(parsed, dict) else None
     )
-    if not isinstance(accurate, bool) or issues is None or (not accurate and not issues):
+    if (
+        not isinstance(accurate, bool)
+        or issues is None
+        or (accurate and issues)
+        or (not accurate and not issues)
+    ):
         logger.warning("summary double-check returned an invalid result: %s", parsed)
         return SummaryDoublecheckResult(
             accurate=None,
             failure_kind="invalid_response",
-            model_tag=repair_tag or result.model_tag,
+            model_tag=result.model_tag,
             provider_name=result.provider_name,
             model=result.model,
         )
-    if accurate and issues:
-        accurate = False
     return SummaryDoublecheckResult(
         accurate=accurate,
         issues=issues,
-        model_tag=repair_tag or result.model_tag,
+        model_tag=result.model_tag,
         provider_name=result.provider_name,
         model=result.model,
     )
@@ -1629,6 +1656,14 @@ async def _repair_summary_candidate(
         timeout=timeout,
         response_format={"type": "json_object"},
     )
+    if not repair_result.text:
+        logger.warning(
+            "summary repair request failed: failure=%s provider=%s model=%s",
+            repair_result.failure_kind or "empty_response",
+            repair_result.provider_name,
+            repair_result.model,
+        )
+        return None, ""
     repaired, repaired_json_tag = await _parse_summary_json(
         repair_result.text,
         timeout=timeout,

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -14,6 +14,7 @@ import random
 import re
 import time
 import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
 
 from ..config import get_config
@@ -1256,8 +1257,11 @@ def _build_summary_prompt(stmt_text: str, input_text: str, limits_text: str) -> 
         "4. 所有数据范围必须完整出现；可合并压缩但不能丢。题面给了上下界时尽量写完整区间，如 1≤n≤2×10⁵、0≤aᵢ≤10⁹、1≤t≤10⁴、多测且所有 n 之和≤2×10⁵；范围里也使用角标，不要写 a_i。\n"
         "5. 时限和内存必须写在末尾，例如“时限2s，内存256MB”。\n"
         "6. 背景故事、角色名、修辞、样例细节能删就删；定义、边界、判定规则、输出目标、数据范围、时空限制不能删。不要改变规则适用对象：若原文说每次操作/每个玩家/任意元素满足某条件，不能误写成只对先手、只对某一次或只对某一类对象成立。\n"
+        "题面为定义补充的特殊约定也必须保留；例如原文明确说无边顶点也算 only incoming edges，summary 必须写清“孤立点也算”。\n"
         "7. LaTeX 是最后手段：普通数组下标和幂次优先用 Unicode 角标，如 aᵢ、a₁、a₂、aₙ、10¹⁸、10⁹+7；也可写“第 i 个/每个位置的 a”。"
         f"{_SUMMARY_UNICODE_NOTATION_GUIDE}"
+        "必须保留加法与下标的作用域：p_i+1 表示 p_i 的值加 1，必须写成 pᵢ+1 或“标号为 pᵢ+1 的顶点”；"
+        "只有原文 p_{i+1} 才能写成 pᵢ₊₁，绝不能把 p_i+1 改成 pᵢ₊₁。"
         "严格递增序列写 a₁<a₂<…<aₙ 或“严格递增坐标”。不要猜测列表端点或把原文没有的下标终点写进 summary；端点不适合用 Unicode 角标时改用自然语言。"
         "简单关系用 ≤、≥、×、mod。只有复杂求和、递推、分式、多重下标、精确定义用中文会失真时，才保留最少必要 LaTeX。\n"
         f"8. 目标长度不超过 {_SUMMARY_TARGET_CHARS} 个中文字符；复杂题可略长，但完整限制优先于短。\n"
@@ -1342,12 +1346,90 @@ def _summary_quality_issues(summary: str, limits_text: str = "") -> list[str]:
     return issues
 
 
+_SUMMARY_SUBSCRIPT_CHARS = {
+    "a": "ₐ", "e": "ₑ", "h": "ₕ", "i": "ᵢ", "j": "ⱼ", "k": "ₖ",
+    "l": "ₗ", "m": "ₘ", "n": "ₙ", "o": "ₒ", "p": "ₚ", "r": "ᵣ",
+    "s": "ₛ", "t": "ₜ", "u": "ᵤ", "v": "ᵥ", "x": "ₓ",
+}
+_SUMMARY_SUBSCRIPT_DIGITS = str.maketrans("0123456789", "₀₁₂₃₄₅₆₇₈₉")
+_SOURCE_INDEXED_VALUE_PLUS_RE = re.compile(
+    r"(?<![\w{])(?P<name>[A-Za-z])_(?P<index>[A-Za-z])\s*\+\s*(?P<amount>\d+)"
+)
+
+
+def _summary_symbol_scope_issues(source_text: str, summary: str) -> list[str]:
+    """Catch unambiguous outside-addition → nested-subscript transcription errors."""
+    issues: list[str] = []
+    source = source_text or ""
+    candidate = summary or ""
+    seen: set[tuple[str, str, str]] = set()
+    for match in _SOURCE_INDEXED_VALUE_PLUS_RE.finditer(source):
+        name = match.group("name")
+        index = match.group("index")
+        amount = match.group("amount")
+        key = (name, index, amount)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        index_char = _SUMMARY_SUBSCRIPT_CHARS.get(index.lower())
+        if not index_char:
+            continue
+        nested_source_re = re.compile(
+            rf"{re.escape(name)}_\{{\s*{re.escape(index)}\s*\+\s*{re.escape(amount)}\s*\}}"
+        )
+        if nested_source_re.search(source):
+            # The source contains both forms, so the Unicode occurrence is ambiguous.
+            continue
+        wrong = f"{name}{index_char}₊{amount.translate(_SUMMARY_SUBSCRIPT_DIGITS)}"
+        if wrong not in candidate:
+            continue
+        correct = f"{name}{index_char}+{amount}"
+        issues.append(
+            f"summary changes source expression {name}_{index}+{amount} "
+            f"(indexed value plus {amount}) into {wrong} (next subscript); "
+            f"write {correct} or an equivalent natural-language expression"
+        )
+    return issues
+
+
+def _summary_required_convention_issues(source_text: str, summary: str) -> list[str]:
+    """Catch explicit conventions whose omission makes a definition ambiguous."""
+    source = (source_text or "").lower()
+    candidate = summary or ""
+    no_edge_is_incoming_only = (
+        "vertex that has no edges is considered to have only incoming edges" in source
+        or "vertex with no edges is considered to have only incoming edges" in source
+    )
+    if not no_edge_is_incoming_only:
+        return []
+    if re.search(r"孤立点|(?:没有|无)边的?顶点", candidate):
+        return []
+    return [
+        "summary omits the explicit convention that a vertex with no edges is "
+        "considered to have only incoming edges; state that isolated vertices also count"
+    ]
+
+
+def _summary_candidate_issues(
+    stmt_text: str,
+    input_text: str,
+    limits_text: str,
+    summary: str,
+) -> list[str]:
+    return [
+        *_summary_quality_issues(summary, limits_text),
+        *_summary_symbol_scope_issues(f"{stmt_text}\n{input_text}", summary),
+        *_summary_required_convention_issues(f"{stmt_text}\n{input_text}", summary),
+    ]
+
+
 def _build_summary_repair_prompt(
     stmt_text: str,
     input_text: str,
     limits_text: str,
     summary: str,
-    issues: list[str],
+    issues: list[str | dict[str, str]],
 ) -> str:
     payload = {
         "source": _summary_source_payload(stmt_text, input_text, limits_text),
@@ -1359,13 +1441,211 @@ def _build_summary_repair_prompt(
         "修正规则：只压缩、改写、删除违规内容；不要加入 source 中没有的新事实。\n"
         "必须保留题目目标、关键定义、输出含义、全部数据范围（上下界都保留）、时限和内存；删除题解/思路/复杂度/样例推导；"
         "修正任何把“每次/任意/双方/所有对象”的规则误写成只对先手、只对一次或只对部分对象成立的表述；"
+        "保留 source 对定义的特殊约定；若 source 说无边顶点也算 only incoming edges，必须明确写“孤立点也算”；"
         "不要单列输入输出；普通输入格式删掉，只保留答案含义、多测和总和限制；正文和数据范围里的普通 a_i、a_{i+1}、a_1<...<a_n 都改成 aᵢ、aᵢ₊₁、a₁<…<aₙ、相邻位置等角标或自然写法；"
         f"{_SUMMARY_UNICODE_NOTATION_GUIDE}"
+        "严格区分 p_i+1 与 p_{i+1}：前者必须写 pᵢ+1 或自然语言中的“pᵢ 的值加 1”，"
+        "后者才写 pᵢ₊₁；不要把下标外的加法移进下标。"
         "把端点无法从 source 直接确认的角标范围改成自然语言，除非 source 明确给出该终点；"
         "把 10^18、1e18、10^9+7、1e9+7 等普通幂次改成 10¹⁸、10⁹+7；"
         "LaTeX 只在复杂公式不可自然中文化时保留。\n\n"
         f"{json.dumps(payload, ensure_ascii=False)}"
     )
+
+
+@dataclass(frozen=True)
+class SummaryDoublecheckResult:
+    """Structured semantic audit result for a generated problem summary."""
+
+    accurate: bool | None
+    issues: tuple[dict[str, str], ...] = ()
+    failure_kind: str = ""
+    model_tag: str = ""
+    provider_name: str = ""
+    model: str = ""
+
+
+def _summary_doublecheck_system_prompt() -> str:
+    return (
+        "你是算法竞赛题意的独立语义审校员。你只核对候选中文简述是否忠实于英文题面素材，"
+        "不解题、不评价文风、不补题解。source 是唯一事实依据，candidate_summary 可能包含致命转写错误。"
+        "必须只输出 JSON 对象。"
+    )
+
+
+def _build_summary_doublecheck_prompt(
+    stmt_text: str,
+    input_text: str,
+    limits_text: str,
+    summary: str,
+) -> str:
+    payload = {
+        "source": _summary_source_payload(stmt_text, input_text, limits_text),
+        "candidate_summary": summary,
+    }
+    return (
+        "逐条 double-check candidate_summary 与 source 的题意语义是否一致。\n"
+        "重点检查：\n"
+        "1. 数学符号和角标的作用域必须逐字符一致。尤其 p_i+1 表示数值 p_i 再加 1，"
+        "而 p_{i+1} 表示排列的下一个元素，二者绝不能互换；同理检查 a_{p_i}、括号、上下标和运算符。\n"
+        "2. 检查对象数量、编号范围、循环端点和相邻变量之间的换元关系。"
+        "若原题用长度 m-1 的排列配 m 个顶点，而简述改用长度 k 的排列，就必须同步核对顶点数与循环范围，不能机械照抄 m。\n"
+        "3. 检查操作方向、条件分支、唯一性/存在性、图或数组定义、答案统计对象、模数、"
+        "多测总和限制、时限和内存，以及题面明确补充的特殊定义约定（例如孤立点是否也计入某类顶点）。"
+        "主动尝试用最小合法规模验证简述是否仍可执行。\n"
+        "4. 只报告会改变题意、让过程无法执行或可能导致错误答案的实质问题。"
+        "允许忠实压缩和自然中文改写；不要因为省略背景、普通输入格式、脚注例子或样例推导而判错。\n"
+        "5. source 中的 [[IMAGE_x: ...]] 是题面图片占位符。general model 看不到图片时，"
+        "不要仅因简述包含可能来自图片的细节就判错；这些细节属于本次审校范围外，但仍要检查它们是否与可见文字冲突。\n"
+        "6. 不要在 issue 中给算法、复杂度或解题提示，只说明简述与原题的最小差异。\n\n"
+        "输出格式：\n"
+        '{"accurate":true,"issues":[]}\n'
+        "或\n"
+        '{"accurate":false,"issues":[{'
+        '"severity":"critical|major|minor",'
+        '"summary_claim":"简述中的原文片段或精确转述",'
+        '"source_fact":"题面中的对应事实",'
+        '"explanation":"两者为什么不同"}]}\n'
+        "accurate=true 时 issues 必须为空；只要有一个实质问题就必须 accurate=false。\n\n"
+        f"{json.dumps(payload, ensure_ascii=False)}"
+    )
+
+
+def _normalize_summary_doublecheck_issues(value: object) -> tuple[dict[str, str], ...] | None:
+    if not isinstance(value, list):
+        return None
+    normalized: list[dict[str, str]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            return None
+        severity = str(item.get("severity", "major") or "major").strip().lower()
+        if severity not in {"critical", "major", "minor"}:
+            severity = "major"
+        issue = {
+            "severity": severity,
+            "summary_claim": str(item.get("summary_claim", "") or "").strip(),
+            "source_fact": str(item.get("source_fact", "") or "").strip(),
+            "explanation": str(item.get("explanation", "") or "").strip(),
+        }
+        if not any(issue[key] for key in ("summary_claim", "source_fact", "explanation")):
+            return None
+        normalized.append(issue)
+    return tuple(normalized)
+
+
+async def doublecheck_problem_summary(
+    stmt_text: str,
+    input_text: str,
+    limits_text: str,
+    summary: str,
+) -> SummaryDoublecheckResult:
+    """Use the general-model queue to compare a summary against its source."""
+    cfg = get_config()
+    result = await call_chat_completion_result(
+        [
+            {"role": "system", "content": _summary_doublecheck_system_prompt()},
+            {
+                "role": "user",
+                "content": _build_summary_doublecheck_prompt(
+                    stmt_text,
+                    input_text,
+                    limits_text,
+                    summary,
+                ),
+            },
+        ],
+        task="summary",
+        temperature=0.0,
+        timeout=cfg.summary_timeout_sec,
+        response_format={"type": "json_object"},
+    )
+    if not result.text:
+        return SummaryDoublecheckResult(
+            accurate=None,
+            failure_kind=result.failure_kind or "empty_response",
+            model_tag=result.model_tag,
+            provider_name=result.provider_name,
+            model=result.model,
+        )
+
+    parsed, repair_tag = await parse_json_with_llm_repair(
+        result.text,
+        expected_schema=(
+            '{"accurate": boolean, "issues": [{"severity": string, '
+            '"summary_claim": string, "source_fact": string, "explanation": string}]}'
+        ),
+        task="summary",
+        timeout=cfg.summary_timeout_sec,
+    )
+    accurate = parsed.get("accurate") if isinstance(parsed, dict) else None
+    issues = _normalize_summary_doublecheck_issues(
+        parsed.get("issues") if isinstance(parsed, dict) else None
+    )
+    if not isinstance(accurate, bool) or issues is None or (not accurate and not issues):
+        logger.warning("summary double-check returned an invalid result: %s", parsed)
+        return SummaryDoublecheckResult(
+            accurate=None,
+            failure_kind="invalid_response",
+            model_tag=repair_tag or result.model_tag,
+            provider_name=result.provider_name,
+            model=result.model,
+        )
+    if accurate and issues:
+        accurate = False
+    return SummaryDoublecheckResult(
+        accurate=accurate,
+        issues=issues,
+        model_tag=repair_tag or result.model_tag,
+        provider_name=result.provider_name,
+        model=result.model,
+    )
+
+
+async def _repair_summary_candidate(
+    stmt_text: str,
+    input_text: str,
+    limits_text: str,
+    summary: str,
+    issues: list[str | dict[str, str]],
+    *,
+    timeout: int,
+) -> tuple[str | None, str]:
+    repair_result = await call_chat_completion_result(
+        [
+            {"role": "system", "content": _summary_system_prompt()},
+            {
+                "role": "user",
+                "content": _build_summary_repair_prompt(
+                    stmt_text,
+                    input_text,
+                    limits_text,
+                    summary,
+                    issues,
+                ),
+            },
+        ],
+        task="summary",
+        temperature=0.2,
+        timeout=timeout,
+        response_format={"type": "json_object"},
+    )
+    repaired, repaired_json_tag = await _parse_summary_json(
+        repair_result.text,
+        timeout=timeout,
+    )
+    if not repaired:
+        logger.warning("summary repair returned invalid JSON/object")
+        return None, ""
+    repair_issues = _summary_candidate_issues(
+        stmt_text,
+        input_text,
+        limits_text,
+        repaired,
+    )
+    if repair_issues:
+        logger.warning("summary repair still failed quality gate: %s", "; ".join(repair_issues))
+        return None, ""
+    return repaired, repaired_json_tag or repair_result.model_tag
 
 
 async def summarize_problem(
@@ -1402,42 +1682,63 @@ async def summarize_problem(
         logger.warning("summary generation returned invalid JSON/object")
         return None, ""
 
-    issues = _summary_quality_issues(summary, limits_text)
-    if not issues:
+    issues = _summary_candidate_issues(
+        stmt_text,
+        input_text,
+        limits_text,
+        summary,
+    )
+    if issues:
+        logger.info("summary quality repair requested: %s", "; ".join(issues))
+        summary, tag = await _repair_summary_candidate(
+            stmt_text,
+            input_text,
+            limits_text,
+            summary,
+            list(issues),
+            timeout=cfg.summary_timeout_sec,
+        )
+        if not summary:
+            return None, ""
+
+    check = await doublecheck_problem_summary(
+        stmt_text,
+        input_text,
+        limits_text,
+        summary,
+    )
+    if check.accurate is None:
+        logger.warning("summary double-check failed: %s", check.failure_kind)
+        return None, ""
+    if check.accurate:
         return summary, tag
 
-    logger.info("summary quality repair requested: %s", "; ".join(issues))
-    repair_result = await call_chat_completion_result(
-        [
-            {"role": "system", "content": _summary_system_prompt()},
-            {
-                "role": "user",
-                "content": _build_summary_repair_prompt(
-                    stmt_text,
-                    input_text,
-                    limits_text,
-                    summary,
-                    issues,
-                ),
-            },
-        ],
-        task="summary",
-        temperature=0.2,
-        timeout=cfg.summary_timeout_sec,
-        response_format={"type": "json_object"},
-    )
-    repaired, repaired_json_tag = await _parse_summary_json(
-        repair_result.text,
+    logger.info("summary semantic repair requested: %s", check.issues)
+    repaired, repaired_tag = await _repair_summary_candidate(
+        stmt_text,
+        input_text,
+        limits_text,
+        summary,
+        [dict(issue) for issue in check.issues],
         timeout=cfg.summary_timeout_sec,
     )
     if not repaired:
-        logger.warning("summary repair returned invalid JSON/object")
         return None, ""
-    repair_issues = _summary_quality_issues(repaired, limits_text)
-    if repair_issues:
-        logger.warning("summary repair still failed quality gate: %s", "; ".join(repair_issues))
+
+    repaired_check = await doublecheck_problem_summary(
+        stmt_text,
+        input_text,
+        limits_text,
+        repaired,
+    )
+    if repaired_check.accurate is not True:
+        logger.warning(
+            "repaired summary still failed semantic double-check: failure=%s issues=%s",
+            repaired_check.failure_kind,
+            repaired_check.issues,
+        )
         return None, ""
-    return repaired, repaired_json_tag or repair_result.model_tag
+    return repaired, repaired_tag
 
 
 async def translate_sample_notes(

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import sys
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -35,6 +36,7 @@ from kouhai_bot.llm import (
     _post_chat_completion_once,
     strip_leaked_thinking,
 )
+from tools import summary_doublecheck as summary_doublecheck_tool
 
 
 def test_judge_prompt_rejects_repaired_greedy_and_unbatched_simulation():
@@ -826,6 +828,18 @@ def test_summary_symbol_scope_gate_avoids_ambiguous_source_with_both_forms():
     assert _summary_symbol_scope_issues(source, "比较 pᵢ₊₁") == []
 
 
+def test_summary_symbol_scope_gate_handles_braced_source_and_latex_candidate():
+    source = "Use a_{p_{i} + 1} and the vertex p_{i} + 2."
+
+    nested_array_issues = _summary_symbol_scope_issues(source, "使用 aₚᵢ₊₁")
+    latex_issues = _summary_symbol_scope_issues(source, "使用顶点 $p_{i+2}$")
+
+    assert len(nested_array_issues) == 1
+    assert "p_i+1" in nested_array_issues[0]
+    assert len(latex_issues) == 1
+    assert "p_i+2" in latex_issues[0]
+
+
 def test_summary_required_convention_gate_preserves_isolated_vertex_rule():
     source = (
         "Note that a vertex that has no edges is considered to have only incoming edges."
@@ -839,6 +853,16 @@ def test_summary_required_convention_gate_preserves_isolated_vertex_rule():
         source,
         "每个分量有唯一只有入边的点（孤立点也算）",
     ) == []
+
+
+def test_summary_required_convention_gate_handles_wording_and_whitespace_variants():
+    source = (
+        "A vertex\nwith no edges is also considered to have only incoming edges."
+    )
+
+    issues = _summary_required_convention_issues(source, "每个分量有唯一只有入边的点")
+
+    assert len(issues) == 1
 
 
 def test_summarize_problem_uses_configured_timeout():
@@ -1028,6 +1052,115 @@ def test_doublecheck_problem_summary_uses_general_model_and_checks_symbol_scope(
     assert "p_i+1" in checker_prompt
     assert "p_{i+1}" in checker_prompt
     assert "candidate_summary" in checker_prompt
+
+
+def test_doublecheck_problem_summary_rejects_inconsistent_or_malformed_payloads():
+    cfg = _openai_cfg(summary_timeout_sec=321)
+    payloads = [
+        {
+            "accurate": True,
+            "issues": [{
+                "severity": "major",
+                "summary_claim": "候选说法",
+                "source_fact": "题面事实",
+                "explanation": "两者不一致",
+            }],
+        },
+        {
+            "accurate": False,
+            "issues": [{
+                "severity": "major",
+                "summary_claim": "候选说法",
+                "source_fact": {"unexpected": "object"},
+                "explanation": "两者不一致",
+            }],
+        },
+    ]
+
+    for payload in payloads:
+        with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+                patch(
+                    "kouhai_bot.handlers.shared.call_chat_completion_result",
+                    AsyncMock(return_value=ChatCompletionResult(text=json.dumps(payload))),
+                ):
+            result = asyncio.run(doublecheck_problem_summary(
+                "statement",
+                "input",
+                "limits",
+                "candidate",
+            ))
+
+        assert result.accurate is None
+        assert result.failure_kind == "invalid_response"
+
+
+def test_doublecheck_problem_summary_accepts_actionable_omission_issue():
+    cfg = _openai_cfg(summary_timeout_sec=321)
+    payload = {
+        "accurate": False,
+        "issues": [{
+            "severity": "major",
+            "summary_claim": "",
+            "source_fact": "题面明确规定孤立点也算只有入边的点",
+            "explanation": "候选简述遗漏了这项约定",
+        }],
+    }
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch(
+                "kouhai_bot.handlers.shared.call_chat_completion_result",
+                AsyncMock(return_value=ChatCompletionResult(text=json.dumps(payload))),
+            ):
+        result = asyncio.run(doublecheck_problem_summary(
+            "statement",
+            "input",
+            "limits",
+            "candidate",
+        ))
+
+    assert result.accurate is False
+    assert result.issues[0]["summary_claim"] == ""
+
+
+def test_summary_doublecheck_tool_explicit_inputs_ignore_state_and_strip_thinking(tmp_path):
+    cfg = _openai_cfg(data_dir=str(tmp_path), current_group=123)
+    summary_file = tmp_path / "candidate.txt"
+    summary_file.write_text("<think>hidden</think>\n候选简述", encoding="utf-8")
+    checker = AsyncMock(return_value=SummaryDoublecheckResult(accurate=True))
+    args = SimpleNamespace(
+        group=None,
+        pid="CF1900a",
+        summary_file=summary_file,
+        expect=None,
+    )
+
+    with patch.object(summary_doublecheck_tool, "get_config", return_value=cfg), \
+            patch.object(
+                summary_doublecheck_tool,
+                "_load_json",
+                side_effect=AssertionError("explicit inputs must not read group state"),
+            ), \
+            patch.object(
+                summary_doublecheck_tool,
+                "load_problem_statement_json",
+                return_value={
+                    "description": "statement",
+                    "input": "input",
+                    "time_limit": "2s",
+                    "memory_limit": "256MB",
+                },
+            ) as statement_loader, \
+            patch.object(summary_doublecheck_tool, "doublecheck_problem_summary", checker):
+        exit_code = asyncio.run(summary_doublecheck_tool._run(args))
+
+    assert exit_code == 0
+    statement_loader.assert_called_once_with("1900A")
+    checker.assert_awaited_once_with(
+        "statement",
+        "input",
+        "Time: 2s, Memory: 256MB",
+        "候选简述",
+    )
 
 
 def test_summarize_problem_repairs_symbol_scope_before_model_doublecheck():

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -9,14 +9,18 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 from kouhai_bot.config import BotConfig
 from kouhai_bot.llm_config import LlmProviderConfig
 from kouhai_bot.handlers.shared import (
+    SummaryDoublecheckResult,
     build_judge_messages,
     build_multimodal_user_content,
     build_second_judge_messages,
     _build_summary_prompt,
     _build_summary_repair_prompt,
+    _summary_required_convention_issues,
+    _summary_symbol_scope_issues,
     call_chat_completion,
     get_judge_prompt,
     call_chat_completion_result,
+    doublecheck_problem_summary,
     judge_submission,
     judge_submission_result,
     parse_json_with_llm_repair,
@@ -329,6 +333,11 @@ def test_summarize_problem_with_images_uses_multimodal_task():
 
     async def fake_call(messages, **kwargs):
         calls.append({"messages": messages, **kwargs})
+        if kwargs["task"] == "summary":
+            return ChatCompletionResult(
+                text=json.dumps({"accurate": True, "issues": []}),
+                model_tag="『T』",
+            )
         return ChatCompletionResult(
             text=json.dumps({"summary": "带图题意"}),
             model_tag="『MMx』",
@@ -347,6 +356,7 @@ def test_summarize_problem_with_images_uses_multimodal_task():
     assert summary == "带图题意"
     assert tag == "『MMx』"
     assert calls[0]["task"] == "multimodal_summary"
+    assert calls[1]["task"] == "summary"
     content = calls[0]["messages"][1]["content"]
     assert isinstance(content, list)
     assert content[0]["type"] == "text"
@@ -511,6 +521,8 @@ def test_task_entrypoints_are_blackbox_except_model_class_and_tag():
             system_content = payload["messages"][0]["content"]
             if "official_editorial" in user_content:
                 text = json.dumps({"matched": "yes", "result": "中文题解"})
+            elif "独立语义审校员" in system_content:
+                text = json.dumps({"accurate": True, "issues": []})
             elif "summary" in system_content:
                 text = json.dumps({"summary": "OK"})
             else:
@@ -553,6 +565,7 @@ def test_task_entrypoints_are_blackbox_except_model_class_and_tag():
     assert [call["model"] for call in calls] == [
         "deepseek-v4-pro",
         "deepseek-v4-pro",
+        "deepseek-v4-flash",
         "deepseek-v4-flash",
         "deepseek-v4-flash",
         "deepseek-v4-flash",
@@ -789,6 +802,43 @@ def test_summary_prompt_lists_unicode_notation_inventory():
         assert "10⁹+7" in text
         assert "不要自己创造看起来像角标的字母" in text
         assert "字符白名单不够用时，优先改成自然语言" in text
+        assert "p_i+1" in text
+        assert "pᵢ+1" in text
+        assert "p_{i+1}" in text
+        assert "pᵢ₊₁" in text
+        assert "孤立点也算" in text
+
+
+def test_summary_symbol_scope_gate_distinguishes_addition_from_next_index():
+    source = "Use components containing vertices p_i and p_i+1 respectively."
+
+    assert _summary_symbol_scope_issues(source, "分别取 pᵢ 和 pᵢ+1 所在分量") == []
+    issues = _summary_symbol_scope_issues(source, "分别取 pᵢ 和 pᵢ₊₁ 所在分量")
+
+    assert len(issues) == 1
+    assert "p_i+1" in issues[0]
+    assert "pᵢ₊₁" in issues[0]
+
+
+def test_summary_symbol_scope_gate_avoids_ambiguous_source_with_both_forms():
+    source = "Compare p_i+1 with p_{i+1}."
+
+    assert _summary_symbol_scope_issues(source, "比较 pᵢ₊₁") == []
+
+
+def test_summary_required_convention_gate_preserves_isolated_vertex_rule():
+    source = (
+        "Note that a vertex that has no edges is considered to have only incoming edges."
+    )
+
+    issues = _summary_required_convention_issues(source, "每个分量有唯一只有入边的点")
+
+    assert len(issues) == 1
+    assert "isolated vertices also count" in issues[0]
+    assert _summary_required_convention_issues(
+        source,
+        "每个分量有唯一只有入边的点（孤立点也算）",
+    ) == []
 
 
 def test_summarize_problem_uses_configured_timeout():
@@ -805,7 +855,11 @@ def test_summarize_problem_uses_configured_timeout():
         return ChatCompletionResult(text=json.dumps({"summary": "summary ok"}), model_tag="🐳")
 
     with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
-            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat):
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat), \
+            patch(
+                "kouhai_bot.handlers.shared.doublecheck_problem_summary",
+                AsyncMock(return_value=SummaryDoublecheckResult(accurate=True)),
+            ):
         summary, tag = asyncio.run(summarize_problem("stmt", "input", "limits"))
         assert summary == "summary ok"
         assert tag == "🐳"
@@ -827,7 +881,11 @@ def test_summarize_problem_repairs_solution_leak_and_format_sections():
         return ChatCompletionResult(text=json.dumps({"summary": text}), model_tag=tag)
 
     with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
-            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat):
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat), \
+            patch(
+                "kouhai_bot.handlers.shared.doublecheck_problem_summary",
+                AsyncMock(return_value=SummaryDoublecheckResult(accurate=True)),
+            ):
         summary, tag = asyncio.run(summarize_problem("stmt", "input", "limits"))
 
     assert summary == fixed
@@ -845,7 +903,35 @@ def test_summarize_problem_invalid_json_returns_none():
         return ChatCompletionResult(text="plain text summary", model_tag="🐳")
 
     with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
-            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat):
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat), \
+            patch(
+                "kouhai_bot.handlers.shared.doublecheck_problem_summary",
+                AsyncMock(return_value=SummaryDoublecheckResult(accurate=True)),
+            ):
+        summary, tag = asyncio.run(summarize_problem("stmt", "input", "limits"))
+
+    assert summary is None
+    assert tag == ""
+
+
+def test_summarize_problem_rejects_indeterminate_semantic_check():
+    cfg = _openai_cfg(summary_timeout_sec=321)
+
+    async def fake_call_chat(messages, **kwargs):
+        return ChatCompletionResult(
+            text=json.dumps({"summary": "给定 n，输出答案。"}),
+            model_tag="🐳",
+        )
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat), \
+            patch(
+                "kouhai_bot.handlers.shared.doublecheck_problem_summary",
+                AsyncMock(return_value=SummaryDoublecheckResult(
+                    accurate=None,
+                    failure_kind="service_unavailable",
+                )),
+            ):
         summary, tag = asyncio.run(summarize_problem("stmt", "input", "limits"))
 
     assert summary is None
@@ -864,7 +950,11 @@ def test_summarize_problem_repairs_missing_time_and_memory_limits():
         return ChatCompletionResult(text=json.dumps({"summary": text}), model_tag="🐳")
 
     with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
-            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat):
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat), \
+            patch(
+                "kouhai_bot.handlers.shared.doublecheck_problem_summary",
+                AsyncMock(return_value=SummaryDoublecheckResult(accurate=True)),
+            ):
         summary, tag = asyncio.run(summarize_problem(
             "stmt",
             "input",
@@ -886,11 +976,133 @@ def test_summarize_problem_does_not_rewrite_formula_notation_with_regex():
         return ChatCompletionResult(text=json.dumps({"summary": summary_text}), model_tag="🐳")
 
     with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
-            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat):
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat), \
+            patch(
+                "kouhai_bot.handlers.shared.doublecheck_problem_summary",
+                AsyncMock(return_value=SummaryDoublecheckResult(accurate=True)),
+            ):
         summary, tag = asyncio.run(summarize_problem("stmt", "input", "limits"))
 
     assert summary == summary_text
     assert tag == "🐳"
+
+
+def test_doublecheck_problem_summary_uses_general_model_and_checks_symbol_scope():
+    cfg = _openai_cfg(summary_timeout_sec=321)
+    calls = []
+
+    async def fake_call_chat(messages, **kwargs):
+        calls.append({"messages": messages, **kwargs})
+        return ChatCompletionResult(
+            text=json.dumps({
+                "accurate": False,
+                "issues": [{
+                    "severity": "critical",
+                    "summary_claim": "含 pᵢ₊₁ 的弱连通分量",
+                    "source_fact": "containing vertices p_i and p_i+1 respectively",
+                    "explanation": "p_{i+1} 是下一个排列元素，p_i+1 是顶点编号加一。",
+                }],
+            }),
+            model_tag="🐳",
+            provider_name="general",
+            model="general-model",
+        )
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat):
+        result = asyncio.run(doublecheck_problem_summary(
+            "components containing vertices p_i and p_i+1 respectively",
+            "",
+            "Time: 2s, Memory: 1024MB",
+            "分别取含 pᵢ 和 pᵢ₊₁ 的弱连通分量",
+        ))
+
+    assert result.accurate is False
+    assert result.issues[0]["severity"] == "critical"
+    assert "p_i+1" in result.issues[0]["source_fact"]
+    assert calls[0]["task"] == "summary"
+    assert calls[0]["temperature"] == 0.0
+    assert calls[0]["timeout"] == 321
+    assert calls[0]["response_format"] == {"type": "json_object"}
+    checker_prompt = calls[0]["messages"][-1]["content"]
+    assert "p_i+1" in checker_prompt
+    assert "p_{i+1}" in checker_prompt
+    assert "candidate_summary" in checker_prompt
+
+
+def test_summarize_problem_repairs_symbol_scope_before_model_doublecheck():
+    cfg = _openai_cfg(summary_timeout_sec=321)
+    bad = "对 i=1..k-1，分别取 pᵢ 和 pᵢ₊₁ 所在分量的汇点并连边。"
+    fixed = "对 i=1..k，分别取 pᵢ 和编号为 pᵢ+1 的顶点所在分量的汇点并连边。"
+    responses = [
+        ChatCompletionResult(text=json.dumps({"summary": bad}), model_tag="first"),
+        ChatCompletionResult(text=json.dumps({"summary": fixed}), model_tag="fixed"),
+        ChatCompletionResult(
+            text=json.dumps({"accurate": True, "issues": []}),
+            model_tag="checker",
+        ),
+    ]
+    calls = []
+
+    async def fake_call_chat(messages, **kwargs):
+        calls.append({"messages": messages, **kwargs})
+        return responses[len(calls) - 1]
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat):
+        summary, tag = asyncio.run(summarize_problem(
+            "For i from 1 to m-1, use components containing p_i and p_i+1.",
+            "",
+            "",
+        ))
+
+    assert summary == fixed
+    assert tag == "fixed"
+    assert [call["temperature"] for call in calls] == [0.4, 0.2, 0.0]
+    repair_payload = calls[1]["messages"][-1]["content"]
+    assert "p_i+1" in repair_payload
+    assert "pᵢ₊₁" in repair_payload
+
+
+def test_summarize_problem_repairs_semantic_mismatch_and_doublechecks_again():
+    cfg = _openai_cfg(summary_timeout_sec=321)
+    bad = "若 aₚᵢ=0 则加边 u→v，否则加边 v→u。"
+    fixed = "若 aₚᵢ=0 则加边 v→u，否则加边 u→v。"
+    responses = [
+        ChatCompletionResult(text=json.dumps({"summary": bad}), model_tag="first"),
+        ChatCompletionResult(text=json.dumps({
+            "accurate": False,
+            "issues": [{
+                "severity": "critical",
+                "summary_claim": "aₚᵢ=0 时加边 u→v",
+                "source_fact": "a_{p_i}=0 时加边 v→u",
+                "explanation": "两个分支的边方向写反了。",
+            }],
+        }), model_tag="checker"),
+        ChatCompletionResult(text=json.dumps({"summary": fixed}), model_tag="fixed"),
+        ChatCompletionResult(
+            text=json.dumps({"accurate": True, "issues": []}),
+            model_tag="checker",
+        ),
+    ]
+    calls = []
+
+    async def fake_call_chat(messages, **kwargs):
+        calls.append({"messages": messages, **kwargs})
+        return responses[len(calls) - 1]
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), \
+            patch("kouhai_bot.handlers.shared.call_chat_completion_result", side_effect=fake_call_chat):
+        summary, tag = asyncio.run(summarize_problem(
+            "If a_{p_i}=0, add v to u; otherwise add u to v.",
+            "",
+            "",
+        ))
+
+    assert summary == fixed
+    assert tag == "fixed"
+    assert [call["temperature"] for call in calls] == [0.4, 0.0, 0.2, 0.0]
+    assert "边方向写反" in calls[2]["messages"][-1]["content"]
 
 
 def test_dashscope_provider_payload_enables_stream():

--- a/tools/summary_doublecheck.py
+++ b/tools/summary_doublecheck.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Run the general-model semantic checker against a saved problem summary."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from kouhai_bot.config import get_config
+from kouhai_bot.handlers.shared import (
+    doublecheck_problem_summary,
+    load_problem_statement_json,
+)
+from kouhai_bot.llm import strip_leaked_thinking
+
+
+def _load_json(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    if not isinstance(data, dict):
+        raise RuntimeError(f"expected a JSON object in {path}")
+    return data
+
+
+def _statement_inputs(statement: dict) -> tuple[str, str, str]:
+    return (
+        str(statement.get("description", "") or ""),
+        str(statement.get("input", "") or ""),
+        (
+            f"Time: {statement.get('time_limit', '?')}, "
+            f"Memory: {statement.get('memory_limit', '?')}"
+        ),
+    )
+
+
+async def _run(args: argparse.Namespace) -> int:
+    cfg = get_config()
+    group_id = args.group if args.group is not None else cfg.current_group
+    group_dir = Path(cfg.data_dir) / "groups" / str(group_id)
+    state = _load_json(group_dir / "state.json")
+    pid = str(args.pid or state.get("today", "") or "").strip().upper()
+    if not pid:
+        raise RuntimeError(f"group {group_id} has no current problem; pass --pid")
+
+    statement = load_problem_statement_json(pid)
+    if not statement:
+        raise RuntimeError(f"statement cache not found for {pid}")
+
+    if args.summary_file:
+        summary = args.summary_file.read_text(encoding="utf-8").strip()
+    else:
+        saved = _load_json(group_dir / "problem_summaries.json").get(pid)
+        if isinstance(saved, dict):
+            summary = str(saved.get("summary_zh", "") or "").strip()
+        else:
+            summary = str(saved or "").strip()
+        summary = strip_leaked_thinking(summary)
+    if not summary:
+        raise RuntimeError(
+            f"saved summary not found for group {group_id}, problem {pid}; "
+            "pass --summary-file"
+        )
+
+    result = await doublecheck_problem_summary(*_statement_inputs(statement), summary)
+    payload = {
+        "group_id": group_id,
+        "pid": pid,
+        "accurate": result.accurate,
+        "issues": list(result.issues),
+        "failure_kind": result.failure_kind,
+        "provider_name": result.provider_name,
+        "model": result.model,
+    }
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+    if result.accurate is None:
+        return 2
+    if args.expect == "accurate":
+        return 0 if result.accurate else 1
+    if args.expect == "inaccurate":
+        return 0 if not result.accurate else 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Use llm.general_model to compare a saved Chinese summary with its "
+            "cached Codeforces statement. No runtime data is modified."
+        )
+    )
+    parser.add_argument("--group", type=int, help="group id (default: current_group)")
+    parser.add_argument("--pid", help="problem id (default: the group's current problem)")
+    parser.add_argument(
+        "--summary-file",
+        type=Path,
+        help="UTF-8 candidate summary file (default: group's saved summary)",
+    )
+    parser.add_argument(
+        "--expect",
+        choices=("accurate", "inaccurate"),
+        help="exit nonzero unless the checker returns this verdict",
+    )
+    args = parser.parse_args()
+    try:
+        return asyncio.run(_run(args))
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"summary double-check harness failed: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/summary_doublecheck.py
+++ b/tools/summary_doublecheck.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -20,11 +21,18 @@ from kouhai_bot.handlers.shared import (
 from kouhai_bot.llm import strip_leaked_thinking
 
 
+_PID_RE = re.compile(r"^(?:CF)?(?P<contest>\d+)(?P<index>[A-Z][A-Z0-9]*)$", re.I)
+
+
 def _load_json(path: Path) -> dict:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         return {}
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"invalid JSON in {path}: {exc.msg}") from exc
+    except (OSError, UnicodeError) as exc:
+        raise RuntimeError(f"could not read {path}: {exc}") from exc
     if not isinstance(data, dict):
         raise RuntimeError(f"expected a JSON object in {path}")
     return data
@@ -41,14 +49,26 @@ def _statement_inputs(statement: dict) -> tuple[str, str, str]:
     )
 
 
+def _normalize_pid(value: object) -> str:
+    raw = str(value or "").strip()
+    match = _PID_RE.fullmatch(raw)
+    if not match:
+        raise RuntimeError(f"invalid problem id {raw!r}; expected a value such as 1900A")
+    return f"{match.group('contest')}{match.group('index').upper()}"
+
+
 async def _run(args: argparse.Namespace) -> int:
     cfg = get_config()
     group_id = args.group if args.group is not None else cfg.current_group
     group_dir = Path(cfg.data_dir) / "groups" / str(group_id)
-    state = _load_json(group_dir / "state.json")
-    pid = str(args.pid or state.get("today", "") or "").strip().upper()
-    if not pid:
+    if args.pid:
+        raw_pid = args.pid
+    else:
+        state = _load_json(group_dir / "state.json")
+        raw_pid = state.get("today", "")
+    if not str(raw_pid or "").strip():
         raise RuntimeError(f"group {group_id} has no current problem; pass --pid")
+    pid = _normalize_pid(raw_pid)
 
     statement = load_problem_statement_json(pid)
     if not statement:
@@ -62,7 +82,7 @@ async def _run(args: argparse.Namespace) -> int:
             summary = str(saved.get("summary_zh", "") or "").strip()
         else:
             summary = str(saved or "").strip()
-        summary = strip_leaked_thinking(summary)
+    summary = strip_leaked_thinking(summary)
     if not summary:
         raise RuntimeError(
             f"saved summary not found for group {group_id}, problem {pid}; "


### PR DESCRIPTION
## Summary

- add a deterministic, source-aware summary gate for symbol scope and explicit definition conventions
- audit every generated summary against the original statement with a structured `llm.general_model` request
- repair a failed candidate once, re-run the audit, and fail closed if the result is still wrong or indeterminate
- add a read-only regression harness plus focused tests and development documentation

## Root cause

The existing summary pipeline checked formatting, limits, and solution leakage, but did not compare the final wording back to the source statement. That allowed a Unicode transcription such as `p_i+1` (the value at index `i`, plus one) becoming `pᵢ₊₁` (the next indexed value), which makes the described process invalid. Related counts, loop endpoints, and special definition conventions could be lost for the same reason.

## Impact

Problem summaries now keep using the standard JSON-content flow and existing JSON-repair fallback, while adding an independent semantic double-check through the general-model queue. A bad summary is repaired and checked again before it can be posted; unresolved or malformed checks reject the candidate so the caller can retry.

## Validation

- `uv run pytest tests/test_shared.py -q` — 60 passed
- `uv run python -m py_compile src/kouhai_bot/handlers/shared.py tools/summary_doublecheck.py`
- `git diff --check`
- ran the harness against the saved bad 1806D summary with `--expect inaccurate`; it detected the `k+1` vertex count, `i=1..k` loop endpoint, and `p_i+1` / `p_{i+1}` scope errors
- regenerated the 1806D summary from the cached source end to end; the final summary preserved `k+1`, `i=1..k`, `pᵢ+1`, and the isolated-vertex convention, and an independent final audit returned `accurate=true`
