### PR TITLE
fix: unified CF HTML fetcher with Playwright fallback (closes #65, closes #66)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,13 @@ NapCat (QQ) ──WS──> worker.py
   only as fallback.
 - **Scheduler current-group config**: `~/.kouhai-bot/scheduler_config.json` stores job list + time overrides for `CURRENT_GROUP`. Jobs are defined in `scheduler/jobs.py`.
 - **Multimodal statements**: `problems/fetcher.py` collects CF `tex-formula` and `tex-graphics` image metadata with statement text. Formula images and diagrams are passed to `llm.multimodal_model` for new-problem summaries and `/clarify`; without that queue, picker logs and skips image-bearing problems.
+- **Unified CF HTML transport**: `problems/cf_fetcher.py` is the single transport for
+  Codeforces problem statement and blog HTML. It tries `cloudscraper` first and falls
+  back to headless Playwright Chromium after HTTP 403, timeout/connection failure,
+  Cloudflare challenge HTML, or a lazy `Tutorial is loading...` response. Its
+  `content_valid()` helper is the shared usability gate. `picker.fetch_statement()`
+  fetches each uncached statement once and passes that HTML into
+  `fetcher.process_problem()` for image/text extraction as well as metadata parsing.
 - **Stale cache detection**: `picker.py:fetch_statement()` detects caches created before image metadata via `_images_collected`. Stale caches with images are re-fetched so image metadata is available for multimodal tasks.
 - **No hermes cron involvement**: The bot runs its own scheduler loop (`scheduler/engine.py`), not hermes cron jobs.
 - **Single worker runtime**: `worker.py` keeps the NapCat reverse-WS connection, dispatches commands, and owns the scheduler in one process. There is no SQLite event queue, ingress supervisor, worker hot-swap, or auto-update loop.
@@ -75,7 +82,9 @@ NapCat (QQ) ──WS──> worker.py
   `schedule_post_solve_editorial_followup()` only **delivers** (awaits in-flight prefetch if
   needed). Neither path uses the state scheduler. Tutorial scraping depends on Playwright
   with Chromium installed for browser fallback when HTTP fetches hit Codeforces blocking.
-  `/review` uses English editorial in LLM context only.
+  `/review` uses English editorial in LLM context only. Tutorial-specific parsing and
+  dynamic-fragment handling remain in `tools/scrape_cf_tutorial.py`; its page-fetching
+  entry points delegate to `problems/cf_fetcher.py`.
 
 ## Configuration
 
@@ -1009,7 +1018,9 @@ Tests mock `data_dir`, group state files, and LLM responses for end-to-end
 command testing. The suite covers submit, clarify, review, problem, tag, scoreboard,
 newproblem, annotation export, napcat parsing, registry discovery, and
 `tutorials.py` extraction/translation (`tests/test_tutorials.py`; submit/review
-editorial paths in `tests/test_commands.py`).
+editorial paths in `tests/test_commands.py`). Shared Codeforces transport fallback
+coverage lives in `tests/test_cf_fetcher.py`; tutorial wrapper delegation is covered by
+`tests/test_scrape_cf_tutorial.py`.
 
 ## GitHub CI
 

--- a/src/kouhai_bot/problems/cf_fetcher.py
+++ b/src/kouhai_bot/problems/cf_fetcher.py
@@ -12,6 +12,7 @@ import re
 from typing import Literal
 
 import cloudscraper
+from cloudscraper import exceptions as cloudscraper_exceptions
 from requests import exceptions as requests_exceptions
 
 try:
@@ -33,13 +34,13 @@ CF_PLAYWRIGHT_USER_AGENT = (
 CF_PLAYWRIGHT_VIEWPORT = {"width": 1365, "height": 768}
 CF_CONTENT_SELECTOR = ".problem-statement, .ttypography"
 CF_CONTENT_WAIT_MS = 45_000
+CF_TUTORIAL_LOADING_WAIT_MS = 5_000
 
 _CHALLENGE_RE = re.compile(
-    r"browser is being checked|please wait\.|just a moment|cf-mitigated",
+    r"_cf_chl_opt|challenge-platform|cf-browser-verify",
     re.I,
 )
 _TUTORIAL_LOADING_RE = re.compile(r"tutorial\s+is\s+loading(?:\.\.\.)?", re.I)
-_SCRAPER = None
 
 
 class CFFetchError(RuntimeError):
@@ -51,11 +52,8 @@ class CFFetchError(RuntimeError):
 
 
 def get_scraper():
-    """Return the process-wide cloudscraper session."""
-    global _SCRAPER
-    if _SCRAPER is None:
-        _SCRAPER = cloudscraper.create_scraper()
-    return _SCRAPER
+    """Create an isolated cloudscraper session for one HTTP fetch."""
+    return cloudscraper.create_scraper()
 
 
 def content_valid(body: str) -> bool:
@@ -76,8 +74,10 @@ def content_valid(body: str) -> bool:
 
 def fetch_html_http(url: str, *, timeout: float = 30) -> str:
     """Fetch a Codeforces HTML page with cloudscraper only."""
+    scraper = None
     try:
-        response = get_scraper().get(url, timeout=timeout)
+        scraper = get_scraper()
+        response = scraper.get(url, timeout=timeout)
         response.raise_for_status()
     except requests_exceptions.HTTPError as exc:
         status = getattr(getattr(exc, "response", None), "status_code", None)
@@ -96,6 +96,24 @@ def fetch_html_http(url: str, *, timeout: float = 30) -> str:
             f"Codeforces HTTP connection failed for {url}: {exc}",
             kind="connection",
         ) from exc
+    except requests_exceptions.RequestException as exc:
+        raise CFFetchError(
+            f"Codeforces HTTP request failed for {url}: {exc}",
+            kind="connection",
+        ) from exc
+    except (
+        cloudscraper_exceptions.CloudflareException,
+        cloudscraper_exceptions.CaptchaException,
+    ) as exc:
+        raise CFFetchError(
+            f"Codeforces challenge handling failed for {url}: {exc}",
+            kind="content",
+        ) from exc
+    finally:
+        if scraper is not None:
+            close = getattr(scraper, "close", None)
+            if close is not None:
+                close()
 
     body = response.text
     if not content_valid(body):
@@ -130,6 +148,19 @@ def fetch_html_playwright(url: str, *, wait_ms: int = 7000) -> str:
                     # The final content check below still rejects challenge pages.
                     pass
                 body = page.content()
+                if _TUTORIAL_LOADING_RE.search(body):
+                    try:
+                        page.wait_for_function(
+                            """() => !/tutorial\\s+is\\s+loading(?:\\.\\.\\.)?/i.test(
+                                document.body?.innerText || ''
+                            )""",
+                            timeout=CF_TUTORIAL_LOADING_WAIT_MS,
+                        )
+                    except PlaywrightTimeoutError:
+                        # The final content check produces a stable content error if
+                        # the lazy tutorial fragment never becomes available.
+                        pass
+                    body = page.content()
             finally:
                 browser.close()
     except PlaywrightTimeoutError as exc:

