### PR TITLE
feat: add proxy support for LLM API calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ All providers use the OpenAI-compatible `/chat/completions` endpoint.
 | `llm.max_retries` | int | 2 | Max retries **per provider** before moving to next |
 | `llm.retry_base_delay_sec` | float | 1.0 | Exponential backoff base |
 | `llm.retry_max_delay_sec` | float | 8.0 | Max backoff cap |
+| `llm.proxy` | str | `""` | HTTP proxy URL for all LLM API calls; use an `http://` URL for a mixed HTTP/SOCKS proxy port |
 | `llm.judge_timeout_sec` | int | 1200 | Judge LLM timeout |
 | `llm.clarify_timeout_sec` | int | 600 | Clarify LLM timeout |
 | `llm.review_timeout_sec` | int | 600 | Review LLM timeout |

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ cp config.example.yaml config.yaml
 
 ZenMux 上的体验模型也可以作为 OpenAI-compatible provider 配置。示例见 `config.example.yaml`；例如 Grok 4.5 Free 可使用 `model: "x-ai/grok-4.5-free"`、`reasoning_effort: "xhigh"`、`model_tag: "『∅』"`。如果某个网关需要特殊 payload，可在 provider 上配置 `temperature`、`send_thinking` 或 `extra_body`，避免为每个模型在代码里新增分支。
 
