### PR TITLE
fix: restore Codeforces tutorial scraping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,12 @@ NapCat (QQ) ──WS──> worker.py
   Codeforces problem statement and blog HTML. It tries `cloudscraper` first and falls
   back to headless Playwright Chromium after HTTP 403, timeout/connection failure,
   Cloudflare challenge HTML, or a lazy `Tutorial is loading...` response. Its
-  `content_valid()` helper is the shared usability gate. `picker.fetch_statement()`
+  `content_valid()` helper is the shared usability gate. Normal Codeforces pages may
+  contain an injected `challenge-platform` asset, so that marker is only treated as a
+  challenge when no problem/blog content container is present; strong challenge-page
+  markers remain invalid. The Playwright path uses the async API, derives its user agent
+  from the bundled Chromium major version, and keeps synchronous compatibility callers
+  safe when an asyncio loop is already running. `picker.fetch_statement()`
   fetches each uncached statement once and passes that HTML into
   `fetcher.process_problem()` for image/text extraction as well as metadata parsing.
 - **Stale cache detection**: `picker.py:fetch_statement()` detects caches created before image metadata via `_images_collected`. Stale caches with images are re-fetched so image metadata is available for multimodal tasks.

--- a/src/kouhai_bot/problems/cf_fetcher.py
+++ b/src/kouhai_bot/problems/cf_fetcher.py
@@ -7,41 +7,51 @@ request or returns HTML that still contains a client-side loading placeholder.
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Awaitable, Callable
+from concurrent.futures import ThreadPoolExecutor
 import logging
 import re
-from typing import Literal
+from typing import Literal, TypeVar
 
 import cloudscraper
 from cloudscraper import exceptions as cloudscraper_exceptions
 from requests import exceptions as requests_exceptions
 
 try:
-    from playwright.sync_api import Error as PlaywrightError
-    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
-    from playwright.sync_api import sync_playwright
+    from playwright.async_api import Error as PlaywrightError
+    from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+    from playwright.async_api import async_playwright
 except ImportError:  # pragma: no cover - playwright is a runtime dependency
-    sync_playwright = None
+    async_playwright = None
     PlaywrightError = Exception
     PlaywrightTimeoutError = TimeoutError
 
 logger = logging.getLogger("kouhai-bot.cf_fetcher")
 
-CF_PLAYWRIGHT_USER_AGENT = (
+CF_PLAYWRIGHT_USER_AGENT_TEMPLATE = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
     "AppleWebKit/537.36 (KHTML, like Gecko) "
-    "Chrome/131.0.0.0 Safari/537.36"
+    "Chrome/{major}.0.0.0 Safari/537.36"
 )
 CF_PLAYWRIGHT_VIEWPORT = {"width": 1365, "height": 768}
 CF_CONTENT_SELECTOR = ".problem-statement, .ttypography"
 CF_CONTENT_WAIT_MS = 45_000
 CF_TUTORIAL_LOADING_WAIT_MS = 5_000
 