--- a/src/kouhai_bot/problems/cf_fetcher.py
+++ b/src/kouhai_bot/problems/cf_fetcher.py
@@ -1,0 +1,185 @@
+"""Shared Codeforces HTML transport with a browser fallback.
+
+Problem statements and tutorial blogs use the same fetch policy: try the cheap
+HTTP client first, then retry with headless Chromium when Codeforces blocks the
+request or returns HTML that still contains a client-side loading placeholder.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Literal
+
+import cloudscraper
+from requests import exceptions as requests_exceptions
+
+try:
+    from playwright.sync_api import Error as PlaywrightError
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+    from playwright.sync_api import sync_playwright
+except ImportError:  # pragma: no cover - playwright is a runtime dependency
+    sync_playwright = None
+    PlaywrightError = Exception
+    PlaywrightTimeoutError = TimeoutError
+
+logger = logging.getLogger("kouhai-bot.cf_fetcher")
+
+CF_PLAYWRIGHT_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/131.0.0.0 Safari/537.36"
+)
+CF_PLAYWRIGHT_VIEWPORT = {"width": 1365, "height": 768}
+CF_CONTENT_SELECTOR = ".problem-statement, .ttypography"
+CF_CONTENT_WAIT_MS = 45_000
+
+_CHALLENGE_RE = re.compile(
+    r"browser is being checked|please wait\.|just a moment|cf-mitigated",
+    re.I,
+)
+_TUTORIAL_LOADING_RE = re.compile(r"tutorial\s+is\s+loading(?:\.\.\.)?", re.I)
+_SCRAPER = None
+
+
+class CFFetchError(RuntimeError):
+    """A Codeforces fetch failed or returned unusable content."""
+
+    def __init__(self, message: str, *, kind: str = "fetch"):
+        super().__init__(message)
+        self.kind = kind
+
+
+def get_scraper():
+    """Return the process-wide cloudscraper session."""
+    global _SCRAPER
+    if _SCRAPER is None:
+        _SCRAPER = cloudscraper.create_scraper()
+    return _SCRAPER
+
+
+def content_valid(body: str) -> bool:
+    """Return whether a fetched CF document is usable by HTML clients.
+
+    Besides empty and Cloudflare challenge pages, this rejects legacy blog
+    pages whose HTTP response only exposes ``Tutorial is loading...`` content.
+    Chromium renders those lazy-loaded tutorial fragments before returning.
+    """
+    if not isinstance(body, str) or not body.strip():
+        return False
+    if _CHALLENGE_RE.search(body):
+        return False
+    if _TUTORIAL_LOADING_RE.search(body):
+        return False
+    return True
+
+
+def fetch_html_http(url: str, *, timeout: float = 30) -> str:
+    """Fetch a Codeforces HTML page with cloudscraper only."""
+    try:
+        response = get_scraper().get(url, timeout=timeout)
+        response.raise_for_status()
+    except requests_exceptions.HTTPError as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        kind = "forbidden" if status == 403 else "http"
+        raise CFFetchError(
+            f"Codeforces HTTP fetch failed for {url}: {exc}",
+            kind=kind,
+        ) from exc
+    except requests_exceptions.Timeout as exc:
+        raise CFFetchError(
+            f"Codeforces HTTP fetch timed out for {url}: {exc}",
+            kind="timeout",
+        ) from exc
+    except requests_exceptions.ConnectionError as exc:
+        raise CFFetchError(
+            f"Codeforces HTTP connection failed for {url}: {exc}",
+            kind="connection",
+        ) from exc
+
+    body = response.text
+    if not content_valid(body):
+        raise CFFetchError(f"Codeforces returned unusable HTML for {url}", kind="content")
+    return body
+
+
+def fetch_html_playwright(url: str, *, wait_ms: int = 7000) -> str:
+    """Fetch a rendered Codeforces HTML page with headless Chromium."""
+    if sync_playwright is None:
+        raise CFFetchError(
+            "Playwright is not installed; install Playwright and Chromium first",
+            kind="dependency",
+        )
+
+    try:
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=True)
+            try:
+                context = browser.new_context(
+                    user_agent=CF_PLAYWRIGHT_USER_AGENT,
+                    viewport=CF_PLAYWRIGHT_VIEWPORT,
+                )
+                page = context.new_page()
+                page.goto(url, wait_until="domcontentloaded", timeout=45_000)
+                if wait_ms > 0:
+                    page.wait_for_timeout(wait_ms)
+                try:
+                    page.wait_for_selector(CF_CONTENT_SELECTOR, timeout=CF_CONTENT_WAIT_MS)
+                except PlaywrightTimeoutError:
+                    # Some valid CF pages do not use either common content class.
+                    # The final content check below still rejects challenge pages.
+                    pass
+                body = page.content()
+            finally:
+                browser.close()
+    except PlaywrightTimeoutError as exc:
+        raise CFFetchError(
+            f"Playwright timed out fetching {url}: {exc}",
+            kind="timeout",
+        ) from exc
+    except PlaywrightError as exc:
+        raise CFFetchError(
+            f"Playwright failed fetching {url}: {exc}",
+            kind="browser",
+        ) from exc
+
+    if not content_valid(body):
+        raise CFFetchError(
+            f"Playwright returned unusable Codeforces HTML for {url}",
+            kind="content",
+        )
+    return body
+
+
+def fetch_html(
+    url: str,
+    *,
+    fetcher: Literal["auto", "http", "playwright"] = "auto",
+    timeout: float = 30,
+    pw_wait_ms: int = 7000,
+) -> str:
+    """Fetch CF HTML using HTTP, Playwright, or automatic fallback."""
+    if fetcher == "http":
+        return fetch_html_http(url, timeout=timeout)
+    if fetcher == "playwright":
+        return fetch_html_playwright(url, wait_ms=pw_wait_ms)
+    if fetcher != "auto":
+        raise ValueError(f"unknown Codeforces fetcher: {fetcher}")
+
+    try:
+        body = fetch_html_http(url, timeout=timeout)
+        if not content_valid(body):
+            raise CFFetchError(
+                f"Codeforces returned unusable HTML for {url}",
+                kind="content",
+            )
+        return body
+    except CFFetchError as exc:
+        if exc.kind not in {"forbidden", "timeout", "connection", "content"}:
+            raise
+        logger.info(
+            "CF HTTP fetch failed (%s); falling back to Playwright for %s",
+            exc.kind,
+            url,
+        )
+        return fetch_html_playwright(url, wait_ms=pw_wait_ms)

--- a/src/kouhai_bot/problems/cf_fetcher.py
+++ b/src/kouhai_bot/problems/cf_fetcher.py
@@ -41,6 +41,7 @@ _CHALLENGE_RE = re.compile(
     re.I,
 )
 _TUTORIAL_LOADING_RE = re.compile(r"tutorial\s+is\s+loading(?:\.\.\.)?", re.I)
+_TRANSIENT_HTTP_STATUSES = {429, 502, 503, 504}
 
 
 class CFFetchError(RuntimeError):
@@ -81,7 +82,12 @@ def fetch_html_http(url: str, *, timeout: float = 30) -> str:
         response.raise_for_status()
     except requests_exceptions.HTTPError as exc:
         status = getattr(getattr(exc, "response", None), "status_code", None)
-        kind = "forbidden" if status == 403 else "http"
+        if status == 403:
+            kind = "forbidden"
+        elif status in _TRANSIENT_HTTP_STATUSES:
+            kind = "transient_http"
+        else:
+            kind = "http"
         raise CFFetchError(
             f"Codeforces HTTP fetch failed for {url}: {exc}",
             kind=kind,
@@ -206,7 +212,13 @@ def fetch_html(
             )
         return body
     except CFFetchError as exc:
-        if exc.kind not in {"forbidden", "timeout", "connection", "content"}:
+        if exc.kind not in {
+            "forbidden",
+            "transient_http",
+            "timeout",
+            "connection",
+            "content",
+        }:
             raise
         logger.info(
             "CF HTTP fetch failed (%s); falling back to Playwright for %s",

--- a/src/kouhai_bot/problems/fetcher.py
+++ b/src/kouhai_bot/problems/fetcher.py
@@ -28,8 +28,12 @@ import urllib.request
 from io import BytesIO
 from urllib.parse import urljoin
 
-import cloudscraper
 from PIL import Image
+
+try:
+    from . import cf_fetcher
+except ImportError:  # Support direct execution of this file.
+    import cf_fetcher
 
 # ── Config ──────────────────────────────────────────────────────────────
 
@@ -42,8 +46,6 @@ QWEN_MODEL = os.environ.get("QWEN_MODEL", "").strip()
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
 OPENAI_BASE_URL = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
 OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o")
-
-_scraper = None
 
 # Hallucination patterns — if VL output matches these, it's likely garbage
 _HALLUCINATION_PATTERNS = [
@@ -79,22 +81,19 @@ def _qwen_config() -> tuple[str, str, str]:
     return api_key.strip(), base_url.rstrip("/"), model.strip()
 
 
-def get_scraper():
-    global _scraper
-    if _scraper is None:
-        _scraper = cloudscraper.create_scraper()
-    return _scraper
-
-
 # ── Fetch problem page ──────────────────────────────────────────────────
 
-def fetch_problem_html(contest_id: int, index: str) -> tuple[str, str]:
+def fetch_problem_html(
+    contest_id: int,
+    index: str,
+    *,
+    fetcher: str = "auto",
+    pw_wait_ms: int = 7000,
+) -> tuple[str, str]:
     """Fetch CF problem page, return (html, pid)."""
     url = f"https://codeforces.com/problemset/problem/{contest_id}/{index}"
-    scraper = get_scraper()
-    resp = scraper.get(url, timeout=30)
-    resp.raise_for_status()
-    return resp.text, f"{contest_id}{index}"
+    body = cf_fetcher.fetch_html(url, fetcher=fetcher, pw_wait_ms=pw_wait_ms)
+    return body, f"{contest_id}{index}"
 
 
 # ── Extract problem statement block ─────────────────────────────────────
@@ -361,8 +360,10 @@ def process_problem(
     contest_id: int,
     index: str,
     vl_backend: str = "none",
+    *,
+    html: str | None = None,
 ) -> dict:
-    """Full pipeline: fetch → extract → handle formulas → return text + metadata.
+    """Fetch or reuse HTML, extract the statement, and return text + metadata.
 
     Returns dict with keys:
       - pid, url, text, text_length
@@ -371,7 +372,11 @@ def process_problem(
       - has_non_formula_images: True if tex-graphics (diagrams) found
       - formulas_failed: number of formulas that couldn't be converted after retries
     """
-    html, pid = fetch_problem_html(contest_id, index)
+    pid = f"{contest_id}{index}"
+    if html is None:
+        html, pid = fetch_problem_html(contest_id, index)
+    elif not cf_fetcher.content_valid(html):
+        return {"error": "Unusable Codeforces HTML", "pid": pid}
     ps_html = extract_problem_statement(html)
     if not ps_html:
         return {"error": "Could not find problem-statement div", "pid": pid}