+如果服务器需要通过本地代理访问 LLM API，可设置 `llm.proxy`，例如 `proxy: "http://127.0.0.1:7897"`。mihomo 等 mixed HTTP/SOCKS 端口应使用 `http://` URL。
+
 #### 多模态题面
 
 ```

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -20,6 +20,7 @@ llm:
   retry_base_delay_sec: 1.0
   retry_max_delay_sec: 8.0
   stream_idle_timeout_sec: 120 # SSE idle timeout; retries if no bytes arrive for this long
+  proxy: ""                    # e.g. "http://127.0.0.1:7897"; empty disables proxying
 
   # Per-task timeouts (apply to all providers)
   judge_timeout_sec: 1200

--- a/src/kouhai_bot/config.py
+++ b/src/kouhai_bot/config.py
@@ -114,6 +114,7 @@ class BotConfig:
     llm_retry_base_delay_sec: float = 1.0
     llm_retry_max_delay_sec: float = 8.0
     llm_stream_idle_timeout_sec: int = 120
+    llm_proxy: str = ""
     judge_timeout_sec: int = 1200
     clarify_timeout_sec: int = 600
     review_timeout_sec: int = 600
@@ -188,6 +189,8 @@ class BotConfig:
         c.llm_stream_idle_timeout_sec = int(
             llm.get("stream_idle_timeout_sec", c.llm_stream_idle_timeout_sec)
         )
+        proxy = llm.get("proxy", c.llm_proxy)
+        c.llm_proxy = "" if proxy is None else str(proxy).strip()
         c.judge_timeout_sec = int(llm.get("judge_timeout_sec", c.judge_timeout_sec))
         c.clarify_timeout_sec = int(
             llm.get("clarify_timeout_sec", c.clarify_timeout_sec)

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 import re
@@ -66,6 +67,24 @@ def _chat_completions_url(base_url: str) -> str:
     if base.endswith("/chat/completions"):
         return base
     return f"{base}/chat/completions"
+
+
+def _client_session_kwargs(proxy: str) -> dict[str, object]:
+    """Build proxy options supported by the installed aiohttp version."""
+    proxy = (proxy or "").strip()
+    if not proxy:
+        return {}
+
+    kwargs: dict[str, object] = {"trust_env": True}
+    try:
+        supports_session_proxy = (
+            "proxy" in inspect.signature(aiohttp.ClientSession).parameters
+        )
+    except (TypeError, ValueError):
+        supports_session_proxy = False
+    if supports_session_proxy:
+        kwargs["proxy"] = proxy
+    return kwargs
 
 
 def strip_leaked_thinking(text: str) -> str:
@@ -431,17 +450,23 @@ async def _post_chat_completion_once(
     payload: dict,
     timeout: int,
     stream_idle_timeout_sec: int | float | None = None,
+    proxy: str = "",
 ) -> _ChatCompletionAttempt:
     try:
-        async with session.post(
-            _chat_completions_url(base_url),
-            json=payload,
-            headers=headers,
-            timeout=_chat_completion_timeout(
+        request_kwargs: dict[str, object] = {
+            "json": payload,
+            "headers": headers,
+            "timeout": _chat_completion_timeout(
                 payload=payload,
                 total_timeout_sec=timeout,
                 stream_idle_timeout_sec=stream_idle_timeout_sec,
             ),
+        }
+        if proxy:
+            request_kwargs["proxy"] = proxy
+        async with session.post(
+            _chat_completions_url(base_url),
+            **request_kwargs,
         ) as resp:
             if resp.status != 200:
                 text = await resp.text()
@@ -557,11 +582,12 @@ async def chat_completion(
     stream_idle_timeout_sec = int(
         getattr(cfg, "llm_stream_idle_timeout_sec", 120) or 0
     )
+    proxy = str(getattr(cfg, "llm_proxy", "") or "").strip()
 
     last_failure_kind: str | None = None
     last_failed_provider: str | None = None
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(**_client_session_kwargs(proxy)) as session:
         for provider in providers:
             model_name = provider.model_for(explicit_model=model)
             headers = {
@@ -608,6 +634,7 @@ async def chat_completion(
                     payload=payload,
                     timeout=timeout,
                     stream_idle_timeout_sec=stream_idle_timeout_sec,
+                    proxy=proxy,
                 )
                 if result.text is not None:
                     if last_failed_provider:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,6 +158,21 @@ def test_llm_stream_idle_timeout_defaults_to_120(monkeypatch, tmp_path):
     assert cfg.llm_stream_idle_timeout_sec == 120
 
 
+def test_llm_proxy_loads_from_yaml(monkeypatch, tmp_path):
+    data = yaml.safe_load(_make_yaml())
+    data["llm"]["proxy"] = "http://127.0.0.1:7897"
+
+    cfg = _from_yaml(yaml.dump(data), monkeypatch, tmp_path)
+
+    assert cfg.llm_proxy == "http://127.0.0.1:7897"
+
+
+def test_llm_proxy_defaults_to_empty_string(monkeypatch, tmp_path):
+    cfg = _from_yaml(_make_yaml(), monkeypatch, tmp_path)
+
+    assert cfg.llm_proxy == ""
+
+
 def test_provider_stream_loads_from_yaml(monkeypatch, tmp_path):
     data = yaml.safe_load(_make_yaml())
     data["llm"]["smart_model"][0]["stream"] = True

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -287,6 +287,61 @@ def test_general_model_tasks_preserve_provider_model_tag():
     assert calls[0]["model"] == "general"
 
 
+def test_call_chat_completion_configures_session_and_request_proxy():
+    cfg = _openai_cfg(llm_proxy="http://127.0.0.1:7897")
+    session_calls = []
+    request_calls = []
+
+    class ProxySession(_DummySession):
+        def __init__(self, *, proxy=None, trust_env=False):
+            session_calls.append({"proxy": proxy, "trust_env": trust_env})
+
+    async def fake_once(session, **kwargs):
+        request_calls.append(kwargs)
+        return _ChatCompletionAttempt(text="OK", retryable=False, retry_after_sec=None)
+
+    with patch("kouhai_bot.llm.get_config", return_value=cfg), \
+            patch("kouhai_bot.llm.aiohttp.ClientSession", ProxySession), \
+            patch("kouhai_bot.llm._post_chat_completion_once", side_effect=fake_once):
+        result = asyncio.run(call_chat_completion(
+            [{"role": "user", "content": "Reply with exactly OK."}],
+            task="judge",
+        ))
+
+    assert result == "OK"
+    assert session_calls == [{
+        "proxy": "http://127.0.0.1:7897",
+        "trust_env": True,
+    }]
+    assert request_calls[0]["proxy"] == "http://127.0.0.1:7897"
+
+
+def test_call_chat_completion_uses_request_proxy_for_older_aiohttp():
+    cfg = _openai_cfg(llm_proxy="http://127.0.0.1:7897")
+    session_calls = []
+    request_calls = []
+
+    class OldAiohttpSession(_DummySession):
+        def __init__(self, *, trust_env=False):
+            session_calls.append({"trust_env": trust_env})
+
+    async def fake_once(session, **kwargs):
+        request_calls.append(kwargs)
+        return _ChatCompletionAttempt(text="OK", retryable=False, retry_after_sec=None)
+
+    with patch("kouhai_bot.llm.get_config", return_value=cfg), \
+            patch("kouhai_bot.llm.aiohttp.ClientSession", OldAiohttpSession), \
+            patch("kouhai_bot.llm._post_chat_completion_once", side_effect=fake_once):
+        result = asyncio.run(call_chat_completion(
+            [{"role": "user", "content": "Reply with exactly OK."}],
+            task="judge",
+        ))
+
+    assert result == "OK"
+    assert session_calls == [{"trust_env": True}]
+    assert request_calls[0]["proxy"] == "http://127.0.0.1:7897"
+
+
 def test_multimodal_task_uses_multimodal_provider_and_preserves_image_content():
     provider = LlmProviderConfig(
         name="mmx",
@@ -1528,6 +1583,26 @@ def test_non_streaming_chat_completion_does_not_use_sock_read_idle_timeout():
     assert result.text == "OK"
     assert timeout.total == 7200
     assert timeout.sock_read is None
+
+
+def test_post_chat_completion_passes_configured_proxy_to_request():
+    response = _DummyResponse(json_data={
+        "choices": [{"message": {"content": "OK"}}],
+    })
+    session = _PostSession(response)
+
+    result = asyncio.run(_post_chat_completion_once(
+        session,
+        provider_name="openai",
+        base_url="https://zenmux.ai/api/v1",
+        headers={},
+        payload={},
+        timeout=120,
+        proxy="http://127.0.0.1:7897",
+    ))
+
+    assert result.text == "OK"
+    assert session.calls[0][1]["proxy"] == "http://127.0.0.1:7897"
 
 
 def test_dashscope_stream_payload_requests_usage_without_token_caps():


### PR DESCRIPTION
## Summary

- add an optional `llm.proxy` configuration for all LLM API calls
- configure aiohttp session-level proxying with `trust_env=True` when supported
- pass the proxy directly to chat-completion POST requests for compatibility with older aiohttp versions
- document the mihomo mixed-port configuration and add regression coverage

## Tests

- `uv run pytest tests/ -q` (384 passed)