-_CHALLENGE_RE = re.compile(
-    r"_cf_chl_opt|challenge-platform|cf-browser-verify",
+_CF_CONTENT_RE = re.compile(
+    r"""class\s*=\s*["'][^"']*\b(?:problem-statement|ttypography)\b""",
     re.I,
 )
+_STRONG_CHALLENGE_RE = re.compile(
+    r"_cf_chl_opt|cf-browser-verify|"
+    r"<title[^>]*>\s*just\s+a\s+moment|performing\s+security\s+verification",
+    re.I,
+)
+_CHALLENGE_ASSET_RE = re.compile(r"(?:cdn-cgi/)?challenge-platform", re.I)
 _TUTORIAL_LOADING_RE = re.compile(r"tutorial\s+is\s+loading(?:\.\.\.)?", re.I)
 _TRANSIENT_HTTP_STATUSES = {429, 502, 503, 504}
+_T = TypeVar("_T")
 
 
 class CFFetchError(RuntimeError):
@@ -63,10 +73,16 @@ def content_valid(body: str) -> bool:
     Besides empty and Cloudflare challenge pages, this rejects legacy blog
     pages whose HTTP response only exposes ``Tutorial is loading...`` content.
     Chromium renders those lazy-loaded tutorial fragments before returning.
+
+    Codeforces also injects a hidden ``challenge-platform`` script into normal
+    pages. That asset is only evidence of a challenge page when no recognizable
+    problem/blog content container exists.
     """
     if not isinstance(body, str) or not body.strip():
         return False
-    if _CHALLENGE_RE.search(body):
+    if _STRONG_CHALLENGE_RE.search(body):
+        return False
+    if _CHALLENGE_ASSET_RE.search(body) and not _CF_CONTENT_RE.search(body):
         return False
     if _TUTORIAL_LOADING_RE.search(body):
         return False
@@ -127,36 +143,47 @@ def fetch_html_http(url: str, *, timeout: float = 30) -> str:
     return body
 
 
-def fetch_html_playwright(url: str, *, wait_ms: int = 7000) -> str:
+def _playwright_user_agent(browser_version: str) -> str:
+    """Build a UA whose Chrome major matches Playwright's bundled browser."""
+    major = str(browser_version or "").partition(".")[0]
+    if not major.isdigit():
+        major = "131"
+    return CF_PLAYWRIGHT_USER_AGENT_TEMPLATE.format(major=major)
+
+
+async def fetch_html_playwright_async(url: str, *, wait_ms: int = 7000) -> str:
     """Fetch a rendered Codeforces HTML page with headless Chromium."""
-    if sync_playwright is None:
+    if async_playwright is None:
         raise CFFetchError(
             "Playwright is not installed; install Playwright and Chromium first",
             kind="dependency",
         )
 
     try:
-        with sync_playwright() as playwright:
-            browser = playwright.chromium.launch(headless=True)
+        async with async_playwright() as playwright:
+            browser = await playwright.chromium.launch(headless=True)
             try:
-                context = browser.new_context(
-                    user_agent=CF_PLAYWRIGHT_USER_AGENT,
+                context = await browser.new_context(
+                    user_agent=_playwright_user_agent(browser.version),
                     viewport=CF_PLAYWRIGHT_VIEWPORT,
                 )
-                page = context.new_page()
-                page.goto(url, wait_until="domcontentloaded", timeout=45_000)
+                page = await context.new_page()
+                await page.goto(url, wait_until="domcontentloaded", timeout=45_000)
                 if wait_ms > 0:
-                    page.wait_for_timeout(wait_ms)
+                    await page.wait_for_timeout(wait_ms)
                 try:
-                    page.wait_for_selector(CF_CONTENT_SELECTOR, timeout=CF_CONTENT_WAIT_MS)
+                    await page.wait_for_selector(
+                        CF_CONTENT_SELECTOR,
+                        timeout=CF_CONTENT_WAIT_MS,
+                    )
                 except PlaywrightTimeoutError:
                     # Some valid CF pages do not use either common content class.
                     # The final content check below still rejects challenge pages.
                     pass
-                body = page.content()
+                body = await page.content()
                 if _TUTORIAL_LOADING_RE.search(body):
                     try:
-                        page.wait_for_function(
+                        await page.wait_for_function(
                             """() => !/tutorial\\s+is\\s+loading(?:\\.\\.\\.)?/i.test(
                                 document.body?.innerText || ''
                             )""",
@@ -166,9 +193,9 @@ def fetch_html_playwright(url: str, *, wait_ms: int = 7000) -> str:
                         # The final content check produces a stable content error if
                         # the lazy tutorial fragment never becomes available.
                         pass
-                    body = page.content()
+                    body = await page.content()
             finally:
-                browser.close()
+                await browser.close()
     except PlaywrightTimeoutError as exc:
         raise CFFetchError(
             f"Playwright timed out fetching {url}: {exc}",
@@ -186,6 +213,26 @@ def fetch_html_playwright(url: str, *, wait_ms: int = 7000) -> str:
             kind="content",
         )
     return body
+
+
+def _run_async_from_sync(factory: Callable[[], Awaitable[_T]]) -> _T:
+    """Run an async operation for synchronous callers, even on an active loop."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(factory())
+
+    # A synchronous compatibility caller cannot await the coroutine. Running it
+    # in a worker avoids nesting asyncio.run() and Playwright inside the bot loop.
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(lambda: asyncio.run(factory())).result()
+
+
+def fetch_html_playwright(url: str, *, wait_ms: int = 7000) -> str:
+    """Synchronous compatibility wrapper around async Playwright."""
+    return _run_async_from_sync(
+        lambda: fetch_html_playwright_async(url, wait_ms=wait_ms)
+    )
 
 
 def fetch_html(

--- a/tests/test_cf_fetcher.py
+++ b/tests/test_cf_fetcher.py
@@ -1,7 +1,8 @@
 """Regression tests for the shared Codeforces HTML fetcher."""
 
+import asyncio
 from concurrent.futures import ThreadPoolExecutor
-from threading import Barrier, Lock
+from threading import Barrier, Lock, get_ident
 from types import SimpleNamespace
 
 import pytest
@@ -39,10 +40,10 @@ class _FakePlaywrightManager:
     def __init__(self, playwright):
         self.playwright = playwright
 
-    def __enter__(self):
+    async def __aenter__(self):
         return self.playwright
 
-    def __exit__(self, exc_type, exc, tb):
+    async def __aexit__(self, exc_type, exc, tb):
         return False
 
 
@@ -51,25 +52,26 @@ class _FakeChromium:
         self.browser = browser
         self.launch_kwargs = None
 
-    def launch(self, **kwargs):
+    async def launch(self, **kwargs):
         self.launch_kwargs = kwargs
         return self.browser
 
 
 class _FakeBrowser:
-    def __init__(self, page):
+    def __init__(self, page, *, version="149.0.7827.55"):
         self.page = page
+        self.version = version
         self.context_kwargs = None
         self.closed = False
 
-    def new_context(self, **kwargs):
+    async def new_context(self, **kwargs):
         self.context_kwargs = kwargs
         return self
 
-    def new_page(self):
+    async def new_page(self):
         return self.page
 
-    def close(self):
+    async def close(self):
         self.closed = True
 
 
@@ -81,23 +83,23 @@ class _FakePage:
         self.function_exc = function_exc
         self.calls = []
 
-    def goto(self, url, **kwargs):
+    async def goto(self, url, **kwargs):
         self.calls.append(("goto", url, kwargs))
 
-    def wait_for_timeout(self, wait_ms):
+    async def wait_for_timeout(self, wait_ms):
         self.calls.append(("wait_for_timeout", wait_ms))
 
-    def wait_for_selector(self, selector, **kwargs):
+    async def wait_for_selector(self, selector, **kwargs):
         self.calls.append(("wait_for_selector", selector, kwargs))
         if self.selector_exc is not None:
             raise self.selector_exc
 
-    def wait_for_function(self, expression, **kwargs):
+    async def wait_for_function(self, expression, **kwargs):
         self.calls.append(("wait_for_function", expression, kwargs))
         if self.function_exc is not None:
             raise self.function_exc
 
-    def content(self):
+    async def content(self):
         self.calls.append(("content",))
         if self._html_results is not None:
             return next(self._html_results)
@@ -130,6 +132,42 @@ def test_content_valid_rejects_unusable_responses(body):
 )
 def test_content_valid_accepts_statement_and_blog_pages(body):
     assert cf_fetcher.content_valid(body) is True
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        (
+            "<html><div class='problem-statement'>A real statement</div>"
+            "<script src='/cdn-cgi/challenge-platform/scripts/jsd/main.js'></script>"
+            "</html>"
+        ),
+        (
+            "<html><div class='ttypography'>A rendered editorial</div>"
+            "<script>const path = '/cdn-cgi/challenge-platform/scripts/jsd/main.js';"
+            "</script></html>"
+        ),
+    ],
+)
+def test_content_valid_accepts_cf_content_with_injected_challenge_asset(body):
+    assert cf_fetcher.content_valid(body) is True
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        (
+            "<html><title>Just a moment...</title>"
+            "<div class='problem-statement'>spoofed content</div></html>"
+        ),
+        (
+            "<html><div class='ttypography'>Performing security verification</div>"
+            "</html>"
+        ),
+    ],
+)
+def test_content_valid_rejects_strong_challenge_markers_even_with_content_class(body):
+    assert cf_fetcher.content_valid(body) is False
 
 
 def _http_error(status: int) -> requests_exceptions.HTTPError:
@@ -284,7 +322,7 @@ def test_explicit_playwright_uses_headless_chromium(monkeypatch):
     playwright = SimpleNamespace(chromium=chromium)
     monkeypatch.setattr(
         cf_fetcher,
-        "sync_playwright",
+        "async_playwright",
         lambda: _FakePlaywrightManager(playwright),
     )
 
@@ -297,7 +335,11 @@ def test_explicit_playwright_uses_headless_chromium(monkeypatch):
     assert result == page.html
     assert chromium.launch_kwargs == {"headless": True}
     assert browser.context_kwargs == {
-        "user_agent": cf_fetcher.CF_PLAYWRIGHT_USER_AGENT,
+        "user_agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/149.0.0.0 Safari/537.36"
+        ),
         "viewport": cf_fetcher.CF_PLAYWRIGHT_VIEWPORT,
     }
     assert page.calls == [
@@ -317,13 +359,37 @@ def test_explicit_playwright_uses_headless_chromium(monkeypatch):
     assert browser.closed is True
 
 
+def test_sync_playwright_wrapper_is_safe_inside_running_event_loop(monkeypatch):
+    worker_threads = []
+
+    async def fake_async_fetch(url, *, wait_ms):
+        worker_threads.append(get_ident())
+        return f"<div class='problem-statement'>{url}:{wait_ms}</div>"
+
+    monkeypatch.setattr(
+        cf_fetcher,
+        "fetch_html_playwright_async",
+        fake_async_fetch,
+    )
+
+    async def invoke_sync_wrapper():
+        loop_thread = get_ident()
+        result = cf_fetcher.fetch_html_playwright("https://codeforces.com/p", wait_ms=12)
+        return loop_thread, result
+
+    loop_thread, result = asyncio.run(invoke_sync_wrapper())
+
+    assert result.endswith("https://codeforces.com/p:12</div>")
+    assert worker_threads and worker_threads[0] != loop_thread
+
+
 def test_playwright_rejects_placeholder_after_render(monkeypatch):
     page = _FakePage("<div>Tutorial is loading...</div>")
     browser = _FakeBrowser(page)
     playwright = SimpleNamespace(chromium=_FakeChromium(browser))
     monkeypatch.setattr(
         cf_fetcher,
-        "sync_playwright",
+        "async_playwright",
         lambda: _FakePlaywrightManager(playwright),
     )
 
@@ -354,7 +420,7 @@ def test_playwright_waits_for_tutorial_placeholder_to_resolve(monkeypatch):
     playwright = SimpleNamespace(chromium=_FakeChromium(browser))
     monkeypatch.setattr(
         cf_fetcher,
-        "sync_playwright",
+        "async_playwright",
         lambda: _FakePlaywrightManager(playwright),
     )
 


### PR DESCRIPTION
## Summary
- accept normal Codeforces pages that include the injected Cloudflare challenge asset
- use Playwright async API and keep synchronous callers safe inside an active event loop
- derive the browser user agent from the bundled Chromium major version
- add regressions for challenge detection and asyncio compatibility

## Verification
- uv run pytest -q (379 passed)
- live Playwright smoke test for 1333D, 786B, 1225E, 733F, 1691E, 2107F1, and 105C
- live low-level tutorial collection for 1333D returned the official editorial without a loading placeholder