--- a/src/kouhai_bot/problems/picker.py
+++ b/src/kouhai_bot/problems/picker.py
@@ -13,12 +13,15 @@ import os
 import random
 import re
 import sys
-
-# Import cf_statement for Codeforces statement/image extraction
-sys.path.insert(0, os.path.dirname(__file__))
-import fetcher as cf_statement
 import time
 from datetime import datetime, timezone, timedelta
+
+try:
+    from . import cf_fetcher, fetcher as cf_statement
+except ImportError:  # Support direct execution of this file.
+    sys.path.insert(0, os.path.dirname(__file__))
+    import cf_fetcher
+    import fetcher as cf_statement
 
 import cloudscraper
 
@@ -309,8 +312,22 @@ def fetch_statement(problem: dict) -> object:
                 return None
             return cached
 
+    # Fetch once, then share the same rendered document between statement/image
+    # extraction and title/limits/sample parsing.
+    url = f"https://codeforces.com/problemset/problem/{contest_id}/{index}"
+    try:
+        raw_html = cf_fetcher.fetch_html(url)
+    except Exception as e:
+        print(f"Warning: failed to fetch {url}: {e}", file=sys.stderr)
+        return None
+
     # Step 1: Process problem text and collect image metadata.
-    cf_result = cf_statement.process_problem(contest_id, index, vl_backend="none")
+    cf_result = cf_statement.process_problem(
+        contest_id,
+        index,
+        vl_backend="none",
+        html=raw_html,
+    )
 
     if "error" in cf_result:
         print(f"Warning: {pid} cf_statement error: {cf_result['error']}", file=sys.stderr)
@@ -324,16 +341,8 @@ def fetch_statement(problem: dict) -> object:
         )
         return None
 
-    # Step 2: Fetch raw HTML for metadata (title, limits, samples)
-    scraper = _get_scraper()
-    url = f"https://codeforces.com/problemset/problem/{contest_id}/{index}"
-    try:
-        resp = scraper.get(url, timeout=30)
-        resp.raise_for_status()
-    except Exception as e:
-        print(f"Warning: failed to fetch {url}: {e}", file=sys.stderr)
-        return None
-    html = resp.text
+    # Step 2: Parse metadata from that same HTML document.
+    html = raw_html
 
     result = {}
 

--- a/tests/test_cf_fetcher.py
+++ b/tests/test_cf_fetcher.py
@@ -1,0 +1,226 @@
+"""Regression tests for the shared Codeforces HTML fetcher."""
+
+from types import SimpleNamespace
+
+import pytest
+from requests import exceptions as requests_exceptions
+
+from kouhai_bot.problems import cf_fetcher
+
+
+class _FakeResponse:
+    def __init__(self, body: str, error: Exception | None = None):
+        self.text = body
+        self.error = error
+
+    def raise_for_status(self):
+        if self.error is not None:
+            raise self.error
+
+
+class _FakeScraper:
+    def __init__(self, result):
+        self.result = result
+
+    def get(self, url, timeout):
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+class _FakePlaywrightManager:
+    def __init__(self, playwright):
+        self.playwright = playwright
+
+    def __enter__(self):
+        return self.playwright
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeChromium:
+    def __init__(self, browser):
+        self.browser = browser
+        self.launch_kwargs = None
+
+    def launch(self, **kwargs):
+        self.launch_kwargs = kwargs
+        return self.browser
+
+
+class _FakeBrowser:
+    def __init__(self, page):
+        self.page = page
+        self.context_kwargs = None
+        self.closed = False
+
+    def new_context(self, **kwargs):
+        self.context_kwargs = kwargs
+        return self
+
+    def new_page(self):
+        return self.page
+
+    def close(self):
+        self.closed = True
+
+
+class _FakePage:
+    def __init__(self, html, selector_exc=None):
+        self.html = html
+        self.selector_exc = selector_exc
+        self.calls = []
+
+    def goto(self, url, **kwargs):
+        self.calls.append(("goto", url, kwargs))
+
+    def wait_for_timeout(self, wait_ms):
+        self.calls.append(("wait_for_timeout", wait_ms))
+
+    def wait_for_selector(self, selector, **kwargs):
+        self.calls.append(("wait_for_selector", selector, kwargs))
+        if self.selector_exc is not None:
+            raise self.selector_exc
+
+    def content(self):
+        self.calls.append(("content",))
+        return self.html
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "",
+        "<html><title>Just a moment...</title></html>",
+        "<html><body>Please wait.</body></html>",
+        "<div class='ttypography'>Tutorial is loading...</div>",
+        "<div>Tutorial is loading</div>",
+    ],
+)
+def test_content_valid_rejects_unusable_responses(body):
+    assert cf_fetcher.content_valid(body) is False
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "<div class='problem-statement'>A real statement</div>",
+        "<div class='ttypography'>A real editorial with an algorithm.</div>",
+    ],
+)
+def test_content_valid_accepts_statement_and_blog_pages(body):
+    assert cf_fetcher.content_valid(body) is True
+
+
+def _http_error(status: int) -> requests_exceptions.HTTPError:
+    error = requests_exceptions.HTTPError(f"{status} response")
+    error.response = SimpleNamespace(status_code=status)
+    return error
+
+
+@pytest.mark.parametrize(
+    "http_result",
+    [
+        _FakeResponse("", _http_error(403)),
+        requests_exceptions.Timeout("slow"),
+        requests_exceptions.ConnectionError("offline"),
+        _FakeResponse("<div>Tutorial is loading...</div>"),
+    ],
+    ids=["403", "timeout", "connection", "loading-placeholder"],
+)
+def test_auto_falls_back_to_playwright(monkeypatch, http_result):
+    browser_calls = []
+    monkeypatch.setattr(cf_fetcher, "get_scraper", lambda: _FakeScraper(http_result))
+
+    def fake_browser(url, *, wait_ms):
+        browser_calls.append((url, wait_ms))
+        return "<div class='ttypography'>rendered editorial</div>"
+
+    monkeypatch.setattr(cf_fetcher, "fetch_html_playwright", fake_browser)
+
+    result = cf_fetcher.fetch_html(
+        "https://codeforces.com/blog/entry/85118",
+        pw_wait_ms=456,
+    )
+
+    assert result == "<div class='ttypography'>rendered editorial</div>"
+    assert browser_calls == [("https://codeforces.com/blog/entry/85118", 456)]
+
+
+def test_non_fallback_http_error_is_reported(monkeypatch):
+    monkeypatch.setattr(
+        cf_fetcher,
+        "get_scraper",
+        lambda: _FakeScraper(_FakeResponse("", _http_error(404))),
+    )
+    monkeypatch.setattr(
+        cf_fetcher,
+        "fetch_html_playwright",
+        lambda *args, **kwargs: pytest.fail("404 must not launch a browser"),
+    )
+
+    with pytest.raises(cf_fetcher.CFFetchError) as exc_info:
+        cf_fetcher.fetch_html("https://codeforces.com/blog/entry/404")
+
+    assert exc_info.value.kind == "http"
+
+
+def test_explicit_playwright_uses_headless_chromium(monkeypatch):
+    page = _FakePage("<div class='problem-statement'>rendered</div>")
+    browser = _FakeBrowser(page)
+    chromium = _FakeChromium(browser)
+    playwright = SimpleNamespace(chromium=chromium)
+    monkeypatch.setattr(
+        cf_fetcher,
+        "sync_playwright",
+        lambda: _FakePlaywrightManager(playwright),
+    )
+
+    result = cf_fetcher.fetch_html(
+        "https://codeforces.com/problemset/problem/1534/F2",
+        fetcher="playwright",
+        pw_wait_ms=321,
+    )
+
+    assert result == page.html
+    assert chromium.launch_kwargs == {"headless": True}
+    assert browser.context_kwargs == {
+        "user_agent": cf_fetcher.CF_PLAYWRIGHT_USER_AGENT,
+        "viewport": cf_fetcher.CF_PLAYWRIGHT_VIEWPORT,
+    }
+    assert page.calls == [
+        (
+            "goto",
+            "https://codeforces.com/problemset/problem/1534/F2",
+            {"wait_until": "domcontentloaded", "timeout": 45_000},
+        ),
+        ("wait_for_timeout", 321),
+        (
+            "wait_for_selector",
+            cf_fetcher.CF_CONTENT_SELECTOR,
+            {"timeout": cf_fetcher.CF_CONTENT_WAIT_MS},
+        ),
+        ("content",),
+    ]
+    assert browser.closed is True
+
+
+def test_playwright_rejects_placeholder_after_render(monkeypatch):
+    page = _FakePage("<div>Tutorial is loading...</div>")
+    browser = _FakeBrowser(page)
+    playwright = SimpleNamespace(chromium=_FakeChromium(browser))
+    monkeypatch.setattr(
+        cf_fetcher,
+        "sync_playwright",
+        lambda: _FakePlaywrightManager(playwright),
+    )
+
+    with pytest.raises(cf_fetcher.CFFetchError) as exc_info:
+        cf_fetcher.fetch_html(
+            "https://codeforces.com/blog/entry/85118",
+            fetcher="playwright",
+            pw_wait_ms=0,
+        )
+
+    assert exc_info.value.kind == "content"

