### PR TITLE
fix: enable trust_env for aiohttp ClientSession

### DIFF
--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -561,7 +561,7 @@ async def chat_completion(
     last_failure_kind: str | None = None
     last_failed_provider: str | None = None
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         for provider in providers:
             model_name = provider.model_for(explicit_model=model)
             headers = {


### PR DESCRIPTION
aiohttp 3.x 默认 trust_env=False，不读取 HTTPS_PROXY 环境变量，导致 LLM 请求无法走本地代理访问 zenmux。加 trust_env=True 让代理生效。