--- a/tests/test_cf_fetcher.py
+++ b/tests/test_cf_fetcher.py
@@ -1,8 +1,11 @@
 """Regression tests for the shared Codeforces HTML fetcher."""
 
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier, Lock
 from types import SimpleNamespace
 
 import pytest
+from cloudscraper import exceptions as cloudscraper_exceptions
 from requests import exceptions as requests_exceptions
 
 from kouhai_bot.problems import cf_fetcher
@@ -21,11 +24,15 @@ class _FakeResponse:
 class _FakeScraper:
     def __init__(self, result):
         self.result = result
+        self.closed = False
 
     def get(self, url, timeout):
         if isinstance(self.result, Exception):
             raise self.result
         return self.result
+
+    def close(self):
+        self.closed = True
 
 
 class _FakePlaywrightManager:
@@ -67,9 +74,11 @@ class _FakeBrowser:
 
 
 class _FakePage:
-    def __init__(self, html, selector_exc=None):
-        self.html = html
+    def __init__(self, html, selector_exc=None, function_exc=None):
+        self.html = html[-1] if isinstance(html, list) else html
+        self._html_results = iter(html) if isinstance(html, list) else None
         self.selector_exc = selector_exc
+        self.function_exc = function_exc
         self.calls = []
 
     def goto(self, url, **kwargs):
@@ -83,8 +92,15 @@ class _FakePage:
         if self.selector_exc is not None:
             raise self.selector_exc
 
+    def wait_for_function(self, expression, **kwargs):
+        self.calls.append(("wait_for_function", expression, kwargs))
+        if self.function_exc is not None:
+            raise self.function_exc
+
     def content(self):
         self.calls.append(("content",))
+        if self._html_results is not None:
+            return next(self._html_results)
         return self.html
 
 
@@ -92,8 +108,9 @@ class _FakePage:
     "body",
     [
         "",
-        "<html><title>Just a moment...</title></html>",
-        "<html><body>Please wait.</body></html>",
+        "<script>window._cf_chl_opt = {}</script>",
+        "<script src='/cdn-cgi/challenge-platform/scripts/jsd/main.js'></script>",
+        "<div id='cf-browser-verify'>Checking your browser</div>",
         "<div class='ttypography'>Tutorial is loading...</div>",
         "<div>Tutorial is loading</div>",
     ],
@@ -107,6 +124,8 @@ def test_content_valid_rejects_unusable_responses(body):
     [
         "<div class='problem-statement'>A real statement</div>",
         "<div class='ttypography'>A real editorial with an algorithm.</div>",
+        "<p>Please wait while the answer is computed.</p>",
+        "<p>Just a moment in the proof requires special handling.</p>",
     ],
 )
 def test_content_valid_accepts_statement_and_blog_pages(body):
@@ -125,9 +144,18 @@ def _http_error(status: int) -> requests_exceptions.HTTPError:
         _FakeResponse("", _http_error(403)),
         requests_exceptions.Timeout("slow"),
         requests_exceptions.ConnectionError("offline"),
+        cloudscraper_exceptions.CloudflareChallengeError("unsolved challenge"),
+        _FakeResponse("<script>window._cf_chl_opt = {}</script>"),
         _FakeResponse("<div>Tutorial is loading...</div>"),
     ],
-    ids=["403", "timeout", "connection", "loading-placeholder"],
+    ids=[
+        "403",
+        "timeout",
+        "connection",
+        "cloudscraper-challenge",
+        "200-challenge-page",
+        "loading-placeholder",
+    ],
 )
 def test_auto_falls_back_to_playwright(monkeypatch, http_result):
     browser_calls = []
@@ -146,6 +174,81 @@ def test_auto_falls_back_to_playwright(monkeypatch, http_result):
 
     assert result == "<div class='ttypography'>rendered editorial</div>"
     assert browser_calls == [("https://codeforces.com/blog/entry/85118", 456)]
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        cloudscraper_exceptions.CloudflareCode1020("blocked"),
+        cloudscraper_exceptions.CaptchaTimeout("captcha timed out"),
+    ],
+)
+def test_cloudscraper_exceptions_become_content_errors(monkeypatch, error):
+    scraper = _FakeScraper(error)
+    monkeypatch.setattr(cf_fetcher, "get_scraper", lambda: scraper)
+
+    with pytest.raises(cf_fetcher.CFFetchError) as exc_info:
+        cf_fetcher.fetch_html_http("https://codeforces.com/blog/entry/1")
+
+    assert exc_info.value.kind == "content"
+    assert exc_info.value.__cause__ is error
+    assert scraper.closed is True
+
+
+def test_fetch_html_http_rejects_200_challenge_page(monkeypatch):
+    scraper = _FakeScraper(
+        _FakeResponse("<script src='/cdn-cgi/challenge-platform/h/g/orchestrate'></script>")
+    )
+    monkeypatch.setattr(cf_fetcher, "get_scraper", lambda: scraper)
+
+    with pytest.raises(cf_fetcher.CFFetchError) as exc_info:
+        cf_fetcher.fetch_html_http("https://codeforces.com/problemset/problem/1/A")
+
+    assert exc_info.value.kind == "content"
+    assert scraper.closed is True
+
+
+def test_http_fetch_uses_isolated_scrapers_concurrently(monkeypatch):
+    gate = Barrier(2)
+    lock = Lock()
+    created = []
+
+    class ConcurrentScraper:
+        def __init__(self, scraper_id):
+            self.scraper_id = scraper_id
+            self.closed = False
+
+        def get(self, url, timeout):
+            gate.wait(timeout=2)
+            return _FakeResponse(
+                f"<div class='problem-statement'>session {self.scraper_id}</div>"
+            )
+
+        def close(self):
+            self.closed = True
+
+    def create_scraper():
+        with lock:
+            scraper = ConcurrentScraper(len(created) + 1)
+            created.append(scraper)
+            return scraper
+
+    monkeypatch.setattr(cf_fetcher.cloudscraper, "create_scraper", create_scraper)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(
+            executor.map(
+                cf_fetcher.fetch_html_http,
+                [
+                    "https://codeforces.com/problemset/problem/1/A",
+                    "https://codeforces.com/problemset/problem/2/A",
+                ],
+            )
+        )
+
+    assert len(created) == 2
+    assert len(set(results)) == 2
+    assert all(scraper.closed for scraper in created)
 
 
 def test_non_fallback_http_error_is_reported(monkeypatch):
@@ -224,3 +327,34 @@ def test_playwright_rejects_placeholder_after_render(monkeypatch):
         )
 
     assert exc_info.value.kind == "content"
+    assert page.calls[-2][0] == "wait_for_function"
+    assert page.calls[-2][2] == {"timeout": cf_fetcher.CF_TUTORIAL_LOADING_WAIT_MS}
+    assert [call for call in page.calls if call[0] == "content"] == [
+        ("content",),
+        ("content",),
+    ]
+
+
+def test_playwright_waits_for_tutorial_placeholder_to_resolve(monkeypatch):
+    page = _FakePage(
+        [
+            "<div class='ttypography'>Tutorial is loading...</div>",
+            "<div class='ttypography'>Rendered dynamic editorial</div>",
+        ]
+    )
+    browser = _FakeBrowser(page)
+    playwright = SimpleNamespace(chromium=_FakeChromium(browser))
+    monkeypatch.setattr(
+        cf_fetcher,
+        "sync_playwright",
+        lambda: _FakePlaywrightManager(playwright),
+    )
+
+    result = cf_fetcher.fetch_html_playwright(
+        "https://codeforces.com/blog/entry/85118",
+        wait_ms=0,
+    )
+
+    assert result == "<div class='ttypography'>Rendered dynamic editorial</div>"
+    function_call = next(call for call in page.calls if call[0] == "wait_for_function")
+    assert function_call[2] == {"timeout": cf_fetcher.CF_TUTORIAL_LOADING_WAIT_MS}

--- a/tests/test_cf_fetcher.py
+++ b/tests/test_cf_fetcher.py
@@ -142,6 +142,10 @@ def _http_error(status: int) -> requests_exceptions.HTTPError:
     "http_result",
     [
         _FakeResponse("", _http_error(403)),
+        _FakeResponse("", _http_error(429)),
+        _FakeResponse("", _http_error(502)),
+        _FakeResponse("", _http_error(503)),
+        _FakeResponse("", _http_error(504)),
         requests_exceptions.Timeout("slow"),
         requests_exceptions.ConnectionError("offline"),
         cloudscraper_exceptions.CloudflareChallengeError("unsolved challenge"),
@@ -150,6 +154,10 @@ def _http_error(status: int) -> requests_exceptions.HTTPError:
     ],
     ids=[
         "403",
+        "429",
+        "502",
+        "503",
+        "504",
         "timeout",
         "connection",
         "cloudscraper-challenge",

--- a/tests/test_cf_tutorial_agent.py
+++ b/tests/test_cf_tutorial_agent.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
@@ -164,9 +166,8 @@ def test_agent_tries_next_blog_when_extractor_rejects_first(tmp_path):
     assert "prefix sums" in result.bundle["sections"][0]["solution"]
 
 
-def test_agent_includes_dynamic_fragment_in_blog_body(tmp_path):
+def test_agent_rejects_placeholder_before_dynamic_fetch_or_llm(tmp_path):
     _write_statement(tmp_path)
-    dynamic_text = ("Dynamic official explanation with enough details about target DP. " * 3) + "This is the unique final dynamic marker."
     pages = {
         "https://codeforces.com/problemset/problem/1000/B": _problem_page(),
         "https://codeforces.com/blog/entry/2": _blog_page("<p>Tutorial is loading...</p>"),
@@ -175,40 +176,75 @@ def test_agent_includes_dynamic_fragment_in_blog_body(tmp_path):
     def fake_fetch(url, **_kwargs):
         return pages[url]
 
-    async def fake_chat_completion(messages, **kwargs):
+    with patch("cf_tutorial_agent.fetch_html", side_effect=fake_fetch), \
+            patch("cf_tutorial_agent.fetch_dynamic_editorial") as dynamic_fetch, \
+            patch("cf_tutorial_agent.chat_completion") as llm_call:
+        with pytest.raises(agent.AgentNoMatch, match="no_readable_blog_bodies"):
+            asyncio.run(
+                agent.run_agent_for_pid(
+                    pid="1000B",
+                    statements_dir=tmp_path,
+                    fetcher="http",
+                    blog_limit=1,
+                    deadline_sec=10,
+                    selector_timeout_sec=5,
+                )
+            )
+
+    dynamic_fetch.assert_not_called()
+    llm_call.assert_not_called()
+
+
+def test_agent_skips_placeholder_and_sends_only_valid_blog_to_llm(tmp_path):
+    _write_statement(tmp_path)
+    target_text = (
+        "Use prefix sums and dynamic programming to evaluate every transition. " * 3
+    ) + "This is the unique final mixed marker."
+    pages = {
+        "https://codeforces.com/problemset/problem/1000/B": _problem_page(),
+        "https://codeforces.com/blog/entry/2": _blog_page(
+            "<p>Tutorial is loading...</p>"
+        ),
+        "https://codeforces.com/blog/entry/1": _blog_page(f"<p>{target_text}</p>"),
+    }
+    llm_urls = []
+
+    def fake_fetch(url, **_kwargs):
+        return pages[url]
+
+    async def fake_chat_completion(messages, **_kwargs):
         payload = json.loads(messages[1]["content"])
-        assert "Tutorial is loading" in payload["blog"]["body"]
-        assert "Codeforces dynamic tutorial fragment" in payload["blog"]["body"]
-        assert dynamic_text.strip() in payload["blog"]["body"]
+        llm_urls.append(payload["blog"]["url"])
+        assert "Tutorial is loading" not in payload["blog"]["body"]
         return ChatCompletionResult(
             text=json.dumps(
                 {
                     "match": True,
                     "section_title": "Target Problem",
-                    "start_text": "Dynamic official explanation",
-                    "end_text": "unique final dynamic marker.",
-                    "confidence": 0.93,
-                    "reason": "dynamic fragment contains the target tutorial",
+                    "start_text": "Use prefix sums and dynamic programming",
+                    "end_text": "unique final mixed marker.",
+                    "confidence": 0.94,
+                    "reason": "valid blog contains the target tutorial",
                 }
             )
         )
 
     with patch("cf_tutorial_agent.fetch_html", side_effect=fake_fetch), \
-            patch("cf_tutorial_agent.fetch_dynamic_editorial", return_value=("Target Problem", dynamic_text)), \
+            patch("cf_tutorial_agent.fetch_dynamic_editorial", return_value=("", "")), \
             patch("cf_tutorial_agent.chat_completion", side_effect=fake_chat_completion):
         result = asyncio.run(
             agent.run_agent_for_pid(
                 pid="1000B",
                 statements_dir=tmp_path,
                 fetcher="http",
-                blog_limit=1,
+                blog_limit=2,
                 deadline_sec=10,
                 selector_timeout_sec=5,
             )
         )
 
-    assert result.bundle["agent_meta"]["source_kind"] == "llm_blog_extract"
-    assert "Dynamic official explanation" in result.bundle["sections"][0]["solution"]
+    assert llm_urls == ["https://codeforces.com/blog/entry/1"]
+    assert result.bundle["tutorial_url"] == "https://codeforces.com/blog/entry/1"
 
 
 def test_agent_rejects_low_confidence_extraction(tmp_path):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -94,6 +94,8 @@ def _write_statement(pid: str, data: dict):
     os.makedirs(d, exist_ok=True)
     payload = dict(data)
     payload.setdefault("_vl_processed", True)
+    payload.setdefault("_images_collected", True)
+    payload.setdefault("images", [])
     with open(os.path.join(d, f"{pid}.json"), "w") as f:
         json.dump(payload, f)
 

--- a/tests/test_fetcher_config.py
+++ b/tests/test_fetcher_config.py
@@ -52,3 +52,26 @@ def test_process_problem_marks_inline_image_position(monkeypatch):
             "placeholder": "[[IMAGE_1: formula: a_i < b_i]]",
         }
     ]
+
+
+def test_fetch_problem_html_uses_shared_fetcher(monkeypatch):
+    calls = []
+
+    def fake_fetch(url, *, fetcher, pw_wait_ms):
+        calls.append((url, fetcher, pw_wait_ms))
+        return "<html>statement</html>"
+
+    monkeypatch.setattr(fetcher.cf_fetcher, "fetch_html", fake_fetch)
+
+    html, pid = fetcher.fetch_problem_html(
+        1534,
+        "F2",
+        fetcher="playwright",
+        pw_wait_ms=321,
+    )
+
+    assert html == "<html>statement</html>"
+    assert pid == "1534F2"
+    assert calls == [
+        ("https://codeforces.com/problemset/problem/1534/F2", "playwright", 321)
+    ]

--- a/tests/test_picker_selection.py
+++ b/tests/test_picker_selection.py
@@ -94,13 +94,22 @@ def test_fetch_statement_skips_image_statement_without_multimodal_model(monkeypa
     _configure_picker_tmp(tmp_path)
 
     monkeypatch.setattr(picker, "_multimodal_model_configured", lambda: False)
-    monkeypatch.setattr(picker.cf_statement, "process_problem", lambda contest_id, index, vl_backend="none": {
-        "pid": f"{contest_id}{index}",
-        "text": "Statement [DIAGRAM]",
-        "formulas_found": 0,
-        "graphics_found": 1,
-        "images": [{"src": "https://codeforces.com/image.png", "kind": "graphic"}],
-    })
+    monkeypatch.setattr(
+        picker.cf_fetcher,
+        "fetch_html",
+        lambda url: "<div class='problem-statement'>statement</div><script>",
+    )
+    monkeypatch.setattr(
+        picker.cf_statement,
+        "process_problem",
+        lambda contest_id, index, vl_backend="none", **kwargs: {
+            "pid": f"{contest_id}{index}",
+            "text": "Statement [DIAGRAM]",
+            "formulas_found": 0,
+            "graphics_found": 1,
+            "images": [{"src": "https://codeforces.com/image.png", "kind": "graphic"}],
+        },
+    )
 
     assert picker.fetch_statement(_problem(1, "A")) is None
 
@@ -109,36 +118,39 @@ def test_fetch_statement_caches_image_metadata_with_multimodal_model(monkeypatch
     _configure_picker_tmp(tmp_path)
 
     monkeypatch.setattr(picker, "_multimodal_model_configured", lambda: True)
-    monkeypatch.setattr(picker.cf_statement, "process_problem", lambda contest_id, index, vl_backend="none": {
-        "pid": f"{contest_id}{index}",
-        "text": "Statement [DIAGRAM]",
-        "formulas_found": 0,
-        "graphics_found": 1,
-        "images": [{"src": "https://codeforces.com/image.png", "kind": "graphic"}],
-    })
+    raw_html = (
+        '<div class="problem-statement">'
+        '<div class="title">A. Image</div>'
+        '<div class="time-limit">1 second</div>'
+        '<div class="memory-limit">256 megabytes</div>'
+        '<div class="section-title">Input</div>n'
+        '<pre>1</pre><pre>1</pre>'
+        "</div><script"
+    )
+    fetch_calls = []
+    process_calls = []
 
-    class _Resp:
-        text = (
-            '<div class="problem-statement">'
-            '<div class="title">A. Image</div>'
-            '<div class="time-limit">1 second</div>'
-            '<div class="memory-limit">256 megabytes</div>'
-            '<div class="section-title">Input</div>n'
-            '<pre>1</pre><pre>1</pre>'
-            "</div><script"
-        )
+    def fake_fetch(url):
+        fetch_calls.append(url)
+        return raw_html
 
-        def raise_for_status(self):
-            return None
+    def fake_process(contest_id, index, vl_backend="none", *, html=None):
+        process_calls.append((contest_id, index, vl_backend, html))
+        return {
+            "pid": f"{contest_id}{index}",
+            "text": "Statement [DIAGRAM]",
+            "formulas_found": 0,
+            "graphics_found": 1,
+            "images": [{"src": "https://codeforces.com/image.png", "kind": "graphic"}],
+        }
 
-    class _Scraper:
-        def get(self, url, timeout=30):
-            return _Resp()
-
-    monkeypatch.setattr(picker, "_get_scraper", lambda: _Scraper())
+    monkeypatch.setattr(picker.cf_fetcher, "fetch_html", fake_fetch)
+    monkeypatch.setattr(picker.cf_statement, "process_problem", fake_process)
 
     stmt = picker.fetch_statement(_problem(1, "A"))
 
+    assert fetch_calls == ["https://codeforces.com/problemset/problem/1/A"]
+    assert process_calls == [(1, "A", "none", raw_html)]
     assert stmt["images"] == [{"src": "https://codeforces.com/image.png", "kind": "graphic"}]
     assert stmt["has_images"] is True
     assert stmt["_images_collected"] is True

--- a/tests/test_scrape_cf_tutorial.py
+++ b/tests/test_scrape_cf_tutorial.py
@@ -10,7 +10,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 import scrape_cf_tutorial
 
 
-@pytest.mark.parametrize("fetcher", ["auto", "http", "playwright"])
+@pytest.mark.parametrize("fetcher", ["http", "playwright"])
 def test_fetch_html_delegates_transport_to_shared_fetcher(monkeypatch, fetcher):
     calls = []
 
@@ -104,4 +104,31 @@ def test_http_mode_falls_back_to_m1_mirror_after_primary_403(monkeypatch):
     assert calls == [
         ("https://codeforces.com/blog/entry/123?locale=en", "http", 7000),
         ("https://m1.codeforces.com/blog/entry/123?locale=en", "http", 7000),
+    ]
+
+
+def test_auto_mode_uses_m1_mirror_before_playwright_after_primary_403(monkeypatch):
+    calls = []
+
+    def fake_fetch(url, *, fetcher, pw_wait_ms):
+        calls.append((url, fetcher, pw_wait_ms))
+        if fetcher == "http":
+            raise scrape_cf_tutorial.cf_fetcher.CFFetchError(
+                "403 response",
+                kind="forbidden",
+            )
+        return "<html><div class='ttypography'>browser editorial</div></html>"
+
+    monkeypatch.setattr(scrape_cf_tutorial.cf_fetcher, "fetch_html", fake_fetch)
+
+    result = scrape_cf_tutorial.fetch_html(
+        "https://codeforces.com/blog/entry/123?locale=en",
+        fetcher="auto",
+    )
+
+    assert result == "<html><div class='ttypography'>browser editorial</div></html>"
+    assert calls == [
+        ("https://codeforces.com/blog/entry/123?locale=en", "http", 7000),
+        ("https://m1.codeforces.com/blog/entry/123?locale=en", "http", 7000),
+        ("https://codeforces.com/blog/entry/123?locale=en", "playwright", 7000),
     ]

--- a/tests/test_scrape_cf_tutorial.py
+++ b/tests/test_scrape_cf_tutorial.py
@@ -79,3 +79,29 @@ def test_fetch_html_preserves_scrape_error_contract(monkeypatch):
         scrape_cf_tutorial.fetch_html("https://codeforces.com/blog/entry/3")
 
     assert exc_info.value.code == 9
+
+
+def test_http_mode_falls_back_to_m1_mirror_after_primary_403(monkeypatch):
+    calls = []
+
+    def fake_fetch(url, *, fetcher, pw_wait_ms):
+        calls.append((url, fetcher, pw_wait_ms))
+        if url.startswith("https://codeforces.com/"):
+            raise scrape_cf_tutorial.cf_fetcher.CFFetchError(
+                "403 response",
+                kind="forbidden",
+            )
+        return "<html><div class='ttypography'>mirror editorial</div></html>"
+
+    monkeypatch.setattr(scrape_cf_tutorial.cf_fetcher, "fetch_html", fake_fetch)
+
+    result = scrape_cf_tutorial.fetch_html(
+        "https://codeforces.com/blog/entry/123?locale=en",
+        fetcher="http",
+    )
+
+    assert result == "<html><div class='ttypography'>mirror editorial</div></html>"
+    assert calls == [
+        ("https://codeforces.com/blog/entry/123?locale=en", "http", 7000),
+        ("https://m1.codeforces.com/blog/entry/123?locale=en", "http", 7000),
+    ]

--- a/tests/test_scrape_cf_tutorial.py
+++ b/tests/test_scrape_cf_tutorial.py
@@ -1,231 +1,81 @@
-"""Tests for low-level Codeforces tutorial scraping helpers."""
+"""Tests for tutorial wrappers around the shared Codeforces transport."""
 
 import os
 import sys
+
+import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
 import scrape_cf_tutorial
 
 
-class _FakePlaywrightManager:
-    def __init__(self, playwright):
-        self.playwright = playwright
+@pytest.mark.parametrize("fetcher", ["auto", "http", "playwright"])
+def test_fetch_html_delegates_transport_to_shared_fetcher(monkeypatch, fetcher):
+    calls = []
 
-    def __enter__(self):
-        return self.playwright
-
-    def __exit__(self, exc_type, exc, tb):
-        return False
-
-
-class _FakeChromium:
-    def __init__(self, browser):
-        self.browser = browser
-        self.launch_kwargs = None
-
-    def launch(self, **kwargs):
-        self.launch_kwargs = kwargs
-        return self.browser
-
-
-class _FakePlaywright:
-    def __init__(self, browser):
-        self.chromium = _FakeChromium(browser)
-
-
-class _FakeBrowser:
-    def __init__(self, page):
-        self.page = page
-        self.context_kwargs = None
-        self.closed = False
-
-    def new_context(self, **kwargs):
-        self.context_kwargs = kwargs
-        return self
-
-    def new_page(self):
-        return self.page
-
-    def close(self):
-        self.closed = True
-
-
-class _FakePage:
-    def __init__(
-        self,
-        *,
-        html="<html><body><div class='problem-statement'>ok</div></body></html>",
-        title="Problem - 601D - Codeforces",
-        selector_exc=None,
-    ):
-        self.html = html
-        self.title_text = title
-        self.selector_exc = selector_exc
-        self.calls = []
-
-    def goto(self, url, **kwargs):
-        self.calls.append(("goto", url, kwargs))
-
-    def wait_for_timeout(self, wait_ms):
-        self.calls.append(("wait_for_timeout", wait_ms))
-
-    def wait_for_selector(self, selector, **kwargs):
-        self.calls.append(("wait_for_selector", selector, kwargs))
-        if self.selector_exc is not None:
-            raise self.selector_exc
-
-    def title(self):
-        self.calls.append(("title",))
-        return self.title_text
-
-    def content(self):
-        self.calls.append(("content",))
-        return self.html
-
-
-def test_fetch_html_auto_falls_back_on_any_scrape_error(monkeypatch):
-    def fake_http(url):
-        raise scrape_cf_tutorial.ScrapeError(f"forbidden: {url}", 2)
-
-    def fake_playwright(url, wait_ms):
-        assert url == "https://codeforces.com/blog/entry/1"
-        assert wait_ms == 123
+    def fake_fetch(url, *, fetcher, pw_wait_ms):
+        calls.append((url, fetcher, pw_wait_ms))
         return "<html>ok</html>"
 
-    monkeypatch.setattr(scrape_cf_tutorial, "fetch_html_http", fake_http)
-    monkeypatch.setattr(scrape_cf_tutorial, "fetch_html_playwright", fake_playwright)
+    monkeypatch.setattr(scrape_cf_tutorial.cf_fetcher, "fetch_html", fake_fetch)
 
     html = scrape_cf_tutorial.fetch_html(
         "https://codeforces.com/blog/entry/1",
-        fetcher="auto",
+        fetcher=fetcher,
         pw_wait_ms=123,
     )
 
     assert html == "<html>ok</html>"
+    assert calls == [("https://codeforces.com/blog/entry/1", fetcher, 123)]
 
 
-def test_fetch_html_auto_falls_back_on_non_scrape_error(monkeypatch):
-    def fake_http(url):
-        raise OSError(f"network down: {url}")
+def test_fetch_html_http_delegates_to_shared_http_mode(monkeypatch):
+    calls = []
 
-    def fake_playwright(url, wait_ms):
-        assert url == "https://codeforces.com/blog/entry/2"
-        assert wait_ms == 456
-        return "<html>browser ok</html>"
+    def fake_fetch(url, *, fetcher, pw_wait_ms):
+        calls.append((url, fetcher, pw_wait_ms))
+        return "<html>http</html>"
 
-    monkeypatch.setattr(scrape_cf_tutorial, "fetch_html_http", fake_http)
-    monkeypatch.setattr(scrape_cf_tutorial, "fetch_html_playwright", fake_playwright)
+    monkeypatch.setattr(scrape_cf_tutorial.cf_fetcher, "fetch_html", fake_fetch)
 
-    html = scrape_cf_tutorial.fetch_html(
-        "https://codeforces.com/blog/entry/2",
-        fetcher="auto",
-        pw_wait_ms=456,
+    assert (
+        scrape_cf_tutorial.fetch_html_http("https://codeforces.com/blog/entry/2")
+        == "<html>http</html>"
     )
+    assert calls == [("https://codeforces.com/blog/entry/2", "http", 7000)]
 
-    assert html == "<html>browser ok</html>"
 
+def test_fetch_html_playwright_delegates_with_wait(monkeypatch):
+    calls = []
 
-def test_fetch_html_playwright_waits_for_cf_content(monkeypatch):
-    page = _FakePage()
-    browser = _FakeBrowser(page)
-    fake_playwright = _FakePlaywright(browser)
-    monkeypatch.setattr(
-        scrape_cf_tutorial,
-        "sync_playwright",
-        lambda: _FakePlaywrightManager(fake_playwright),
-    )
+    def fake_fetch(url, *, fetcher, pw_wait_ms):
+        calls.append((url, fetcher, pw_wait_ms))
+        return "<html>browser</html>"
+
+    monkeypatch.setattr(scrape_cf_tutorial.cf_fetcher, "fetch_html", fake_fetch)
 
     html = scrape_cf_tutorial.fetch_html_playwright(
         "https://codeforces.com/problemset/problem/601/D",
         wait_ms=321,
     )
 
-    assert html == page.html
-    assert fake_playwright.chromium.launch_kwargs == {"headless": True}
-    assert browser.context_kwargs == {
-        "user_agent": scrape_cf_tutorial.CF_PLAYWRIGHT_USER_AGENT,
-        "viewport": scrape_cf_tutorial.CF_PLAYWRIGHT_VIEWPORT,
-    }
-    assert page.calls == [
-        (
-            "goto",
-            "https://codeforces.com/problemset/problem/601/D",
-            {"wait_until": "domcontentloaded", "timeout": 45000},
-        ),
-        ("wait_for_timeout", 321),
-        (
-            "wait_for_selector",
-            scrape_cf_tutorial.CF_CONTENT_SELECTOR,
-            {"timeout": scrape_cf_tutorial.CF_CONTENT_WAIT_MS},
-        ),
-        ("content",),
+    assert html == "<html>browser</html>"
+    assert calls == [
+        ("https://codeforces.com/problemset/problem/601/D", "playwright", 321)
     ]
-    assert browser.closed is True
 
 
-def test_fetch_html_playwright_selector_timeout_checks_challenge_title(monkeypatch):
-    class FakeTimeout(Exception):
-        pass
+def test_fetch_html_preserves_scrape_error_contract(monkeypatch):
+    def fake_fetch(url, *, fetcher, pw_wait_ms):
+        raise scrape_cf_tutorial.cf_fetcher.CFFetchError(
+            "placeholder body",
+            kind="content",
+        )
 
-    page = _FakePage(selector_exc=FakeTimeout(), title="Just a moment...")
-    browser = _FakeBrowser(page)
-    fake_playwright = _FakePlaywright(browser)
-    monkeypatch.setattr(scrape_cf_tutorial, "PlaywrightTimeoutError", FakeTimeout)
-    monkeypatch.setattr(
-        scrape_cf_tutorial,
-        "sync_playwright",
-        lambda: _FakePlaywrightManager(fake_playwright),
-    )
+    monkeypatch.setattr(scrape_cf_tutorial.cf_fetcher, "fetch_html", fake_fetch)
 
-    try:
-        scrape_cf_tutorial.fetch_html_playwright("https://codeforces.com/blog/entry/1")
-    except scrape_cf_tutorial.ScrapeError as exc:
-        assert exc.code == 9
-    else:
-        raise AssertionError("expected ScrapeError")
+    with pytest.raises(scrape_cf_tutorial.ScrapeError) as exc_info:
+        scrape_cf_tutorial.fetch_html("https://codeforces.com/blog/entry/3")
 
-    assert page.calls[-1] == ("title",)
-
-
-def test_fetch_html_playwright_selector_timeout_allows_non_challenge_title(monkeypatch):
-    class FakeTimeout(Exception):
-        pass
-
-    page = _FakePage(
-        html="<html><title>Other Codeforces page</title><body>ok</body></html>",
-        title="Other Codeforces page",
-        selector_exc=FakeTimeout(),
-    )
-    browser = _FakeBrowser(page)
-    fake_playwright = _FakePlaywright(browser)
-    monkeypatch.setattr(scrape_cf_tutorial, "PlaywrightTimeoutError", FakeTimeout)
-    monkeypatch.setattr(
-        scrape_cf_tutorial,
-        "sync_playwright",
-        lambda: _FakePlaywrightManager(fake_playwright),
-    )
-
-    html = scrape_cf_tutorial.fetch_html_playwright("https://codeforces.com/blog/entry/1")
-
-    assert html == page.html
-    assert page.calls[-2:] == [("title",), ("content",)]
-    assert browser.closed is True
-
-
-def test_fetch_html_playwright_keeps_final_challenge_body_check(monkeypatch):
-    page = _FakePage(html="<html><body>Please wait.</body></html>")
-    browser = _FakeBrowser(page)
-    fake_playwright = _FakePlaywright(browser)
-    monkeypatch.setattr(
-        scrape_cf_tutorial,
-        "sync_playwright",
-        lambda: _FakePlaywrightManager(fake_playwright),
-    )
-
-    try:
-        scrape_cf_tutorial.fetch_html_playwright("https://codeforces.com/blog/entry/1")
-    except scrape_cf_tutorial.ScrapeError as exc:
-        assert exc.code == 9
-    else:
-        raise AssertionError("expected ScrapeError")
+    assert exc_info.value.code == 9

--- a/tools/cf_tutorial_agent.py
+++ b/tools/cf_tutorial_agent.py
@@ -21,6 +21,7 @@ from urllib.parse import urldefrag, urljoin
 
 from kouhai_bot.handlers.shared import parse_json_with_llm_repair
 from kouhai_bot.llm import chat_completion
+from kouhai_bot.problems.cf_fetcher import content_valid
 from kouhai_bot.tutorials import MIN_EDITORIAL_LEN, extract_editorial
 
 from scrape_cf_tutorial import ScrapeError
@@ -200,6 +201,8 @@ def collect_blog_documents(
     for idx, blog_url in enumerate(blog_urls, start=1):
         try:
             tutorial_html = fetch_html(blog_url, fetcher=fetcher, pw_wait_ms=pw_wait_ms)
+            if not content_valid(tutorial_html):
+                continue
             tutorial_title = extract_page_title(tutorial_html)
             body_html = extract_blog_body_html(tutorial_html)
             body = html_to_markdownish(body_html)

--- a/tools/scrape_cf_tutorial.py
+++ b/tools/scrape_cf_tutorial.py
@@ -18,7 +18,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
@@ -30,26 +30,9 @@ try:
     from curl_cffi import requests as curl_requests
 except ImportError:
     curl_requests = None
-try:
-    from playwright.sync_api import Error as PlaywrightError
-    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
-    from playwright.sync_api import sync_playwright
-except ImportError:
-    sync_playwright = None
-    PlaywrightError = Exception
-    PlaywrightTimeoutError = TimeoutError
+from kouhai_bot.problems import cf_fetcher
 
 CF_ROOT = "https://codeforces.com"
-CF_PLAYWRIGHT_USER_AGENT = (
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-    "AppleWebKit/537.36 (KHTML, like Gecko) "
-    "Chrome/131.0.0.0 Safari/537.36"
-)
-CF_PLAYWRIGHT_VIEWPORT = {"width": 1365, "height": 768}
-CF_CONTENT_SELECTOR = ".problem-statement, .ttypography"
-CF_CONTENT_WAIT_MS = 45000
-
-
 class ScrapeError(RuntimeError):
     """Expected scrape/parsing error with a stable exit code."""
 
@@ -101,98 +84,35 @@ def get_curl_session():
     return _CURL_SESSION
 
 
-def _is_cf_challenge_page(text: str) -> bool:
-    return bool(
-        re.search(r"browser is being checked|Please wait\.|Just a moment", text, re.I)
-    )
-
-
-def _is_cf_challenge_title(title: str) -> bool:
-    return title.strip().lower().startswith("just a moment")
+def _fetch_with_shared_transport(
+    url: str,
+    *,
+    fetcher: str,
+    pw_wait_ms: int = 7000,
+) -> str:
+    try:
+        return cf_fetcher.fetch_html(
+            url,
+            fetcher=fetcher,
+            pw_wait_ms=pw_wait_ms,
+        )
+    except cf_fetcher.CFFetchError as exc:
+        code = 10 if exc.kind == "dependency" else 9 if exc.kind == "content" else 2
+        raise ScrapeError(f"抓取失败: {url} ({exc})", code) from exc
 
 
 def fetch_html_http(url: str) -> str:
-    try:
-        scraper = get_scraper()
-        if scraper is not None:
-            resp = scraper.get(url, timeout=30)
-            resp.raise_for_status()
-            body = resp.text
-            if _is_cf_challenge_page(body):
-                raise ScrapeError(f"被 Codeforces 反爬挑战拦截: {url}", 9)
-            return body
-
-        req = Request(url, headers={"User-Agent": "Mozilla/5.0"})
-        with urlopen(req, timeout=30) as resp:
-            body = resp.read()
-            text = body.decode("utf-8", errors="replace")
-            if _is_cf_challenge_page(text):
-                raise ScrapeError(f"被 Codeforces 反爬挑战拦截: {url}", 9)
-            return text
-    except Exception as exc:
-        parsed = urlparse(url)
-        if (
-            "403" in str(exc)
-            and parsed.netloc == "codeforces.com"
-            and parsed.path
-        ):
-            mirror_url = f"https://m1.codeforces.com{parsed.path}"
-            if parsed.query:
-                mirror_url = f"{mirror_url}?{parsed.query}"
-            try:
-                req = Request(mirror_url, headers={"User-Agent": "Mozilla/5.0"})
-                with urlopen(req, timeout=30) as resp:
-                    body = resp.read()
-                    text = body.decode("utf-8", errors="replace")
-                    if _is_cf_challenge_page(text):
-                        raise ScrapeError(f"被 Codeforces 反爬挑战拦截: {mirror_url}", 9)
-                    return text
-            except Exception:
-                pass
-        raise ScrapeError(f"抓取失败: {url} ({exc})", 2) from exc
+    """Compatibility wrapper around the shared HTTP-only transport."""
+    return _fetch_with_shared_transport(url, fetcher="http")
 
 
 def fetch_html_playwright(url: str, wait_ms: int = 7000) -> str:
-    if sync_playwright is None:
-        raise ScrapeError(
-            "未安装 playwright。请先运行: python -m pip install playwright && python -m playwright install chromium",
-            10,
-        )
-    try:
-        with sync_playwright() as p:
-            browser = p.chromium.launch(headless=True)
-            try:
-                context = browser.new_context(
-                    user_agent=CF_PLAYWRIGHT_USER_AGENT,
-                    viewport=CF_PLAYWRIGHT_VIEWPORT,
-                )
-                page = context.new_page()
-                page.goto(url, wait_until="domcontentloaded", timeout=45000)
-                if wait_ms > 0:
-                    page.wait_for_timeout(wait_ms)
-                try:
-                    page.wait_for_selector(
-                        CF_CONTENT_SELECTOR,
-                        timeout=CF_CONTENT_WAIT_MS,
-                    )
-                except PlaywrightTimeoutError:
-                    if _is_cf_challenge_title(page.title()):
-                        raise ScrapeError(
-                            f"Playwright 抓取后仍命中反爬挑战页: {url}",
-                            9,
-                        )
-                text = page.content()
-            finally:
-                browser.close()
-        if _is_cf_challenge_page(text):
-            raise ScrapeError(f"Playwright 抓取后仍命中反爬挑战页: {url}", 9)
-        return text
-    except ScrapeError:
-        raise
-    except PlaywrightTimeoutError as exc:
-        raise ScrapeError(f"Playwright 超时: {url} ({exc})", 2) from exc
-    except PlaywrightError as exc:
-        raise ScrapeError(f"Playwright 抓取失败: {url} ({exc})", 2) from exc
+    """Compatibility wrapper around the shared Chromium transport."""
+    return _fetch_with_shared_transport(
+        url,
+        fetcher="playwright",
+        pw_wait_ms=wait_ms,
+    )
 
 
 def fetch_html(url: str, fetcher: str = "auto", pw_wait_ms: int = 7000) -> str:
@@ -209,16 +129,11 @@ def fetch_html(url: str, fetcher: str = "auto", pw_wait_ms: int = 7000) -> str:
             time.sleep(wait_s - elapsed)
         _LAST_FETCH_AT = time.time()
 
-    if fetcher == "http":
-        return fetch_html_http(url)
-    if fetcher == "playwright":
-        return fetch_html_playwright(url, wait_ms=pw_wait_ms)
-
-    # auto: HTTP first, then let a real browser try any failure path.
-    try:
-        return fetch_html_http(url)
-    except Exception:
-        return fetch_html_playwright(url, wait_ms=pw_wait_ms)
+    return _fetch_with_shared_transport(
+        url,
+        fetcher=fetcher,
+        pw_wait_ms=pw_wait_ms,
+    )
 
 
 def _extract_csrf_token(page_html: str) -> str:

--- a/tools/scrape_cf_tutorial.py
+++ b/tools/scrape_cf_tutorial.py
@@ -139,6 +139,27 @@ def fetch_html_playwright(url: str, wait_ms: int = 7000) -> str:
     )
 
 
+def fetch_html_auto(url: str, *, pw_wait_ms: int = 7000) -> str:
+    """Try primary/mirror HTTP transport before falling back to Chromium."""
+    try:
+        return fetch_html_http(url, pw_wait_ms=pw_wait_ms)
+    except ScrapeError as exc:
+        cause = exc.__cause__
+        if not (
+            isinstance(cause, cf_fetcher.CFFetchError)
+            and cause.kind
+            in {
+                "forbidden",
+                "transient_http",
+                "timeout",
+                "connection",
+                "content",
+            }
+        ):
+            raise
+        return fetch_html_playwright(url, wait_ms=pw_wait_ms)
+
+
 def fetch_html(url: str, fetcher: str = "auto", pw_wait_ms: int = 7000) -> str:
     global _LAST_FETCH_AT
     wait_s = 0.0
@@ -155,6 +176,8 @@ def fetch_html(url: str, fetcher: str = "auto", pw_wait_ms: int = 7000) -> str:
 
     if fetcher == "http":
         return fetch_html_http(url, pw_wait_ms=pw_wait_ms)
+    if fetcher == "auto":
+        return fetch_html_auto(url, pw_wait_ms=pw_wait_ms)
     return _fetch_with_shared_transport(url, fetcher=fetcher, pw_wait_ms=pw_wait_ms)
 
 

--- a/tools/scrape_cf_tutorial.py
+++ b/tools/scrape_cf_tutorial.py
@@ -18,7 +18,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
@@ -101,9 +101,33 @@ def _fetch_with_shared_transport(
         raise ScrapeError(f"抓取失败: {url} ({exc})", code) from exc
 
 
-def fetch_html_http(url: str) -> str:
-    """Compatibility wrapper around the shared HTTP-only transport."""
-    return _fetch_with_shared_transport(url, fetcher="http")
+def fetch_html_http(url: str, *, pw_wait_ms: int = 7000) -> str:
+    """Use shared HTTP transport, with the legacy CF mirror on a primary 403."""
+    try:
+        return _fetch_with_shared_transport(
+            url,
+            fetcher="http",
+            pw_wait_ms=pw_wait_ms,
+        )
+    except ScrapeError as exc:
+        cause = exc.__cause__
+        parsed = urlparse(url)
+        if (
+            isinstance(cause, cf_fetcher.CFFetchError)
+            and cause.kind == "forbidden"
+            and parsed.netloc == "codeforces.com"
+            and parsed.path
+        ):
+            mirror_url = parsed._replace(netloc="m1.codeforces.com").geturl()
+            try:
+                return _fetch_with_shared_transport(
+                    mirror_url,
+                    fetcher="http",
+                    pw_wait_ms=pw_wait_ms,
+                )
+            except ScrapeError:
+                pass
+        raise
 
 
 def fetch_html_playwright(url: str, wait_ms: int = 7000) -> str:
@@ -129,11 +153,9 @@ def fetch_html(url: str, fetcher: str = "auto", pw_wait_ms: int = 7000) -> str:
             time.sleep(wait_s - elapsed)
         _LAST_FETCH_AT = time.time()
 
-    return _fetch_with_shared_transport(
-        url,
-        fetcher=fetcher,
-        pw_wait_ms=pw_wait_ms,
-    )
+    if fetcher == "http":
+        return fetch_html_http(url, pw_wait_ms=pw_wait_ms)
+    return _fetch_with_shared_transport(url, fetcher=fetcher, pw_wait_ms=pw_wait_ms)
 
 
 def _extract_csrf_token(page_html: str) -> str:


### PR DESCRIPTION
## Summary

- add one shared Codeforces HTML transport for problem and blog pages
- try cloudscraper first, then fall back to headless Chromium on 403, timeout, connection failure, Cloudflare challenge HTML, or Tutorial is loading placeholder content
- expose content_valid() and route statement and tutorial callers through it
- reuse the same statement HTML in picker and fetcher to remove the duplicate request
- keep tutorial parsing and dynamic-fragment handling in scrape_cf_tutorial.py
- document the architecture in AGENTS.md

## Verification

- uv run pytest tests/ -q: 346 passed
- 1534F2: Playwright fetched 147,258 HTML chars and parsed a 3,926-char statement with 3 graphics
- 1415D: auto mode detected the HTTP loading placeholder, fell back to Playwright, and parsed a 13,243-char editorial body with no placeholder
- 1761D: Playwright parsed blog entry 109256 into a 17,098-char editorial body with the target section and no placeholder

Closes #65
Closes #66