### PR TITLE
Prefetch the next group problem to hide /np latency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,8 +68,12 @@ NapCat (QQ) ──WS──> worker.py
   preparation is not reported by `/status`; only an admitted post is. While a slot is
   READY, the worker also idempotently maintains its full official-editorial prefetch:
   persisted slots resume crawler + translation work after restart, in-flight work is
-  deduplicated by pid, and completed/no-editorial terminal states stop retries. This
-  editorial maintenance never blocks a `/newproblem` claim. `/setproblem` and
+  deduplicated by pid, and verified/no-editorial terminal states stop retries. Cancellation,
+  deadline exhaustion, scraper/LLM errors, and other incomplete attempts do not write a
+  terminal marker, so startup or the next maintenance pass retries them; only a completed
+  search with no match or an explicit final mismatch may write the versioned
+  `no_editorial` marker with a reason. Legacy zero-byte markers are untrusted and retried.
+  This editorial maintenance never blocks a `/newproblem` claim. `/setproblem` and
   `/setproblem random` intentionally keep their live-fetch behavior and never use this
   slot.
 - **Friend request auto-approval**: Normal OneBot `post_type="request"` / `request_type="friend"` events are parsed by `napcat/client.py`, routed by `handlers.process_event()`, and approved via `set_friend_add_request`. QQ/NapCat "doubtful" friend requests are not reliably pushed as request events, so `worker.py` also runs `friend_requests.doubt_friend_request_loop()`, which polls `get_doubt_friends_add_request` every 60 seconds and approves with `set_doubt_friends_add_request`. Both paths approve only after the requester is confirmed to be a member of `CURRENT_GROUP`; lookup failure, malformed events, non-friend requests, and non-members are ignored without approving. Requests that were already consumed by another QQ client may not appear in the doubtful-request poll.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,8 @@ NapCat (QQ) ──WS──> worker.py
                          │
                          ├── process_event(..., spawn_handlers=True)
                          ├── cmd/*.py  auto-discovered by registry
-                         └── scheduler/ background loop (60s tick)
+                         ├── scheduler/ background loop (60s tick)
+                         └── next-problem prefetch loop (one READY slot)
 ```
 
 ## Key Design Decisions
@@ -52,7 +53,21 @@ NapCat (QQ) ──WS──> worker.py
   `fetcher.process_problem()` for image/text extraction as well as metadata parsing.
 - **Stale cache detection**: `picker.py:fetch_statement()` detects caches created before image metadata via `_images_collected`. Stale caches with images are re-fetched so image metadata is available for multimodal tasks.
 - **No hermes cron involvement**: The bot runs its own scheduler loop (`scheduler/engine.py`), not hermes cron jobs.
-- **Single worker runtime**: `worker.py` keeps the NapCat reverse-WS connection, dispatches commands, and owns the scheduler in one process. There is no SQLite event queue, ingress supervisor, worker hot-swap, or auto-update loop.
+- **Single worker runtime**: `worker.py` keeps the NapCat reverse-WS connection,
+  dispatches commands, and owns the scheduler and next-problem prefetch loop in one
+  process. There is no SQLite event queue, ingress supervisor, worker hot-swap, or
+  auto-update loop.
+- **Next-problem prefetch**: `problem_preparation.py` contains the complete blocking
+  group-problem preparation pipeline (pick/fetch, samples, translated notes, audited
+  summary), while `problem_prefetch.py` maintains one durable READY slot per group in
+  `next_problem.json`. `/newproblem` claims that slot under its existing post lock and
+  normally only builds/sends the QQ card; if startup preparation is still cold it awaits
+  the same single-flight task. A claim prevents refill until publication finishes, then
+  release wakes the worker loop. READY-slot validation covers rating-range changes,
+  current/solved problems, statement presence, and multimodal availability. Background
+  preparation is not reported by `/status`; only an admitted post is. `/setproblem`
+  and `/setproblem random` intentionally keep their live-fetch behavior and never use
+  this slot.
 - **Friend request auto-approval**: Normal OneBot `post_type="request"` / `request_type="friend"` events are parsed by `napcat/client.py`, routed by `handlers.process_event()`, and approved via `set_friend_add_request`. QQ/NapCat "doubtful" friend requests are not reliably pushed as request events, so `worker.py` also runs `friend_requests.doubt_friend_request_loop()`, which polls `get_doubt_friends_add_request` every 60 seconds and approves with `set_doubt_friends_add_request`. Both paths approve only after the requester is confirmed to be a member of `CURRENT_GROUP`; lookup failure, malformed events, non-friend requests, and non-members are ignored without approving. Requests that were already consumed by another QQ client may not appear in the doubtful-request poll.
 - **User groups**: `user_groups.py` — all users default to `default`; `USER_GROUPS` configures
   non-default groups such as `starred`/`打星`, their members, submit delay, and rejection
@@ -90,10 +105,14 @@ NapCat (QQ) ──WS──> worker.py
   repair followed by another audit; indeterminate or repeatedly failing audits reject the
   summary so the caller can retry instead of posting it.
 - **Official CF tutorials**: Scraped editorials live under `{data_dir}/tutorials/{pid}.json`
-  (see `tools/cf_tutorial_agent.py`; low-level CF HTML helpers live in `tools/scrape_cf_tutorial.py`). Runtime extraction is in `tutorials.py`. On the
-  On **new problem** (`/newproblem`), `schedule_prefetch_editorial(pid)`
-  starts background translation (using the `llm.general_model` queue) into `tutorial_translations/` so first AC
-  can deliver without waiting. On **first AC**, congrats is sent in `_finalize_submit`, then
+  (see `tools/cf_tutorial_agent.py`; low-level CF HTML helpers live in
+  `tools/scrape_cf_tutorial.py`). Runtime extraction is in `tutorials.py`. During
+  **next-problem preparation**, `schedule_prefetch_editorial(pid)` starts background
+  translation (using the `llm.general_model` queue) into `tutorial_translations/` so
+  first AC can deliver without waiting. Editorial completion does not gate the
+  next-problem READY slot. Publication reasserts the same trigger so a READY slot that
+  survived a worker restart also resumes any interrupted crawl. On **first AC**,
+  congrats is sent in `_finalize_submit`, then
   `schedule_post_solve_editorial_followup()` only **delivers** (awaits in-flight prefetch if
   needed). Neither path uses the state scheduler. Tutorial scraping depends on Playwright
   with Chromium installed for browser fallback when HTTP fetches hit Codeforces blocking.
@@ -368,6 +387,7 @@ An empty `model_tag` disables the feature per-provider.
 groups/<gid>/state.json      # today's problem (+ posted_at unix ts when card was delivered)
 groups/<gid>/scoreboard.json # cumulative {solves, user_submissions}
 groups/<gid>/daily_msg.json  # forward card payload (msg_id/sample_msg_ids/note_msg_id/snake_msg_id 等, for /problem)
+groups/<gid>/next_problem.json # durable READY prefetch slot; atomically claimed by /newproblem
 groups/<gid>/problem_summaries.json # saved Chinese problem summaries keyed by pid
 groups/<gid>/used.json       # used problem IDs
 groups/<gid>/groupctx_*.json # group message context
@@ -396,7 +416,7 @@ No repository-local runtime queue is used.
 | `/submit` (`/sbm`) | submit.py | `handle` | ✅ state scheduler | `llm.smart_model` queue | Judge solution, save history, serialize only first-blood/scoreboard; configured dynamic-wait group submits redirect to private judge; private AC does not score until synced |
 | `/clarify` (`/clrf`) | clarify.py | `handle` | ✅ state scheduler | `llm.general_model` queue | Clarify problem details (JSON output, anti-spoiler, no original problem identity), using admission-time pid; private uses pid-specific summary |
 | `/clear` | clear.py | `handle` | ✅ state scheduler | — | Clear the current user's stored submit/clarify/review history for the admission-time current problem or current private problem |
-| `/newproblem` (`/np`) | newproblem.py | `handle` | ✅ post lock | `llm.general_model` queue | Force new problem when solved (or none); unsolved needs exact `/newproblem --force`; samples are forwarded as separate nodes; if statement has `notes`, translate+symbol-normalize and append as a dedicated notes node; commits state only after card delivery succeeds and keeps `daily_msg.json` in sync even on direct-text fallback |
+| `/newproblem` (`/np`) | newproblem.py | `handle` | ✅ post lock | prefetched `llm.general_model` result | Force new problem when solved (or none); unsolved needs exact `/newproblem --force`; claims the one-slot group prefetch (or awaits its single-flight cold build); samples are forwarded as separate nodes; if statement has `notes`, translate+symbol-normalize and append as a dedicated notes node; commits state only after card delivery succeeds and keeps `daily_msg.json` in sync even on direct-text fallback |
 | `/problem` (`/pb`) | stubs.py | `handle_problem` | ❌ | — | Resend current group/private problem via forward card; group path only uses `daily_msg.json` when pid matches `state.json.today`; if solved, add a friendly `/newproblem` hint |
 | `/tag` | stubs.py | `handle_tag` | ❌ | — | Show current group/private problem CF tags |
 | `/scoreboard` | stubs.py | `handle_scoreboard` | ❌ | — | Cumulative weighted leaderboard; shows the formula at the top, then refreshes latest group nicknames at display time |
@@ -412,9 +432,8 @@ No repository-local runtime queue is used.
 Stateful commands (`/submit`, `/clarify`, `/review`, `/clear`) no longer serialize
 through one global lock or one per-group FIFO execution queue. Group requests run
 through a **per-group state scheduler** implemented in `submit.py`; private judge
-requests run through a separate **per-user private coordinator**. `/newproblem` and
-`/newproblem` uses its own per-group post lock and commits current-problem state only
-after delivery.
+requests run through a separate **per-user private coordinator**. `/newproblem` uses
+its own per-group post lock and commits current-problem state only after delivery.
 
 Key rules:
 
@@ -457,15 +476,16 @@ Key rules:
   addendum can refer to it after a restart, and the received `/submit` still counts as a
   submit attempt in saved user history. When superseded by `/clear`,
   it is removed with the rest of that user's current-problem context.
-- **New problem visibility**: `/newproblem` picks and summarizes a candidate
-  without changing `state.json`. Until the new card is successfully delivered, all
-  commands still see the old problem. Failed delivery leaves the old current problem
-  intact.
-- **New problem serialization/status**: `/newproblem`, `/newproblem --force`, and
-  `/newproblem` uses a per-group post lock. User-triggered new-problem
-  commands are rejected immediately with a busy reminder while another new problem is
-  being prepared. `/status` reports this post work as busy while the lock holder is
-  building/sending the card.
+- **New problem visibility**: the worker prepares one candidate without changing
+  `state.json`. `/newproblem` atomically claims it, but all commands continue to see the
+  old problem until the new card is successfully delivered. Failed delivery leaves the
+  old current problem intact; the claimed candidate is discarded, then background
+  refill begins.
+- **New problem serialization/status**: `/newproblem`, `/newproblem --force`, and the
+  poke trigger use a per-group post lock. User-triggered new-problem commands are
+  rejected immediately with a busy reminder while another post is claiming/building/
+  sending. `/status` reports only admitted post work as busy; routine background
+  prefetch is deliberately invisible.
 
 Status helpers used by `/status`:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,9 +54,9 @@ NapCat (QQ) ──WS──> worker.py
 - **Stale cache detection**: `picker.py:fetch_statement()` detects caches created before image metadata via `_images_collected`. Stale caches with images are re-fetched so image metadata is available for multimodal tasks.
 - **No hermes cron involvement**: The bot runs its own scheduler loop (`scheduler/engine.py`), not hermes cron jobs.
 - **Single worker runtime**: `worker.py` keeps the NapCat reverse-WS connection,
-  dispatches commands, and owns the scheduler and next-problem prefetch loop in one
-  process. There is no SQLite event queue, ingress supervisor, worker hot-swap, or
-  auto-update loop.
+  dispatches commands, and owns the scheduler, next-problem prefetch loop, and
+  current/next editorial maintenance loop in one process. There is no SQLite event
+  queue, ingress supervisor, worker hot-swap, or auto-update loop.
 - **Next-problem prefetch**: `problem_preparation.py` contains the complete blocking
   group-problem preparation pipeline (pick/fetch, samples, translated notes, audited
   summary), while `problem_prefetch.py` maintains one durable READY slot per group in
@@ -64,15 +64,22 @@ NapCat (QQ) ──WS──> worker.py
   normally only builds/sends the QQ card; if startup preparation is still cold it awaits
   the same single-flight task. A claim prevents refill until publication finishes, then
   release wakes the worker loop. READY-slot validation covers rating-range changes,
-  current/solved problems, statement presence, and multimodal availability. Background
-  preparation is not reported by `/status`; only an admitted post is. While a slot is
-  READY, the worker also idempotently maintains its full official-editorial prefetch:
+  current/solved problems, statement presence and fingerprint, and multimodal
+  availability. Summary generation is a side-effect-free complete action: only a
+  semantically audited result is stored; after the existing two failed attempts the
+  availability fallback is explicitly stored as `summary_status=incomplete` and the
+  problem can still be posted without a summary. Background preparation is not reported
+  by `/status`; only an admitted post is. A newly READY slot notifies the worker's
+  orchestration hook immediately, and the worker also idempotently maintains full
+  official-editorial prefetch for both current and READY problems:
   persisted slots resume crawler + translation work after restart, in-flight work is
   deduplicated by pid, and verified/no-editorial terminal states stop retries. Cancellation,
   deadline exhaustion, scraper/LLM errors, and other incomplete attempts do not write a
-  terminal marker, so startup or the next maintenance pass retries them; only a completed
-  search with no match or an explicit final mismatch may write the versioned
-  `no_editorial` marker with a reason. Legacy zero-byte markers are untrusted and retried.
+  terminal marker, so startup or the next maintenance pass retries them. Only a completed,
+  exhaustive search of all non-rejected candidates may write the versioned
+  `no_editorial` marker with a reason. READY and no-editorial markers are both bound to
+  the statement fingerprint; the READY marker is also bound to the persisted editorial
+  fingerprint. Legacy markers are untrusted and retried.
   This editorial maintenance never blocks a `/newproblem` claim. `/setproblem` and
   `/setproblem random` intentionally keep their live-fetch behavior and never use this
   slot.
@@ -111,15 +118,22 @@ NapCat (QQ) ──WS──> worker.py
   whose omission would make a definition ambiguous (for example, an isolated vertex also
   counting as having only incoming edges). A failed gate or audit triggers one targeted
   repair followed by another audit; indeterminate or repeatedly failing audits reject the
-  summary so the caller can retry instead of posting it.
+  summary so the caller can retry instead of posting it. `problem_summary.py` owns the
+  side-effect-free preparation result; `problem_summaries.json` accepts only a verified
+  result bound to the current statement fingerprint, so stale/legacy cache entries are
+  not used as trusted summaries.
 - **Official CF tutorials**: Scraped editorials live under `{data_dir}/tutorials/{pid}.json`
   (see `tools/cf_tutorial_agent.py`; low-level CF HTML helpers live in
-  `tools/scrape_cf_tutorial.py`). Runtime extraction is in `tutorials.py`. During
-  **next-problem preparation**, `schedule_prefetch_editorial(pid)` starts background
-  translation (using the `llm.general_model` queue) into `tutorial_translations/` so
-  first AC can deliver without waiting. Editorial completion does not gate the
-  next-problem READY slot. Publication reasserts the same trigger so a READY slot that
-  survived a worker restart also resumes any interrupted crawl. On **first AC**,
+  `tools/scrape_cf_tutorial.py`). `editorial_content.py` contains only normalized
+  editorial models and extraction rules, so the scraper and runtime action share parsing
+  without importing each other. `editorial_preparation.py` owns the complete
+  side-effect-free runtime action: discover candidates, validate them against the
+  statement, and translate the first verified match. Candidate bundles are never
+  persisted. `tutorials.py` is the persistence/read boundary and commits source,
+  translation, then the source-bound verified marker last. Editorial completion does
+  not gate the next-problem READY slot. The worker starts editorial work from the READY
+  notification and continuously retries incomplete current/next work; publication
+  reasserts the same trigger. On **first AC**,
   congrats is sent in `_finalize_submit`, then
   `schedule_post_solve_editorial_followup()` only **delivers** (awaits in-flight prefetch if
   needed). Neither path uses the state scheduler. Tutorial scraping depends on Playwright
@@ -395,8 +409,8 @@ An empty `model_tag` disables the feature per-provider.
 groups/<gid>/state.json      # today's problem (+ posted_at unix ts when card was delivered)
 groups/<gid>/scoreboard.json # cumulative {solves, user_submissions}
 groups/<gid>/daily_msg.json  # forward card payload (msg_id/sample_msg_ids/note_msg_id/snake_msg_id 等, for /problem)
-groups/<gid>/next_problem.json # durable READY prefetch slot; atomically claimed by /newproblem
-groups/<gid>/problem_summaries.json # saved Chinese problem summaries keyed by pid
+groups/<gid>/next_problem.json # source-bound durable READY slot; atomically claimed by /newproblem
+groups/<gid>/problem_summaries.json # verified, source-bound Chinese summaries keyed by pid
 groups/<gid>/used.json       # used problem IDs
 groups/<gid>/groupctx_*.json # group message context
 groups/<gid>/problem_ratings.json # cached problem rating by pid for weighted scoreboard totals
@@ -404,8 +418,10 @@ private_judge/users/<uid>.json # per-user private judge current problem, history
 annotations/pending/<gid>/<pid>.json # pending human-label bundle for solved problems
 annotations/labeled/<gid>/<pid>.json # completed human-label bundle for solved problems
 statements/<pid>.json        # cached problem statements
-tutorials/<pid>.json         # scraped CF editorials (hint/solution/raw_text/code_blocks)
+tutorials/<pid>.json         # verified CF editorial source (never an unverified candidate)
 tutorial_translations/<pid>.txt  # cached Chinese editorial for group cards (per pid)
+tutorial_translations/<pid>.verified # statement+editorial-bound READY marker
+tutorial_translations/<pid>.no_editorial # exhaustive source-bound no-match marker
 sessions/                    # per-user session context
 scheduler_config.json        # job config for CURRENT_GROUP
 ```
@@ -701,14 +717,18 @@ newer AC can silently retarget an older review request.
   (shared cooldown + per-group post lock).
 - Plain `/problem` (or `/pb`) still resends the current problem card.
 
-`/newproblem` uses a per-group post lock. If another `/newproblem` is already preparing a card, the user gets a short "新的题目正在准备中，别急～" reply and the request is not queued. Otherwise the command holds the lock while checking cooldown, checking whether plain `/newproblem` is allowed, and building/sending the card. Cooldown starts only after a new problem card is successfully delivered and committed. The locked implementation:
-1. Reveal yesterday's problem via `picker.py reveal`
-2. Pick a candidate problem via `picker.py pick-json --with-statement`; this marks used
-   problems and caches statements but does **not** write `state.json`
-3. Generate Chinese summary via `summarize_problem()` → `llm.general_model` queue,
-   timeout from `llm.summary_timeout_sec`; after the local format/limit/symbol-scope gate,
-   run the general-model semantic double-check. A mismatch is repaired from structured
-   issues and checked again before the summary can be posted.
+`/newproblem` uses a per-group post lock. If another `/newproblem` is already preparing a card, the user gets a short "新的题目正在准备中，别急～" reply and the request is not queued. Otherwise the command holds the lock while checking cooldown, checking whether plain `/newproblem` is allowed, and claiming/sending the card. Cooldown starts only after a new problem card is successfully delivered and committed. The implementation:
+1. The worker maintains one source-bound `next_problem.json` READY slot. Its complete
+   preparation action runs `picker.py pick-json --with-statement`, builds samples and
+   translated notes, and calls the summary action. The picker marks candidates used and
+   caches statements but does **not** write `state.json`.
+2. The summary action calls `summarize_problem()` through `llm.general_model`, using
+   `llm.summary_timeout_sec`; after the local format/limit/symbol-scope gate it runs the
+   general-model semantic double-check. A mismatch is repaired from structured issues
+   and checked again before the action can return READY. If both outer attempts remain
+   incomplete, the established no-summary publication fallback is retained explicitly.
+3. `/newproblem` claims the READY slot (or awaits that same single-flight preparation on
+   a cold start) and formats the previous-problem reveal from current state.
 4. Self-send summary text; self-send each sample as an independent node; if statement has
    `notes`, translate it to Chinese and append a dedicated `样例解释` node (with LaTeX/Markdown
    artifacts normalized to readable symbols such as `→`, `≤`, `<`, `>`); then append snake
@@ -718,8 +738,11 @@ newer AC can silently retarget an older review request.
    counts as successful delivery and must save `daily_msg.json` with `pid`, `post_msg`,
    `sample_messages`, `notes_message`, and `snake_enabled` so `/problem` can rebuild a
    card later. If delivery fails completely, keep the old current problem.
-6. Save the Chinese summary to `problem_summaries.json` keyed by pid for later reuse
-7. `schedule_prefetch_editorial(pid)` — background editorial translation (not sent yet)
+6. Save a successful Chinese summary to `problem_summaries.json` with its statement
+   fingerprint for later verified reuse.
+7. Release the claimed slot and wake background refill. The worker's READY observer and
+   periodic current/next maintenance own editorial preparation; publication only
+   idempotently reasserts that trigger.
 
 `/newproblem` uses a per-group post lock so two new posts
 do not overlap. They no longer block `/submit`, `/clarify`, or `/review`; those commands
@@ -747,14 +770,14 @@ KOUHAI_CONFIG=/path/to/config.yaml uv run python tools/tutorial_tools.py agent \
 uv run python tools/tutorial_tools.py validate --heuristic-only
 ```
 
-**Runtime** (`src/kouhai_bot/tutorials.py`):
+**Runtime** (`editorial_preparation.py` + `tutorials.py`):
 
 | Function | Purpose |
 |----------|---------|
-| `get_official_editorial(pid)` | Load JSON, extract body (priority: non-placeholder `solution` → `hint` → cleaned `raw_text`; append `code_blocks` for review source only) |
-| `prefetch_editorial_zh(pid)` | Background translate on new problem; `{pid}.no_editorial` if none |
-| `get_editorial_zh_for_group(editorial, pid)` | Disk cache or `translate_editorial_to_zh()` |
-| `has_cached_editorial_zh(pid)` / `is_no_official_editorial(pid)` | Fast paths for delivery |
+| `prepare_editorial(pid)` | Side-effect-free exhaustive search + validation + translation; returns READY / EXHAUSTIVE_NO_MATCH / INCOMPLETE |
+| `prefetch_editorial_zh(pid)` | Commit only a complete result; source → translation → verified marker, or exhaustive no-match marker |
+| `get_verified_official_editorial(pid)` | Return English source only when translation marker matches both editorial and statement fingerprints |
+| `has_cached_editorial_zh(pid)` / `is_no_official_editorial(pid)` | Source-bound terminal checks |
 | `format_editorial_for_review(editorial)` | English block for `/review` LLM user message |
 
 **Group card translation** (`handlers/shared.py:translate_editorial_to_zh`):
@@ -766,20 +789,24 @@ uv run python tools/tutorial_tools.py validate --heuristic-only
 - QQ plain text, no Markdown fences in output
 - Re-translate after prompt changes: delete `tutorial_translations/{pid}.txt`
 
-**Prefetch** (on new problem + active-worker startup):
+**Prefetch** (worker-owned current + next maintenance):
 
-- `/newproblem` calls `schedule_prefetch_editorial(pid)` **immediately after pick** (in parallel
-  with `summarize_problem`, not after it — otherwise first AC waits for summary+translation)
-- `worker.py` bootstraps `schedule_prefetch_for_current_group()` on startup (covers worker restart without new post)
-- Background `prefetch_editorial_zh(pid)` → `tutorial_translations/{pid}.txt` or `{pid}.no_editorial`
+- A newly persisted READY problem invokes the generic READY observer, so worker
+  orchestration starts its editorial immediately without coupling problem preparation
+  to tutorial code.
+- `editorial_prefetch_maintenance_loop()` continuously covers both `state.json.today`
+  and the READY slot; this resumes interrupted work and retries INCOMPLETE results.
+- Background `prefetch_editorial_zh(pid)` writes no candidate or transient-failure
+  marker. It commits only verified source+translation or an exhaustive no-match result.
+- `/newproblem` publication idempotently reasserts the current pid trigger.
 - Runs outside the state scheduler (parallel with submit/review/clarify)
 
 **Delivery** (on first AC, `editorial_followup.py`):
 
 - `schedule_post_solve_editorial_followup()` → if cache warm, deliver immediately (no prefetch wait)
-- Otherwise await in-flight prefetch, then deliver; cache miss logs and translates (~30s)
+- Otherwise await an already in-flight prefetch, then deliver only if it became verified
 - Has cached zh: self-send chunk(s) → `send_group_forward_msg` (low latency)
-- No editorial: silent skip (no group message)
+- No editorial or still incomplete: silent skip (no group message)
 - **Not** part of `GroupCoordinator`; do not `await` inside `_finalize_submit`
 
 ## Annotation Tooling
@@ -791,8 +818,8 @@ Solved problems are exported for human labeling:
 - Exported bundles live under `~/.kouhai-bot/annotations/pending/`
 - Bundles include the statement snapshot, per-round `/submit` verdict data, the exact
   `history_before` seen by the judge, and mutable `human_label` fields
-- If a saved Chinese summary exists in `problem_summaries.json`, annotation export
-  reuses it directly instead of re-translating
+- If a source-bound verified Chinese summary exists in `problem_summaries.json`,
+  annotation export reuses it directly instead of re-translating
 
 Local HTML labeling UI:
 
@@ -942,8 +969,9 @@ Per-user submission history is intentionally unbounded. Records with a `request_
 update the matching existing record in place; records without one append normally.
 
 ### 11. Save Chinese summaries by pid if you need later reuse
-The summary shown in the group post is now persisted in `groups/<gid>/problem_summaries.json`.
-Annotation export and the HTML labeling UI reuse this first before attempting any new
+An audited summary shown in the group post is persisted in
+`groups/<gid>/problem_summaries.json` with its statement fingerprint. Annotation export
+and the HTML labeling UI reuse only a matching verified entry before attempting any new
 translation. Do not force synchronous translation on detail-page clicks.
 
 ### 12. `/newproblem` uses merged-forward
@@ -1111,8 +1139,8 @@ uv run python -m kouhai_bot.worker
 ```
 
 The worker starts the WS server, discovers commands, registers scheduler jobs,
-prefetches the current group's tutorial if needed, and runs the scheduler. No
-external cron or process manager needed.
+maintains one READY next problem plus current/next editorial preparation, and runs the
+scheduler. No external cron or process manager needed.
 
 For an already-managed local instance, prefer:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,9 +65,13 @@ NapCat (QQ) ──WS──> worker.py
   the same single-flight task. A claim prevents refill until publication finishes, then
   release wakes the worker loop. READY-slot validation covers rating-range changes,
   current/solved problems, statement presence, and multimodal availability. Background
-  preparation is not reported by `/status`; only an admitted post is. `/setproblem`
-  and `/setproblem random` intentionally keep their live-fetch behavior and never use
-  this slot.
+  preparation is not reported by `/status`; only an admitted post is. While a slot is
+  READY, the worker also idempotently maintains its full official-editorial prefetch:
+  persisted slots resume crawler + translation work after restart, in-flight work is
+  deduplicated by pid, and completed/no-editorial terminal states stop retries. This
+  editorial maintenance never blocks a `/newproblem` claim. `/setproblem` and
+  `/setproblem random` intentionally keep their live-fetch behavior and never use this
+  slot.
 - **Friend request auto-approval**: Normal OneBot `post_type="request"` / `request_type="friend"` events are parsed by `napcat/client.py`, routed by `handlers.process_event()`, and approved via `set_friend_add_request`. QQ/NapCat "doubtful" friend requests are not reliably pushed as request events, so `worker.py` also runs `friend_requests.doubt_friend_request_loop()`, which polls `get_doubt_friends_add_request` every 60 seconds and approves with `set_doubt_friends_add_request`. Both paths approve only after the requester is confirmed to be a member of `CURRENT_GROUP`; lookup failure, malformed events, non-friend requests, and non-members are ignored without approving. Requests that were already consumed by another QQ client may not appear in the doubtful-request poll.
 - **User groups**: `user_groups.py` — all users default to `default`; `USER_GROUPS` configures
   non-default groups such as `starred`/`打星`, their members, submit delay, and rejection

--- a/src/kouhai_bot/editorial_content.py
+++ b/src/kouhai_bot/editorial_content.py
@@ -1,0 +1,119 @@
+"""Pure models and extraction helpers for normalized official editorials."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+MIN_EDITORIAL_LEN = 80
+
+_PLACEHOLDER_RE = re.compile(
+    r"Tutorial is loading|Will be added soon",
+    re.I,
+)
+_SHORT_SOLUTION_RE = re.compile(r"^.+solution$", re.I | re.S)
+_SECTION_MARKER_RE = re.compile(
+    r"Hint(?:\s*\d+)?|Solution(?:\s+with[\s\S]*)?|Solution\s*\([^)]*\)"
+    r"|Tutorial|Editorial|Code(?:\s*\([^)]+\))?",
+    re.I,
+)
+_AUTHOR_LINE_RE = re.compile(r"^authors?\s*&\s*preparation", re.I)
+
+
+@dataclass(frozen=True)
+class OfficialEditorial:
+    text: str
+    tutorial_url: str
+    tutorial_title: str
+
+
+def is_placeholder(text: str) -> bool:
+    stripped = text.strip()
+    if not stripped:
+        return True
+    if _PLACEHOLDER_RE.search(stripped):
+        return True
+    if len(stripped) < 60 and _SHORT_SOLUTION_RE.fullmatch(stripped):
+        return True
+    return False
+
+
+def _is_section_marker(line: str) -> bool:
+    token = line.strip().strip("*").strip()
+    return bool(_SECTION_MARKER_RE.fullmatch(token))
+
+
+def _clean_raw_text(raw_text: str) -> str:
+    lines = raw_text.splitlines()
+    out: list[str] = []
+    for line in lines:
+        token = line.strip()
+        if not out and (
+            _AUTHOR_LINE_RE.match(token)
+            or token.lower() == "editorial"
+        ):
+            continue
+        if _is_section_marker(token):
+            continue
+        out.append(line)
+    return "\n".join(out).strip()
+
+
+def _append_code_blocks(body: str, code_blocks: list[str]) -> str:
+    codes = [code.strip() for code in code_blocks if code and code.strip()]
+    if not codes:
+        return body
+    code_part = "\n\n".join(f"```\n{code}\n```" for code in codes)
+    return f"{body}\n\n{code_part}".strip() if body else code_part
+
+
+def extract_editorial(section: dict) -> str:
+    """Extract editorial body from one normalized tutorial section."""
+    hint = (section.get("hint") or "").strip()
+    solution = (section.get("solution") or "").strip()
+    raw_text = (section.get("raw_text") or "").strip()
+    code_blocks = section.get("code_blocks") or []
+
+    body = ""
+    if solution and not is_placeholder(solution):
+        body = solution
+    elif hint and not is_placeholder(hint):
+        body = hint
+    elif raw_text:
+        body = _clean_raw_text(raw_text)
+        if is_placeholder(body):
+            body = ""
+    return _append_code_blocks(body, code_blocks)
+
+
+def editorial_from_bundle(bundle: object) -> OfficialEditorial | None:
+    if not isinstance(bundle, dict):
+        return None
+    sections = bundle.get("sections") or []
+    if not sections or not isinstance(sections[0], dict):
+        return None
+    text = extract_editorial(sections[0])
+    if len(text) < MIN_EDITORIAL_LEN:
+        return None
+    return OfficialEditorial(
+        text=text,
+        tutorial_url=(bundle.get("tutorial_url") or "").strip(),
+        tutorial_title=(bundle.get("tutorial_title") or "").strip(),
+    )
+
+
+def bundle_for_editorial(editorial: OfficialEditorial) -> dict[str, Any]:
+    """Build a normalized bundle for an externally supplied candidate."""
+    return {
+        "tutorial_url": editorial.tutorial_url,
+        "tutorial_title": editorial.tutorial_title,
+        "sections": [
+            {
+                "hint": "",
+                "solution": editorial.text,
+                "raw_text": editorial.text,
+                "code_blocks": [],
+            }
+        ],
+    }

--- a/src/kouhai_bot/editorial_followup.py
+++ b/src/kouhai_bot/editorial_followup.py
@@ -25,7 +25,6 @@ from .tutorials import (
     has_cached_editorial_zh,
     is_no_official_editorial,
     load_cached_editorial_zh,
-    mark_no_official_editorial,
     prefetch_editorial_zh,
 )
 
@@ -104,7 +103,7 @@ def ensure_editorial_prefetch(pid: str) -> None:
 
 
 def schedule_prefetch_for_group_today(group_id: int) -> None:
-    """Prefetch editorial for the group's current problem (e.g. on bot startup)."""
+    """Resume full editorial prefetch for the current problem on bot startup."""
     state_path = os.path.join(get_config().data_dir, "groups", str(group_id), "state.json")
     if not os.path.isfile(state_path):
         return
@@ -115,7 +114,7 @@ def schedule_prefetch_for_group_today(group_id: int) -> None:
         return
     pid = str(state.get("today", "") or "").strip()
     if pid:
-        schedule_prefetch_editorial(pid, run_agent=False)
+        ensure_editorial_prefetch(pid)
 
 
 def schedule_prefetch_for_current_group() -> None:
@@ -209,10 +208,8 @@ async def run_post_solve_editorial_followup(group_id: int, pid: str) -> None:
             return
         editorial = get_official_editorial(pid)
         if not editorial:
-            if not has_cached_editorial_zh(pid):
-                mark_no_official_editorial(pid)
             logger.info(
-                "[group_%s] no official editorial for %s, skipping delivery",
+                "[group_%s] editorial for %s remains incomplete, skipping delivery",
                 group_id,
                 pid,
             )

--- a/src/kouhai_bot/editorial_followup.py
+++ b/src/kouhai_bot/editorial_followup.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import time
+from collections.abc import Awaitable, Callable
 
 from .config import get_config
 from .napcat.client import (
@@ -20,8 +21,7 @@ from .napcat.client import (
 from .tutorials import (
     MIN_EDITORIAL_LEN,
     OfficialEditorial,
-    get_editorial_zh_for_group,
-    get_official_editorial,
+    get_verified_official_editorial,
     has_cached_editorial_zh,
     is_no_official_editorial,
     load_cached_editorial_zh,
@@ -48,14 +48,10 @@ def _chunk_text(text: str, chunk_size: int) -> list[str]:
     return [text[i:i + chunk_size] for i in range(0, len(text), chunk_size)] or [""]
 
 
-def _prefetch_needed(pid: str, *, run_agent: bool) -> bool:
+def _prefetch_needed(pid: str) -> bool:
     if has_cached_editorial_zh(pid):
         return False
-    if (
-        is_no_official_editorial(pid)
-        and not run_agent
-        and get_official_editorial(pid) is None
-    ):
+    if is_no_official_editorial(pid):
         return False
     return True
 
@@ -63,7 +59,7 @@ def _prefetch_needed(pid: str, *, run_agent: bool) -> bool:
 def schedule_prefetch_editorial(pid: str, *, run_agent: bool = True) -> None:
     """Start translating editorial when a new problem is set."""
     pid = (pid or "").strip()
-    if not pid or not _prefetch_needed(pid, run_agent=run_agent):
+    if not pid or not _prefetch_needed(pid):
         return
     existing = _prefetch_tasks.get(pid)
     if existing is not None and not existing.done():
@@ -102,17 +98,23 @@ def ensure_editorial_prefetch(pid: str) -> None:
     schedule_prefetch_editorial(pid, run_agent=True)
 
 
-def schedule_prefetch_for_group_today(group_id: int) -> None:
-    """Resume full editorial prefetch for the current problem on bot startup."""
+def _load_group_today_pid(group_id: int) -> str:
     state_path = os.path.join(get_config().data_dir, "groups", str(group_id), "state.json")
     if not os.path.isfile(state_path):
-        return
+        return ""
     try:
         with open(state_path, encoding="utf-8") as f:
             state = json.load(f)
     except (OSError, json.JSONDecodeError):
-        return
-    pid = str(state.get("today", "") or "").strip()
+        return ""
+    if not isinstance(state, dict):
+        return ""
+    return str(state.get("today", "") or "").strip()
+
+
+def schedule_prefetch_for_group_today(group_id: int) -> None:
+    """Resume full editorial prefetch for the current problem."""
+    pid = _load_group_today_pid(group_id)
     if pid:
         ensure_editorial_prefetch(pid)
 
@@ -121,6 +123,39 @@ def schedule_prefetch_for_current_group() -> None:
     cfg = get_config()
     if cfg.current_group:
         schedule_prefetch_for_group_today(cfg.current_group)
+
+
+async def editorial_prefetch_maintenance_loop(
+    group_id: int,
+    *,
+    get_next_problem_pid: Callable[[], Awaitable[str]],
+    stop_event: asyncio.Event,
+    interval_seconds: float = 60.0,
+) -> None:
+    """Continuously maintain editorial work for both current and READY problems."""
+    logger.info("[group_%s] editorial prefetch maintenance started", group_id)
+    while not stop_event.is_set():
+        try:
+            current_pid = _load_group_today_pid(group_id)
+            next_pid = (await get_next_problem_pid()).strip()
+            for pid in dict.fromkeys([current_pid, next_pid]):
+                if pid:
+                    ensure_editorial_prefetch(pid)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "[group_%s] editorial prefetch maintenance failed: %s",
+                group_id,
+                exc,
+                exc_info=True,
+            )
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)
+        except asyncio.TimeoutError:
+            continue
+    logger.info("[group_%s] editorial prefetch maintenance stopped", group_id)
 
 
 async def _run_prefetch_editorial(pid: str, *, run_agent: bool) -> None:
@@ -148,6 +183,7 @@ async def _run_prefetch_editorial(pid: str, *, run_agent: bool) -> None:
 
 
 async def _await_prefetch_if_running(pid: str) -> None:
+    """Wait for the shared preparation task when one is already in flight."""
     task = _prefetch_tasks.get(pid)
     if task is None or task.done():
         return
@@ -179,24 +215,23 @@ def schedule_post_solve_editorial_followup(group_id: int, pid: str) -> None:
 async def run_post_solve_editorial_followup(group_id: int, pid: str) -> None:
     started = time.monotonic()
     try:
-        if has_cached_editorial_zh(pid):
-            editorial = get_official_editorial(pid)
-            if editorial:
-                await deliver_official_tutorial_forward(group_id, pid, editorial)
-                logger.info(
-                    "[group_%s] editorial delivered from cache for %s in %.1fs",
-                    group_id,
-                    pid,
-                    time.monotonic() - started,
-                )
-                return
-            if is_no_official_editorial(pid):
-                logger.info(
-                    "[group_%s] no official editorial for %s, skipping delivery",
-                    group_id,
-                    pid,
-                )
-                return
+        editorial = get_verified_official_editorial(pid)
+        if editorial:
+            await deliver_official_tutorial_forward(group_id, pid, editorial)
+            logger.info(
+                "[group_%s] editorial delivered from cache for %s in %.1fs",
+                group_id,
+                pid,
+                time.monotonic() - started,
+            )
+            return
+        if is_no_official_editorial(pid):
+            logger.info(
+                "[group_%s] no official editorial for %s, skipping delivery",
+                group_id,
+                pid,
+            )
+            return
 
         await _await_prefetch_if_running(pid)
         if is_no_official_editorial(pid):
@@ -206,7 +241,7 @@ async def run_post_solve_editorial_followup(group_id: int, pid: str) -> None:
                 pid,
             )
             return
-        editorial = get_official_editorial(pid)
+        editorial = get_verified_official_editorial(pid)
         if not editorial:
             logger.info(
                 "[group_%s] editorial for %s remains incomplete, skipping delivery",
@@ -236,19 +271,20 @@ async def deliver_official_tutorial_forward(
     pid: str,
     editorial: OfficialEditorial,
 ) -> None:
-    """Send cached Chinese editorial; translate only if prefetch did not finish."""
-    zh_text = load_cached_editorial_zh(pid)
-    if len(zh_text) < MIN_EDITORIAL_LEN:
-        logger.info(
-            "[group_%s] editorial cache miss for %s, translating on delivery",
+    """Deliver one already verified and cached Chinese editorial."""
+    verified_editorial = get_verified_official_editorial(pid)
+    if verified_editorial is None:
+        logger.warning(
+            "[group_%s] refused unverified tutorial delivery for %s",
             group_id,
             pid,
         )
-        zh_text, _model_tag = await get_editorial_zh_for_group(editorial, pid)
-        zh_text = zh_text or ""
+        return
+    editorial = verified_editorial
+    zh_text = load_cached_editorial_zh(pid)
     if len(zh_text) < MIN_EDITORIAL_LEN:
         logger.warning(
-            "[group_%s] official tutorial translation unavailable for %s",
+            "[group_%s] verified tutorial translation missing for %s",
             group_id,
             pid,
         )

--- a/src/kouhai_bot/editorial_followup.py
+++ b/src/kouhai_bot/editorial_followup.py
@@ -84,6 +84,25 @@ def schedule_prefetch_editorial(pid: str, *, run_agent: bool = True) -> None:
     task.add_done_callback(_drop)
 
 
+def ensure_editorial_prefetch(pid: str) -> None:
+    """Keep full editorial prefetch active for an unpublished READY problem.
+
+    This entry point is safe to call from a maintenance loop: an in-flight task
+    is deduplicated by ``schedule_prefetch_editorial``, while a verified cache
+    or a confirmed no-editorial marker is treated as terminal.  If a task dies
+    before reaching either terminal state, the next maintenance pass retries
+    the complete crawler + translation pipeline.
+    """
+    pid = (pid or "").strip()
+    if (
+        not pid
+        or has_cached_editorial_zh(pid)
+        or is_no_official_editorial(pid)
+    ):
+        return
+    schedule_prefetch_editorial(pid, run_agent=True)
+
+
 def schedule_prefetch_for_group_today(group_id: int) -> None:
     """Prefetch editorial for the group's current problem (e.g. on bot startup)."""
     state_path = os.path.join(get_config().data_dir, "groups", str(group_id), "state.json")

--- a/src/kouhai_bot/editorial_preparation.py
+++ b/src/kouhai_bot/editorial_preparation.py
@@ -1,0 +1,321 @@
+"""Complete, side-effect-free preparation of one verified official editorial.
+
+This module owns the whole remote/LLM action: discover candidate Codeforces
+blogs, reject mismatched candidates, validate the source against the statement,
+and translate the first verified match.  It never writes tutorial/cache status.
+Callers commit only a ``READY`` result.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from .config import get_config
+from .editorial_content import (
+    MIN_EDITORIAL_LEN,
+    OfficialEditorial,
+    editorial_from_bundle,
+)
+from .handlers.shared import translate_editorial_to_zh
+from .problem_content import (
+    format_problem_statement_for_llm,
+    load_statement_json,
+    statement_fingerprint,
+    statement_images,
+)
+
+logger = logging.getLogger("kouhai-bot.editorial_preparation")
+
+
+class EditorialPreparationStatus(str, Enum):
+    READY = "ready"
+    EXHAUSTIVE_NO_MATCH = "exhaustive_no_match"
+    INCOMPLETE = "incomplete"
+
+
+@dataclass(frozen=True)
+class PreparedEditorial:
+    bundle: dict[str, Any]
+    editorial: OfficialEditorial
+    translated_text: str
+    statement_sha256: str
+
+
+@dataclass(frozen=True)
+class EditorialPreparationResult:
+    status: EditorialPreparationStatus
+    prepared: PreparedEditorial | None = None
+    reason: str = ""
+    rejected_initial_candidate: bool = False
+    statement_sha256: str = ""
+
+
+@dataclass(frozen=True)
+class _TutorialSearch:
+    outcome: str
+    result: Any | None = None
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class _StatementContext:
+    text: str
+    images: list[dict]
+    source_sha256: str
+
+
+def _load_statement_context(
+    pid: str,
+    *,
+    data_dir: str | Path,
+) -> _StatementContext | None:
+    statement = load_statement_json(pid, data_dir=data_dir)
+    source_sha256 = statement_fingerprint(statement)
+    if not source_sha256:
+        return None
+    return _StatementContext(
+        text=format_problem_statement_for_llm(statement),
+        images=statement_images(statement),
+        source_sha256=source_sha256,
+    )
+
+
+def _tools_dir() -> Path:
+    return Path(__file__).resolve().parents[2] / "tools"
+
+
+def _load_tutorial_agent() -> tuple[
+    type[Exception],
+    type[Exception],
+    type[Exception],
+    Any,
+]:
+    tools_dir = _tools_dir()
+    if tools_dir.is_dir():
+        tools_dir_str = str(tools_dir)
+        if tools_dir_str not in sys.path:
+            sys.path.insert(0, tools_dir_str)
+
+    from cf_tutorial_agent import AgentIncomplete, AgentNoMatch, run_agent_for_pid
+    from scrape_cf_tutorial import ScrapeError
+
+    return AgentNoMatch, AgentIncomplete, ScrapeError, run_agent_for_pid
+
+
+async def _search_tutorial(
+    pid: str,
+    *,
+    data_dir: str | Path,
+    excluded_tutorial_urls: frozenset[str],
+) -> _TutorialSearch:
+    statements_dir = Path(data_dir) / "statements"
+    statement_path = statements_dir / f"{pid}.json"
+    if not statement_path.is_file():
+        return _TutorialSearch("incomplete", reason="statement_cache_missing")
+
+    try:
+        (
+            AgentNoMatch,
+            AgentIncomplete,
+            ScrapeError,
+            run_agent_for_pid,
+        ) = _load_tutorial_agent()
+    except Exception as exc:
+        logger.warning(
+            "tutorial agent unavailable for %s: %s",
+            pid,
+            exc,
+            exc_info=True,
+        )
+        return _TutorialSearch("incomplete", reason=f"agent_unavailable:{exc}")
+
+    try:
+        result = await run_agent_for_pid(
+            pid=pid,
+            statements_dir=statements_dir,
+            # A terminal "no match" marker is only valid after every linked
+            # candidate has been examined. Timeouts remain retryable incomplete
+            # work, so the outer lifecycle can safely try again later.
+            blog_limit=0,
+            excluded_tutorial_urls=excluded_tutorial_urls,
+        )
+    except AgentNoMatch as exc:
+        return _TutorialSearch("no_match", reason=str(exc))
+    except AgentIncomplete as exc:
+        return _TutorialSearch("incomplete", reason=str(exc))
+    except ScrapeError as exc:
+        return _TutorialSearch("incomplete", reason=str(exc))
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "tutorial agent failed for %s: %s",
+            pid,
+            exc,
+            exc_info=True,
+        )
+        return _TutorialSearch("incomplete", reason=str(exc))
+    return _TutorialSearch("candidate", result=result)
+
+
+async def _validate_and_translate(
+    pid: str,
+    editorial: OfficialEditorial,
+    *,
+    statement: _StatementContext,
+) -> tuple[str | None, bool | None]:
+    translated, model_tag, matched = await translate_editorial_to_zh(
+        editorial.text,
+        pid=pid,
+        problem_text=statement.text,
+        images=statement.images,
+    )
+    if matched is False:
+        return None, False
+    if matched is not True or not translated:
+        return None, None
+    translated = translated.strip()
+    if len(translated) < MIN_EDITORIAL_LEN:
+        return None, None
+    full_text = (translated + model_tag).strip() if model_tag else translated
+    return full_text, True
+
+
+async def prepare_editorial(
+    pid: str,
+    *,
+    initial_bundle: dict[str, Any] | None = None,
+    run_agent: bool = True,
+    data_dir: str | Path | None = None,
+) -> EditorialPreparationResult:
+    """Return a verified editorial result without mutating persistent state."""
+    pid = (pid or "").strip()
+    if not pid:
+        return EditorialPreparationResult(
+            EditorialPreparationStatus.INCOMPLETE,
+            reason="empty_pid",
+        )
+    resolved_data_dir = (
+        Path(data_dir) if data_dir is not None else Path(get_config().data_dir)
+    )
+    statement = _load_statement_context(pid, data_dir=resolved_data_dir)
+    if statement is None:
+        return EditorialPreparationResult(
+            EditorialPreparationStatus.INCOMPLETE,
+            reason="statement_cache_missing",
+        )
+
+    rejected_urls: set[str] = set()
+    rejected_initial = False
+    if initial_bundle is not None:
+        initial = editorial_from_bundle(initial_bundle)
+        if initial is None:
+            rejected_initial = True
+        else:
+            translated, matched = await _validate_and_translate(
+                pid,
+                initial,
+                statement=statement,
+            )
+            if matched is True and translated:
+                return EditorialPreparationResult(
+                    EditorialPreparationStatus.READY,
+                    prepared=PreparedEditorial(
+                        bundle=initial_bundle,
+                        editorial=initial,
+                        translated_text=translated,
+                        statement_sha256=statement.source_sha256,
+                    ),
+                    statement_sha256=statement.source_sha256,
+                )
+            if matched is None:
+                return EditorialPreparationResult(
+                    EditorialPreparationStatus.INCOMPLETE,
+                    reason="initial_candidate_validation_incomplete",
+                    statement_sha256=statement.source_sha256,
+                )
+            rejected_initial = True
+            if initial.tutorial_url:
+                rejected_urls.add(initial.tutorial_url)
+
+    if not run_agent:
+        return EditorialPreparationResult(
+            EditorialPreparationStatus.INCOMPLETE,
+            reason="agent_disabled",
+            rejected_initial_candidate=rejected_initial,
+            statement_sha256=statement.source_sha256,
+        )
+
+    while True:
+        search = await _search_tutorial(
+            pid,
+            data_dir=resolved_data_dir,
+            excluded_tutorial_urls=frozenset(rejected_urls),
+        )
+        if search.outcome == "incomplete":
+            return EditorialPreparationResult(
+                EditorialPreparationStatus.INCOMPLETE,
+                reason=search.reason,
+                rejected_initial_candidate=rejected_initial,
+                statement_sha256=statement.source_sha256,
+            )
+        if search.outcome == "no_match":
+            return EditorialPreparationResult(
+                EditorialPreparationStatus.EXHAUSTIVE_NO_MATCH,
+                reason=search.reason,
+                rejected_initial_candidate=rejected_initial,
+                statement_sha256=statement.source_sha256,
+            )
+
+        result = search.result
+        bundle = getattr(result, "bundle", None)
+        candidate = editorial_from_bundle(bundle)
+        if candidate is None:
+            return EditorialPreparationResult(
+                EditorialPreparationStatus.INCOMPLETE,
+                reason="agent_returned_unusable_candidate",
+                rejected_initial_candidate=rejected_initial,
+                statement_sha256=statement.source_sha256,
+            )
+        candidate_url = candidate.tutorial_url
+        if not candidate_url or candidate_url in rejected_urls:
+            return EditorialPreparationResult(
+                EditorialPreparationStatus.INCOMPLETE,
+                reason="agent_returned_non_unique_candidate",
+                rejected_initial_candidate=rejected_initial,
+                statement_sha256=statement.source_sha256,
+            )
+
+        translated, matched = await _validate_and_translate(
+            pid,
+            candidate,
+            statement=statement,
+        )
+        if matched is None:
+            return EditorialPreparationResult(
+                EditorialPreparationStatus.INCOMPLETE,
+                reason="candidate_validation_incomplete",
+                rejected_initial_candidate=rejected_initial,
+                statement_sha256=statement.source_sha256,
+            )
+        if matched is False:
+            rejected_urls.add(candidate_url)
+            continue
+
+        return EditorialPreparationResult(
+            EditorialPreparationStatus.READY,
+            prepared=PreparedEditorial(
+                bundle=bundle,
+                editorial=candidate,
+                translated_text=translated or "",
+                statement_sha256=statement.source_sha256,
+            ),
+            rejected_initial_candidate=rejected_initial,
+            statement_sha256=statement.source_sha256,
+        )

--- a/src/kouhai_bot/handlers/cmd/newproblem.py
+++ b/src/kouhai_bot/handlers/cmd/newproblem.py
@@ -6,8 +6,9 @@ import asyncio
 import json
 import logging
 import os
-import sys
 import time
+from contextlib import suppress
+from datetime import datetime, timedelta, timezone
 
 from .. import registry
 from ..registry import CommandDef
@@ -19,16 +20,11 @@ from ..shared import (
     save_problem_card_ref,
     save_problem_summary,
     save_scoreboard,
-    statement_images,
     snake_replace,
-    summarize_problem,
-    translate_sample_notes,
 )
 from ...config import get_config
 from ...context import append_group_ctx
 from ...editorial_followup import schedule_prefetch_editorial
-from ...llm import strip_leaked_thinking
-from ...user_groups import settle_dynamic_submit_wait_for_problem
 from ...napcat.client import (
     build_plain_message,
     react_emoji,
@@ -36,10 +32,17 @@ from ...napcat.client import (
     send_group_forward_msg,
     send_private_msg,
 )
-from ...problems.picker import _normalize_sample_block
+from ...problem_prefetch import get_next_problem_prefetcher
+from ...problem_preparation import (
+    PICKER_PATH,
+    ProblemPreparationError,
+    format_previous_problem_reveal,
+)
+from ...user_groups import settle_dynamic_submit_wait_for_problem
 from .submit import run_group_state_update
 
 logger = logging.getLogger("kouhai-bot.cmd.newproblem")
+TZ = timezone(timedelta(hours=8))
 
 # ── Cooldown ────────────────────────────────────────────────────────────
 
@@ -138,71 +141,6 @@ async def enqueue_new_problem(
     finally:
         lock.release()
 
-# ── Picker path ─────────────────────────────────────────────────────────
-
-_PICKER_PATH = os.path.join(
-    os.path.dirname(__file__), "..", "..", "..", "kouhai_bot", "problems", "picker.py",
-)
-_PICKER_PATH = os.path.abspath(os.path.normpath(_PICKER_PATH))
-_STATEMENTS_FALLBACK_DIR = os.path.expanduser("~/.kouhai-bot/statements")
-
-
-def _effective_rating_range(group_id: int) -> tuple[int, int]:
-    cfg = get_config()
-    min_rating = int(cfg.min_rating)
-    max_rating = int(cfg.max_rating)
-    try:
-        from ...scheduler.engine import load_group_configs
-
-        group_cfg = load_group_configs().get(group_id)
-        if group_cfg:
-            if group_cfg.min_rating is not None:
-                min_rating = int(group_cfg.min_rating)
-            if group_cfg.max_rating is not None:
-                max_rating = int(group_cfg.max_rating)
-    except Exception:
-        logger.warning(
-            f"[group_{group_id}] Failed to load scheduler rating overrides; using config range",
-            exc_info=True,
-        )
-    return min_rating, max_rating
-
-
-def _picker_args(command: str, group_id: int, *extra: str) -> list[str]:
-    min_rating, max_rating = _effective_rating_range(group_id)
-    args = [
-        _PICKER_PATH,
-        command,
-        "--group",
-        str(group_id),
-        "--data-dir",
-        str(get_config().data_dir),
-        "--min-rating",
-        str(min_rating),
-        "--max-rating",
-        str(max_rating),
-    ]
-    args.extend(extra)
-    return args
-
-
-def _classify_pick_error(stderr_text: str) -> str:
-    """Classify picker stderr into a user-friendly Chinese message."""
-    lower = stderr_text.lower()
-    # CF-specific connectivity issues
-    if any(kw in stderr_text for kw in (
-        "codeforces.com", "SSL", "SSLEOFError", "SSLError",
-        "ConnectionError", "Max retries exceeded", "RemoteDisconnected",
-    )):
-        return "Codeforces 连接失败"
-    if any(kw in lower for kw in ("timeout", "timed out")):
-        return "Codeforces 请求超时"
-    if any(kw in lower for kw in ("permission", "access denied", "ioerror", "filenotfound")):
-        return "本地数据读取异常"
-    # fallback — still log the raw text above
-    return "题目选取失败，稍后再试"
-
-
 def _newproblem_lock(group_id: int) -> asyncio.Lock:
     lock = _newproblem_locks.get(group_id)
     if lock is None:
@@ -264,66 +202,6 @@ def _save_daily_msg(
         json.dump(daily_msg, f, ensure_ascii=False, indent=2)
 
 
-def _load_statement_json(cfg, group_id: int, pid: str) -> dict:
-    """Load statement JSON from runtime dir, then fallback dir."""
-    candidate_paths = [
-        os.path.join(cfg.data_dir, "statements", f"{pid}.json"),
-        os.path.join(_STATEMENTS_FALLBACK_DIR, f"{pid}.json"),
-    ]
-    for path in candidate_paths:
-        if not os.path.exists(path):
-            continue
-        try:
-            with open(path) as f:
-                stmt = json.load(f)
-            if isinstance(stmt, dict):
-                return stmt
-            logger.warning(f"[group_{group_id}] Statement at {path} is not a dict")
-        except Exception as e:
-            logger.warning(f"[group_{group_id}] Failed to load statement {path}: {e}")
-    return {}
-
-
-def _build_sample_messages(stmt: dict) -> list[str]:
-    """Build one message per sample."""
-    samples = stmt.get("samples")
-    if not isinstance(samples, list):
-        return []
-    lines: list[str] = []
-    for idx, sample in enumerate(samples, 1):
-        if not isinstance(sample, dict):
-            continue
-        sample_input = sample.get("input")
-        sample_output = sample.get("output")
-        if sample_input is None and sample_output is None:
-            continue
-        normalized_input = _normalize_sample_block(sample_input).rstrip("\n")
-        normalized_output = _normalize_sample_block(sample_output).rstrip("\n")
-        text = (
-            f"样例 {idx}\n"
-            f"Input:\n{normalized_input}\n\n"
-            f"Output:\n{normalized_output}"
-        )
-        lines.append(text)
-    return lines
-
-
-async def _build_notes_message(stmt: dict) -> str:
-    raw_notes = stmt.get("notes")
-    normalized_notes = _normalize_sample_block(raw_notes)
-    if not normalized_notes:
-        return ""
-    try:
-        translated_notes, _model_tag = await translate_sample_notes(normalized_notes, statement_images(stmt))
-    except Exception as e:
-        logger.warning("Notes translation failed, skipping notes node: %s", e)
-        return ""
-    final_notes = strip_leaked_thinking(translated_notes or normalized_notes)
-    if not final_notes:
-        return ""
-    return f"样例解释：\n{final_notes}"
-
-
 async def _send_problem_forward_card(
     group_id: int,
     post_msg: str,
@@ -338,7 +216,7 @@ async def _send_problem_forward_card(
 
     snake_msg_id = None
     if snake_enabled:
-        snake_path = os.path.join(os.path.dirname(_PICKER_PATH), "snake_trio.jpg")
+        snake_path = str(PICKER_PATH.parent / "snake_trio.jpg")
         if os.path.exists(snake_path):
             try:
                 import base64
@@ -392,127 +270,80 @@ async def _post_new_problem_locked(
     group_id: int, prefix: str | None = None, *, notify_group: bool = False,
 ) -> bool:
     cfg = get_config()
-    python = sys.executable
     state_dir = os.path.join(cfg.data_dir, "groups", str(group_id))
     os.makedirs(state_dir, exist_ok=True)
-
-    # Step 1: Reveal yesterday's problem
-    reveal_text = ""
+    prefetcher = get_next_problem_prefetcher(group_id)
     try:
-        proc = await asyncio.create_subprocess_exec(
-            python, *_picker_args("reveal", group_id),
-            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
-        if proc.returncode == 0:
-            reveal_text = stdout.decode().strip()
-    except Exception as e:
-        logger.error(f"Reveal error (group {group_id}): {e}")
-
-    # Step 2: Pick today's problem (w/ retry)
-    picked_state: dict = {}
-    pick_error_msg = ""
-    for attempt in range(1, 4):
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                python, *_picker_args("pick-json", group_id, "--with-statement"),
-                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
-            )
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
-            if proc.returncode != 0:
-                err_text = stderr.decode()[:200]
-                logger.error(
-                    f"Pick failed (group {group_id}, attempt {attempt}/3): {err_text}"
-                )
-                pick_error_msg = _classify_pick_error(err_text)
-            else:
-                picked_state = json.loads(stdout.decode())
-                if not isinstance(picked_state, dict):
-                    logger.error(
-                        f"Pick failed (group {group_id}, attempt {attempt}/3): "
-                        f"invalid picker payload"
-                    )
-                    pick_error_msg = "题目选取结果异常"
-                    picked_state = {}  # reset to ensure truthiness check catches it
-                else:
-                    break  # success
-        except Exception as e:
-            logger.error(
-                f"Pick error (group {group_id}, attempt {attempt}/3): {e}"
-            )
-            pick_error_msg = f"Codeforces 连接失败"
-        if attempt < 3:
-            delay = 2 * attempt
-            logger.info(f"Retrying pick in {delay}s...")
-            await asyncio.sleep(delay)
-
-    if not picked_state:
+        slot = await prefetcher.claim()
+    except ProblemPreparationError as exc:
         if notify_group:
             await send_group_msg(group_id, build_plain_message(
-                f"刷题失败了…{pick_error_msg}，连试 3 次都没成功，等一会儿再试试吧😢"
+                f"刷题失败了…{exc.user_message}，连试 3 次都没成功，等一会儿再试试吧😢"
             ))
         return False
 
-    # Step 3: Generate Chinese summary
-    desc = ""
-    model_tag = ""
-    pid = str(picked_state.get("today", "") or "")
-    sample_messages: list[str] = []
-    notes_message = ""
     try:
-        if pid:
+        prepared = slot.problem
+        picked_state = dict(prepared.state)
+        picked_state["date"] = datetime.now(TZ).strftime("%Y-%m-%d")
+        pid = prepared.pid
+        desc = prepared.summary
+        model_tag = prepared.model_tag
+        sample_messages = list(prepared.sample_messages)
+        notes_message = prepared.notes_message
+        reveal_text = format_previous_problem_reveal(get_today_problem(group_id))
+
+        # Preserve the original publication-time trigger.  Normally this
+        # deduplicates against preparation; after a process restart it resumes
+        # a crawler that may have died while the durable slot survived.
+        try:
             schedule_prefetch_editorial(pid)
+        except Exception as exc:
+            logger.warning(
+                "[group_%s] Failed to schedule editorial prefetch for %s: %s",
+                group_id,
+                pid,
+                exc,
+            )
 
-        stmt: dict = {}
-        stmt_text = ""
-        input_text = ""
-        limits_text = ""
-        if pid:
-            stmt = _load_statement_json(cfg, group_id, pid)
-        if stmt:
-            stmt_text = stmt.get("description", "") or ""
-            input_text = stmt.get("input", "") or ""
-            tl = stmt.get("time_limit", "?")
-            ml = stmt.get("memory_limit", "?")
-            limits_text = f"Time: {tl}, Memory: {ml}"
-            sample_messages = _build_sample_messages(stmt)
-            notes_message = await _build_notes_message(stmt)
+        if desc:
+            try:
+                save_problem_summary(group_id, pid, desc)
+            except Exception as exc:
+                # Summary persistence was best-effort in the original path;
+                # a cache write must not prevent an otherwise ready card.
+                logger.warning(
+                    "[group_%s] Failed to save problem summary for %s: %s",
+                    group_id,
+                    pid,
+                    exc,
+                )
 
-        images = statement_images(stmt)
-        summary, model_tag = await summarize_problem(stmt_text, input_text, limits_text, images)
-        if not summary:
-            logger.warning(f"[group_{group_id}] Summary 1st attempt failed, retrying...")
-            summary, model_tag = await summarize_problem(stmt_text, input_text, limits_text, images)
-        if summary:
-            desc = summary.strip()
-            save_problem_summary(group_id, pid, desc)
-        else:
-            logger.warning(f"[group_{group_id}] Summary failed after retry")
-    except Exception as e:
-        logger.warning(f"[group_{group_id}] Summary error: {e}")
+        greeting = prefix if prefix else "来看看这道新题吧！"
+        post_msg = f"{greeting}\n\n{desc}" if desc else greeting
+        if model_tag:
+            post_msg += model_tag
+        if reveal_text and "还没有发过题哦" not in reveal_text:
+            post_msg += "\n\n" + reveal_text
+        post_msg = snake_replace(post_msg)
 
-    # Step 4: Compose and deliver via merged-forward card
-    greeting = prefix if prefix else "来看看这道新题吧！"
-    post_msg = f"{greeting}\n\n{desc}" if desc else greeting
-    if model_tag:
-        post_msg += model_tag
+        fwd_resp, node_payload = await _send_problem_forward_card(
+            group_id=group_id,
+            post_msg=post_msg,
+            sample_messages=sample_messages,
+            notes_message=notes_message,
+            snake_enabled=True,
+        )
+        if not fwd_resp:
+            logger.error(
+                "[group_%s] Problem forward-card send failed, falling back to direct",
+                group_id,
+            )
+            ok = await send_group_msg(group_id, build_plain_message(post_msg))
+            if not ok:
+                logger.error("[group_%s] New problem post send failed", group_id)
+                return False
 
-    if reveal_text and "还没有发过题哦" not in reveal_text:
-        post_msg = post_msg + "\n\n" + reveal_text
-
-    post_msg = snake_replace(post_msg)
-
-    fwd_resp, node_payload = await _send_problem_forward_card(
-        group_id=group_id,
-        post_msg=post_msg,
-        sample_messages=sample_messages,
-        notes_message=notes_message,
-        snake_enabled=True,
-    )
-    if not fwd_resp:
-        logger.error(f"[group_{group_id}] Problem forward-card send failed, falling back to direct")
-        ok = await send_group_msg(group_id, build_plain_message(post_msg))
-        if ok:
             await _send_high_difficulty_notice_group(group_id, picked_state)
             await _commit_problem_state(group_id, picked_state)
             try:
@@ -525,38 +356,57 @@ async def _post_new_problem_locked(
                     snake_enabled=True,
                     node_payload=node_payload,
                 )
-            except Exception as e:
-                logger.warning(f"[group_{group_id}] Failed to save fallback daily_msg.json: {e}")
+            except Exception as exc:
+                logger.warning(
+                    "[group_%s] Failed to save fallback daily_msg.json: %s",
+                    group_id,
+                    exc,
+                )
             append_group_ctx(group_id, {"role": "assistant", "content": post_msg})
-            logger.info(f"[group_{group_id}] New problem post sent (fallback) ✓")
+            logger.info("[group_%s] New problem post sent (fallback) ✓", group_id)
             return True
-        else:
-            logger.error(f"[group_{group_id}] New problem post send failed")
-        return False
-    append_group_ctx(group_id, {"role": "assistant", "content": post_msg})
-    logger.info(
-        f"[group_{group_id}] New problem post forwarded ✓ "
-        f"({1 + len(sample_messages) + (1 if node_payload.get('note_msg_id') else 0) + (1 if node_payload.get('snake_msg_id') else 0)} msgs)"
-    )
-    await _commit_problem_state(group_id, picked_state)
-    if pid:
-        save_problem_card_ref(group_id, fwd_resp, pid, "newproblem")
-    await _send_high_difficulty_notice_group(group_id, picked_state)
 
-    try:
-        _save_daily_msg(
-            state_dir,
-            pid=pid,
-            post_msg=post_msg,
-            sample_messages=sample_messages,
-            notes_message=notes_message,
-            snake_enabled=True,
-            node_payload=node_payload,
-            fwd_message_id=fwd_resp,
+        append_group_ctx(group_id, {"role": "assistant", "content": post_msg})
+        logger.info(
+            "[group_%s] New problem post forwarded ✓ (%s msgs)",
+            group_id,
+            1
+            + len(sample_messages)
+            + (1 if node_payload.get("note_msg_id") else 0)
+            + (1 if node_payload.get("snake_msg_id") else 0),
         )
-    except Exception as e:
-        logger.warning(f"[group_{group_id}] Failed to save daily_msg.json: {e}")
-    return True
+        await _commit_problem_state(group_id, picked_state)
+        if pid:
+            save_problem_card_ref(group_id, fwd_resp, pid, "newproblem")
+        await _send_high_difficulty_notice_group(group_id, picked_state)
+
+        try:
+            _save_daily_msg(
+                state_dir,
+                pid=pid,
+                post_msg=post_msg,
+                sample_messages=sample_messages,
+                notes_message=notes_message,
+                snake_enabled=True,
+                node_payload=node_payload,
+                fwd_message_id=fwd_resp,
+            )
+        except Exception as exc:
+            logger.warning(
+                "[group_%s] Failed to save daily_msg.json: %s",
+                group_id,
+                exc,
+            )
+        return True
+    finally:
+        # A cancelled command must not strand the coordinator in CLAIMED.
+        release_task = asyncio.create_task(prefetcher.release(slot.slot_id))
+        try:
+            await asyncio.shield(release_task)
+        except asyncio.CancelledError:
+            with suppress(asyncio.CancelledError):
+                await release_task
+            raise
 
 
 # ── Command handler ─────────────────────────────────────────────────────

--- a/src/kouhai_bot/handlers/cmd/newproblem.py
+++ b/src/kouhai_bot/handlers/cmd/newproblem.py
@@ -308,7 +308,12 @@ async def _post_new_problem_locked(
 
         if desc:
             try:
-                save_problem_summary(group_id, pid, desc)
+                save_problem_summary(
+                    group_id,
+                    pid,
+                    desc,
+                    source_sha256=prepared.statement_sha256,
+                )
             except Exception as exc:
                 # Summary persistence was best-effort in the original path;
                 # a cache write must not prevent an otherwise ready card.

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -75,7 +75,10 @@ from ...private_judge import (
     send_problem_card_private,
     set_private_current_problem,
 )
-from ...tutorials import format_editorial_for_review, get_official_editorial, has_cached_editorial_zh
+from ...tutorials import (
+    format_editorial_for_review,
+    get_verified_official_editorial,
+)
 from ...napcat.client import (
     build_at,
     build_private_reaction_message,
@@ -827,7 +830,7 @@ class GroupCoordinator:
             _log_preview(parsed.get("reason", "")),
         )
         if parsed.get("correct", False) and parsed.get("reaction", "") != "123":
-            editorial = get_official_editorial(pid) if has_cached_editorial_zh(pid) else None
+            editorial = get_verified_official_editorial(pid)
             if editorial:
                 source = "\n".join(
                     part for part in [editorial.tutorial_title, editorial.tutorial_url]
@@ -985,7 +988,7 @@ class GroupCoordinator:
             user_parts.append(
                 "被 @ 群友在此题的上下文：\n" + "\n\n".join(mentioned_parts)
             )
-        editorial = get_official_editorial(pid)
+        editorial = get_verified_official_editorial(pid)
         if editorial:
             user_parts.append(format_editorial_for_review(editorial))
         user_parts.append(f"用户的问题：\n{req.payload}")

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -19,6 +19,12 @@ from pathlib import Path
 
 from ..config import get_config
 from ..llm import ChatCompletionResult, chat_completion, strip_leaked_thinking
+from ..problem_content import (
+    format_problem_statement_for_llm,
+    load_statement_json,
+    statement_fingerprint,
+    statement_images,
+)
 
 logger = logging.getLogger("kouhai-bot.shared")
 
@@ -251,64 +257,12 @@ def multimodal_model_configured() -> bool:
 
 def load_problem_statement_json(pid: str) -> dict:
     """Load raw problem statement cache JSON."""
-    cfg = get_config()
-    stmt_path = os.path.join(cfg.data_dir, "statements", f"{pid}.json")
-    if not os.path.exists(stmt_path):
-        return {}
-
-    try:
-        with open(stmt_path, encoding="utf-8") as f:
-            data = json.load(f)
-    except Exception:
-        return {}
-    return data if isinstance(data, dict) else {}
-
-
-def format_problem_statement_for_llm(stmt: dict) -> str:
-    """Format statement cache JSON as text for LLM context."""
-    if not isinstance(stmt, dict):
-        return ""
-
-    parts = []
-    if stmt.get("name"):
-        parts.append(f"Problem: {stmt['name']}")
-    if stmt.get("time_limit"):
-        parts.append(f"Time limit: {stmt['time_limit']}")
-    if stmt.get("memory_limit"):
-        parts.append(f"Memory limit: {stmt['memory_limit']}")
-
-    desc = stmt.get("description", "")
-    if desc:
-        parts.append(f"\nDescription:\n{desc}")
-
-    inp = stmt.get("input", "")
-    if inp:
-        parts.append(f"\nInput:\n{inp}")
-
-    output = stmt.get("output", "")
-    if output:
-        parts.append(f"\nOutput:\n{output}")
-
-    samples = stmt.get("samples", [])
-    if samples:
-        for s in samples:
-            parts.append(f"\nInput:\n{s['input']}\nOutput:\n{s['output']}")
-
-    notes = stmt.get("notes", "")
-    if notes:
-        parts.append(f"\nNote:\n{notes}")
-
-    return "\n".join(parts)
+    return load_statement_json(pid)
 
 
 def load_problem_statement(pid: str) -> str:
     """Load full problem statement from cache, formatted for LLM."""
     return format_problem_statement_for_llm(load_problem_statement_json(pid))
-
-
-def statement_images(stmt: dict) -> list[dict]:
-    images = stmt.get("images", []) if isinstance(stmt, dict) else []
-    return [item for item in images if isinstance(item, dict) and item.get("src")]
 
 
 def _download_image_data_url(url: str) -> str:
@@ -436,6 +390,9 @@ async def _multimodal_content_or_text(text: str, images: list[dict]) -> str | li
 
 # ── Today's problem ─────────────────────────────────────────────────────
 
+PROBLEM_SUMMARY_FORMAT_VERSION = 2
+
+
 def _today_state_file(group_id: int) -> str:
     cfg = get_config()
     d = os.path.join(cfg.data_dir, "groups", str(group_id))
@@ -535,21 +492,45 @@ def load_problem_summaries(group_id: int) -> dict:
 def get_problem_summary(group_id: int, pid: str) -> str:
     data = load_problem_summaries(group_id)
     item = data.get(pid)
-    if isinstance(item, dict):
-        return strip_leaked_thinking(item.get("summary_zh", "") or "")
-    if isinstance(item, str):
-        return strip_leaked_thinking(item)
-    return ""
+    if not isinstance(item, dict):
+        return ""
+    source_sha256 = statement_fingerprint(
+        load_statement_json(pid, include_legacy_fallback=True)
+    )
+    if (
+        not source_sha256
+        or item.get("format_version") != PROBLEM_SUMMARY_FORMAT_VERSION
+        or item.get("status") != "verified"
+        or item.get("source_sha256") != source_sha256
+    ):
+        return ""
+    return strip_leaked_thinking(item.get("summary_zh", "") or "")
 
 
-def save_problem_summary(group_id: int, pid: str, summary_zh: str) -> None:
+def save_problem_summary(
+    group_id: int,
+    pid: str,
+    summary_zh: str,
+    *,
+    source_sha256: str = "",
+) -> None:
     if not pid or not summary_zh:
         return
     summary_zh = strip_leaked_thinking(summary_zh)
     if not summary_zh:
         return
+    current_source_sha256 = statement_fingerprint(
+        load_statement_json(pid, include_legacy_fallback=True)
+    )
+    if not current_source_sha256:
+        raise ValueError(f"cannot verify summary source for {pid}: statement missing")
+    if source_sha256 and source_sha256 != current_source_sha256:
+        raise ValueError(f"cannot save stale summary source for {pid}")
     data = load_problem_summaries(group_id)
     data[pid] = {
+        "format_version": PROBLEM_SUMMARY_FORMAT_VERSION,
+        "status": "verified",
+        "source_sha256": current_source_sha256,
         "summary_zh": summary_zh,
     }
     with open(_problem_summary_file(group_id), "w", encoding="utf-8") as f:

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -473,9 +473,9 @@ def resolve_problem_by_pid(pid: str) -> dict:
 
 
 def resolve_random_problem(group_id: int) -> dict:
-    from .handlers.cmd.newproblem import _effective_rating_range
+    from .problem_preparation import effective_rating_range
 
-    min_rating, max_rating = _effective_rating_range(group_id)
+    min_rating, max_rating = effective_rating_range(group_id)
     candidates: list[dict] = []
     for item in _fetch_problemset():
         if not isinstance(item, dict):

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -17,7 +17,6 @@ from typing import Any
 import cloudscraper
 
 from .config import get_config
-from .llm import strip_leaked_thinking
 from .handlers.shared import (
     get_problem_summary,
     get_today_problem,
@@ -27,7 +26,6 @@ from .handlers.shared import (
     save_problem_summary,
     save_problem_card_ref,
     sanitize_cached_problem_card_payload,
-    statement_images,
     summarize_problem,
     translate_sample_notes,
 )
@@ -38,7 +36,12 @@ from .napcat.client import (
     send_private_forward_msg,
     send_private_msg,
 )
-from .problems.picker import _normalize_sample_block
+from .problem_content import (
+    build_notes_message,
+    build_sample_messages,
+    statement_images,
+)
+from .problem_summary import SummaryPreparationStatus, prepare_problem_summary
 
 logger = logging.getLogger("kouhai-bot.private_judge")
 
@@ -340,22 +343,6 @@ def problem_id_from_ref(contest_id: int, index: str) -> str:
     return f"{int(contest_id)}{str(index).upper()}"
 
 
-def _statement_path(pid: str) -> Path:
-    return _data_dir() / "statements" / f"{pid}.json"
-
-
-def load_statement_json(pid: str) -> dict:
-    path = _statement_path(pid)
-    if not path.exists():
-        return {}
-    try:
-        with path.open(encoding="utf-8") as f:
-            data = json.load(f)
-        return data if isinstance(data, dict) else {}
-    except Exception:
-        return {}
-
-
 def _problem_id(problem: dict) -> str:
     contest_id = problem.get("contestId")
     index = problem.get("index")
@@ -512,57 +499,29 @@ def resolve_random_problem(group_id: int) -> dict:
     raise RuntimeError(f"no statement-ready random candidate: {last_error}")
 
 
-def _build_sample_messages(stmt: dict) -> list[str]:
-    samples = stmt.get("samples")
-    if not isinstance(samples, list):
-        return []
-    messages: list[str] = []
-    for idx, sample in enumerate(samples, 1):
-        if not isinstance(sample, dict):
-            continue
-        sample_input = _normalize_sample_block(sample.get("input", "")).rstrip("\n")
-        sample_output = _normalize_sample_block(sample.get("output", "")).rstrip("\n")
-        if not sample_input and not sample_output:
-            continue
-        messages.append(
-            f"样例 {idx}\n"
-            f"Input:\n{sample_input}\n\n"
-            f"Output:\n{sample_output}"
-        )
-    return messages
-
-
-async def _build_notes_message(stmt: dict) -> str:
-    raw_notes = _normalize_sample_block(stmt.get("notes", ""))
-    if not raw_notes:
-        return ""
-    try:
-        translated, _tag = await translate_sample_notes(raw_notes, statement_images(stmt))
-    except Exception:
-        translated = ""
-    text = strip_leaked_thinking(translated or raw_notes)
-    return f"样例解释：\n{text}" if text else ""
-
-
 async def _problem_summary(group_id: int, pid: str, stmt: dict) -> str:
     summary = get_problem_summary(group_id, pid)
     if summary:
         return summary
-    stmt_text = stmt.get("description", "") or ""
-    input_text = stmt.get("input", "") or ""
-    tl = stmt.get("time_limit", "?")
-    ml = stmt.get("memory_limit", "?")
-    result, model_tag = await summarize_problem(
-        stmt_text,
-        input_text,
-        f"Time: {tl}, Memory: {ml}",
-        statement_images(stmt),
+    result = await prepare_problem_summary(
+        stmt,
+        generate=summarize_problem,
+        attempts=1,
     )
-    summary = (result or "").strip()
-    if summary:
-        if model_tag:
-            summary += model_tag
-        save_problem_summary(group_id, pid, summary)
+    if (
+        result.status is not SummaryPreparationStatus.READY
+        or result.prepared is None
+    ):
+        return ""
+    summary = result.prepared.text
+    if result.prepared.model_tag:
+        summary += result.prepared.model_tag
+    save_problem_summary(
+        group_id,
+        pid,
+        summary,
+        source_sha256=result.prepared.source_sha256,
+    )
     return summary
 
 
@@ -576,8 +535,14 @@ async def build_problem_card_payload(group_id: int, problem: dict, *, greeting: 
     return {
         "pid": pid,
         "post_msg": post_msg,
-        "sample_messages": _build_sample_messages(stmt),
-        "notes_message": await _build_notes_message(stmt),
+        "sample_messages": list(build_sample_messages(stmt)),
+        "notes_message": await build_notes_message(
+            stmt,
+            translate_notes=translate_sample_notes,
+            images=statement_images(stmt),
+            on_translate_exception="source",
+            log_context="private judge",
+        ),
         "snake_enabled": False,
     }
 

--- a/src/kouhai_bot/problem_content.py
+++ b/src/kouhai_bot/problem_content.py
@@ -1,0 +1,196 @@
+"""Shared problem-cache loading and user-visible problem-card content helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any, Literal
+
+from .config import get_config
+from .llm import strip_leaked_thinking
+from .problems.content import normalize_sample_block
+
+logger = logging.getLogger("kouhai-bot.problem_content")
+
+LEGACY_STATEMENTS_DIR = Path.home() / ".kouhai-bot" / "statements"
+
+
+def statement_fingerprint(statement: object) -> str:
+    """Return a stable identity for the user-visible statement payload."""
+    if not isinstance(statement, dict) or not statement:
+        return ""
+    semantic_statement = {
+        key: value
+        for key, value in statement.items()
+        if not str(key).startswith("_")
+    }
+    if not semantic_statement:
+        return ""
+    payload = json.dumps(
+        semantic_statement,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def statement_images(statement: object) -> list[dict]:
+    if not isinstance(statement, dict):
+        return []
+    images = statement.get("images", [])
+    return [
+        item
+        for item in images
+        if isinstance(item, dict) and item.get("src")
+    ]
+
+
+def format_problem_statement_for_llm(statement: object) -> str:
+    """Format one cached statement as stable LLM grounding text."""
+    if not isinstance(statement, dict):
+        return ""
+
+    parts: list[str] = []
+    if statement.get("name"):
+        parts.append(f"Problem: {statement['name']}")
+    if statement.get("time_limit"):
+        parts.append(f"Time limit: {statement['time_limit']}")
+    if statement.get("memory_limit"):
+        parts.append(f"Memory limit: {statement['memory_limit']}")
+
+    for label, key in (
+        ("Description", "description"),
+        ("Input", "input"),
+        ("Output", "output"),
+    ):
+        value = statement.get(key, "")
+        if value:
+            parts.append(f"\n{label}:\n{value}")
+
+    samples = statement.get("samples", [])
+    if isinstance(samples, list):
+        for sample in samples:
+            if not isinstance(sample, dict):
+                continue
+            parts.append(
+                f"\nInput:\n{sample.get('input', '')}\n"
+                f"Output:\n{sample.get('output', '')}"
+            )
+
+    notes = statement.get("notes", "")
+    if notes:
+        parts.append(f"\nNote:\n{notes}")
+    return "\n".join(parts)
+
+
+def load_statement_json(
+    pid: str,
+    *,
+    data_dir: str | Path | None = None,
+    include_legacy_fallback: bool = False,
+    log_context: str = "",
+) -> dict[str, Any]:
+    """Load one cached statement from the configured data directory."""
+    pid = (pid or "").strip()
+    if not pid:
+        return {}
+    root = Path(data_dir) if data_dir is not None else Path(get_config().data_dir)
+    paths = [root / "statements" / f"{pid}.json"]
+    if include_legacy_fallback and LEGACY_STATEMENTS_DIR not in {
+        path.parent for path in paths
+    }:
+        paths.append(LEGACY_STATEMENTS_DIR / f"{pid}.json")
+
+    for path in paths:
+        if not path.is_file():
+            continue
+        try:
+            with path.open(encoding="utf-8") as f:
+                statement = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "%sfailed to load statement %s: %s",
+                f"{log_context}: " if log_context else "",
+                path,
+                exc,
+            )
+            continue
+        if isinstance(statement, dict):
+            return statement
+        logger.warning(
+            "%sstatement at %s is not an object",
+            f"{log_context}: " if log_context else "",
+            path,
+        )
+    return {}
+
+
+def build_sample_messages(
+    statement: dict[str, Any],
+    *,
+    include_explicit_empty: bool = False,
+) -> tuple[str, ...]:
+    """Build the canonical one-message-per-sample QQ payload."""
+    samples = statement.get("samples")
+    if not isinstance(samples, list):
+        return ()
+    messages: list[str] = []
+    for idx, sample in enumerate(samples, 1):
+        if not isinstance(sample, dict):
+            continue
+        sample_input = sample.get("input")
+        sample_output = sample.get("output")
+        if sample_input is None and sample_output is None:
+            continue
+        normalized_input = normalize_sample_block(sample_input).rstrip("\n")
+        normalized_output = normalize_sample_block(sample_output).rstrip("\n")
+        if (
+            not include_explicit_empty
+            and not normalized_input
+            and not normalized_output
+        ):
+            continue
+        messages.append(
+            f"样例 {idx}\n"
+            f"Input:\n{normalized_input}\n\n"
+            f"Output:\n{normalized_output}"
+        )
+    return tuple(messages)
+
+
+async def build_notes_message(
+    statement: dict[str, Any],
+    *,
+    translate_notes: Callable[
+        [str, list[dict]],
+        Awaitable[tuple[str | None, str]],
+    ],
+    images: list[dict],
+    on_translate_exception: Literal["skip", "source"],
+    log_context: str = "",
+) -> str:
+    """Build the canonical Notes node while preserving caller fallback policy."""
+    normalized_notes = normalize_sample_block(statement.get("notes"))
+    if not normalized_notes:
+        return ""
+    try:
+        translated_notes, _model_tag = await translate_notes(
+            normalized_notes,
+            images,
+        )
+    except Exception as exc:
+        if on_translate_exception == "skip":
+            logger.warning(
+                "%sNotes translation failed, skipping notes node: %s",
+                f"{log_context}: " if log_context else "",
+                exc,
+            )
+            return ""
+        translated_notes = None
+
+    final_notes = strip_leaked_thinking(translated_notes or normalized_notes)
+    return f"样例解释：\n{final_notes}" if final_notes else ""

--- a/src/kouhai_bot/problem_prefetch.py
+++ b/src/kouhai_bot/problem_prefetch.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Awaitable, Callable
 
 from .config import get_config
-from .editorial_followup import schedule_prefetch_editorial
+from .editorial_followup import ensure_editorial_prefetch
 from .handlers.shared import get_today_problem, load_scoreboard, statement_images
 from .problem_preparation import (
     PreparedProblem,
@@ -79,7 +79,6 @@ class NextProblemPrefetcher:
         self._build_task: asyncio.Task[PrefetchedProblem] | None = None
         self._ready_slot: PrefetchedProblem | None = None
         self._claimed_slot_id: str | None = None
-        self._resumed_slot_ids: set[str] = set()
 
     @property
     def slot_path(self) -> Path:
@@ -302,13 +301,12 @@ class NextProblemPrefetcher:
             # group state or rating overrides may have changed during a slow build.
             await asyncio.shield(task)
 
-    def _resume_cached_editorial_once(self, slot: PrefetchedProblem) -> None:
-        if slot.slot_id in self._resumed_slot_ids:
-            return
-        self._resumed_slot_ids.add(slot.slot_id)
-        # Never restart the crawler for a persisted READY slot.  This only
-        # finishes translation when tutorial JSON already reached disk.
-        schedule_prefetch_editorial(slot.problem.pid, run_agent=False)
+    def _maintain_editorial_prefetch(self, slot: PrefetchedProblem) -> None:
+        # This is deliberately fire-and-forget: editorial readiness must not
+        # become part of the /newproblem claim latency.  Repeated calls are
+        # idempotent and let a rehydrated READY slot restart work interrupted
+        # by a process exit.
+        ensure_editorial_prefetch(slot.problem.pid)
 
     async def _wait_for_wake_or_stop(self, stop_event: asyncio.Event) -> None:
         wake_task = asyncio.create_task(self._wake.wait())
@@ -337,7 +335,7 @@ class NextProblemPrefetcher:
                 try:
                     slot = await self._ensure_ready()
                     if slot is not None:
-                        self._resume_cached_editorial_once(slot)
+                        self._maintain_editorial_prefetch(slot)
                 except asyncio.CancelledError:
                     if stop_event.is_set():
                         break

--- a/src/kouhai_bot/problem_prefetch.py
+++ b/src/kouhai_bot/problem_prefetch.py
@@ -14,18 +14,17 @@ from pathlib import Path
 from typing import Awaitable, Callable
 
 from .config import get_config
-from .editorial_followup import ensure_editorial_prefetch
 from .handlers.shared import get_today_problem, load_scoreboard, statement_images
+from .problem_content import load_statement_json, statement_fingerprint
 from .problem_preparation import (
     PreparedProblem,
     effective_rating_range,
-    load_statement_json,
     prepare_problem,
 )
 
 logger = logging.getLogger("kouhai-bot.problem_prefetch")
 
-SLOT_FORMAT_VERSION = 1
+SLOT_FORMAT_VERSION = 2
 DEFAULT_RETRY_INTERVAL_SEC = 60.0
 
 
@@ -79,6 +78,26 @@ class NextProblemPrefetcher:
         self._build_task: asyncio.Task[PrefetchedProblem] | None = None
         self._ready_slot: PrefetchedProblem | None = None
         self._claimed_slot_id: str | None = None
+        self._ready_observer: Callable[[str], None] | None = None
+
+    def set_ready_observer(self, observer: Callable[[str], None] | None) -> None:
+        """Register a non-blocking orchestration hook for newly READY slots."""
+        self._ready_observer = observer
+
+    def _notify_ready(self, pid: str) -> None:
+        observer = self._ready_observer
+        if observer is None:
+            return
+        try:
+            observer(pid)
+        except Exception as exc:
+            logger.warning(
+                "[group_%s] next-problem READY observer failed for %s: %s",
+                self.group_id,
+                pid,
+                exc,
+                exc_info=True,
+            )
 
     @property
     def slot_path(self) -> Path:
@@ -143,9 +162,16 @@ class NextProblemPrefetcher:
         ):
             return False, "already_solved"
 
-        statement = load_statement_json(self.group_id, pid)
+        statement = load_statement_json(
+            pid,
+            data_dir=get_config().data_dir,
+            include_legacy_fallback=True,
+            log_context=f"group_{self.group_id}",
+        )
         if not statement:
             return False, "statement_missing"
+        if statement_fingerprint(statement) != prepared.statement_sha256:
+            return False, "statement_changed"
         if statement_images(statement) and not get_config().llm_multimodal_providers:
             return False, "multimodal_unavailable"
         return True, ""
@@ -228,6 +254,7 @@ class NextProblemPrefetcher:
             prepared.pid,
             asyncio.get_running_loop().time() - started,
         )
+        self._notify_ready(prepared.pid)
         return slot
 
     def _ensure_build_task_locked(self) -> asyncio.Task[PrefetchedProblem]:
@@ -254,6 +281,10 @@ class NextProblemPrefetcher:
     async def peek(self) -> PrefetchedProblem | None:
         async with self._lock:
             return self._load_slot_locked()
+
+    async def peek_pid(self) -> str:
+        slot = await self.peek()
+        return slot.problem.pid if slot is not None else ""
 
     async def claim(self) -> PrefetchedProblem:
         """Claim READY, waiting for the shared build task on a cold path."""
@@ -301,13 +332,6 @@ class NextProblemPrefetcher:
             # group state or rating overrides may have changed during a slow build.
             await asyncio.shield(task)
 
-    def _maintain_editorial_prefetch(self, slot: PrefetchedProblem) -> None:
-        # This is deliberately fire-and-forget: editorial readiness must not
-        # become part of the /newproblem claim latency.  Repeated calls are
-        # idempotent and let a rehydrated READY slot restart work interrupted
-        # by a process exit.
-        ensure_editorial_prefetch(slot.problem.pid)
-
     async def _wait_for_wake_or_stop(self, stop_event: asyncio.Event) -> None:
         wake_task = asyncio.create_task(self._wake.wait())
         stop_task = asyncio.create_task(stop_event.wait())
@@ -333,9 +357,7 @@ class NextProblemPrefetcher:
                 async with self._lock:
                     self._wake.clear()
                 try:
-                    slot = await self._ensure_ready()
-                    if slot is not None:
-                        self._maintain_editorial_prefetch(slot)
+                    await self._ensure_ready()
                 except asyncio.CancelledError:
                     if stop_event.is_set():
                         break

--- a/src/kouhai_bot/problem_prefetch.py
+++ b/src/kouhai_bot/problem_prefetch.py
@@ -1,0 +1,384 @@
+"""Durable single-slot prefetch coordinator for the next group problem."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+import uuid
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Awaitable, Callable
+
+from .config import get_config
+from .editorial_followup import schedule_prefetch_editorial
+from .handlers.shared import get_today_problem, load_scoreboard, statement_images
+from .problem_preparation import (
+    PreparedProblem,
+    effective_rating_range,
+    load_statement_json,
+    prepare_problem,
+)
+
+logger = logging.getLogger("kouhai-bot.problem_prefetch")
+
+SLOT_FORMAT_VERSION = 1
+DEFAULT_RETRY_INTERVAL_SEC = 60.0
+
+
+@dataclass(frozen=True)
+class PrefetchedProblem:
+    """A durable READY slot claimed by one /newproblem publication."""
+
+    slot_id: str
+    problem: PreparedProblem
+
+    def to_json(self) -> dict:
+        return {
+            "format_version": SLOT_FORMAT_VERSION,
+            "slot_id": self.slot_id,
+            "problem": self.problem.to_json(),
+        }
+
+    @classmethod
+    def from_json(cls, value: object) -> PrefetchedProblem | None:
+        if not isinstance(value, dict):
+            return None
+        if value.get("format_version") != SLOT_FORMAT_VERSION:
+            return None
+        slot_id = str(value.get("slot_id", "") or "")
+        problem = PreparedProblem.from_json(value.get("problem"))
+        if not slot_id or problem is None:
+            return None
+        return cls(slot_id=slot_id, problem=problem)
+
+
+class NextProblemPrefetcher:
+    """Maintain exactly one READY problem with single-flight preparation.
+
+    The post lock remains owned by the command handler.  This coordinator owns
+    only preparation and the READY/CLAIMED handoff, so slow work never runs
+    while its internal lock is held.
+    """
+
+    def __init__(
+        self,
+        group_id: int,
+        *,
+        prepare: Callable[[int], Awaitable[PreparedProblem]] = prepare_problem,
+        retry_interval_sec: float = DEFAULT_RETRY_INTERVAL_SEC,
+    ) -> None:
+        self.group_id = int(group_id)
+        self._prepare = prepare
+        self._retry_interval_sec = float(retry_interval_sec)
+        self._lock = asyncio.Lock()
+        self._wake = asyncio.Event()
+        self._build_task: asyncio.Task[PrefetchedProblem] | None = None
+        self._ready_slot: PrefetchedProblem | None = None
+        self._claimed_slot_id: str | None = None
+        self._resumed_slot_ids: set[str] = set()
+
+    @property
+    def slot_path(self) -> Path:
+        return (
+            Path(get_config().data_dir)
+            / "groups"
+            / str(self.group_id)
+            / "next_problem.json"
+        )
+
+    def _write_slot_locked(self, slot: PrefetchedProblem) -> None:
+        path = self.slot_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_name(f".{path.name}.{slot.slot_id}.tmp")
+        try:
+            with tmp_path.open("w", encoding="utf-8") as f:
+                json.dump(slot.to_json(), f, ensure_ascii=False, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, path)
+        finally:
+            with suppress(FileNotFoundError):
+                tmp_path.unlink()
+
+    def _remove_slot_locked(self) -> None:
+        self._ready_slot = None
+        try:
+            self.slot_path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            # Keep the in-memory state authoritative for availability.  A stale
+            # disk slot is revalidated on the next process start.
+            logger.warning(
+                "[group_%s] failed to remove next-problem slot: %s",
+                self.group_id,
+                exc,
+            )
+
+    def _slot_valid_locked(self, slot: PrefetchedProblem) -> tuple[bool, str]:
+        prepared = slot.problem
+        current_min, current_max = effective_rating_range(self.group_id)
+        if (prepared.min_rating, prepared.max_rating) != (current_min, current_max):
+            return False, "rating_range_changed"
+
+        pid = prepared.pid
+        current = get_today_problem(self.group_id)
+        current_pid = (
+            str(current.get("today", "") or "")
+            if isinstance(current, dict)
+            else ""
+        )
+        if pid == current_pid:
+            return False, "already_current"
+
+        scoreboard = load_scoreboard(self.group_id)
+        solves = scoreboard.get("solves", []) if isinstance(scoreboard, dict) else []
+        if any(
+            isinstance(item, dict)
+            and str(item.get("problem", "") or "") == pid
+            for item in solves
+        ):
+            return False, "already_solved"
+
+        statement = load_statement_json(self.group_id, pid)
+        if not statement:
+            return False, "statement_missing"
+        if statement_images(statement) and not get_config().llm_multimodal_providers:
+            return False, "multimodal_unavailable"
+        return True, ""
+
+    def _load_slot_locked(self) -> PrefetchedProblem | None:
+        if self._ready_slot is not None:
+            valid, reason = self._slot_valid_locked(self._ready_slot)
+            if valid:
+                return self._ready_slot
+            logger.info(
+                "[group_%s] next-problem slot %s invalidated: %s",
+                self.group_id,
+                self._ready_slot.problem.pid,
+                reason,
+            )
+            self._remove_slot_locked()
+
+        path = self.slot_path
+        if not path.is_file():
+            return None
+        try:
+            with path.open(encoding="utf-8") as f:
+                raw = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "[group_%s] next-problem slot unreadable, rebuilding: %s",
+                self.group_id,
+                exc,
+            )
+            self._remove_slot_locked()
+            return None
+
+        slot = PrefetchedProblem.from_json(raw)
+        if slot is None:
+            logger.info(
+                "[group_%s] next-problem slot format invalid, rebuilding",
+                self.group_id,
+            )
+            self._remove_slot_locked()
+            return None
+
+        valid, reason = self._slot_valid_locked(slot)
+        if not valid:
+            logger.info(
+                "[group_%s] next-problem slot %s invalidated: %s",
+                self.group_id,
+                slot.problem.pid,
+                reason,
+            )
+            self._remove_slot_locked()
+            return None
+        self._ready_slot = slot
+        return slot
+
+    async def _build_and_store(self) -> PrefetchedProblem:
+        started = asyncio.get_running_loop().time()
+        prepared = await self._prepare(self.group_id)
+        slot = PrefetchedProblem(slot_id=uuid.uuid4().hex, problem=prepared)
+        async with self._lock:
+            existing = self._load_slot_locked()
+            if existing is not None:
+                return existing
+            if self._claimed_slot_id is not None:
+                raise RuntimeError("cannot store next problem while another slot is claimed")
+            self._ready_slot = slot
+            try:
+                self._write_slot_locked(slot)
+            except OSError as exc:
+                # A foreground /newproblem can still use the in-memory slot.
+                # The maintenance loop will rebuild after a process restart.
+                logger.warning(
+                    "[group_%s] failed to persist next problem %s: %s",
+                    self.group_id,
+                    prepared.pid,
+                    exc,
+                )
+        logger.info(
+            "[group_%s] next problem READY pid=%s elapsed=%.1fs",
+            self.group_id,
+            prepared.pid,
+            asyncio.get_running_loop().time() - started,
+        )
+        return slot
+
+    def _ensure_build_task_locked(self) -> asyncio.Task[PrefetchedProblem]:
+        task = self._build_task
+        if task is None or task.done():
+            task = asyncio.create_task(
+                self._build_and_store(),
+                name=f"next_problem_build_{self.group_id}",
+            )
+            # A foreground claim can be cancelled while the shielded build
+            # continues.  Observe its terminal exception even if no waiter is
+            # left; existing awaiters still receive the same exception.
+            task.add_done_callback(self._observe_build_result)
+            self._build_task = task
+        return task
+
+    @staticmethod
+    def _observe_build_result(task: asyncio.Task[PrefetchedProblem]) -> None:
+        if task.cancelled():
+            return
+        with suppress(Exception):
+            task.exception()
+
+    async def peek(self) -> PrefetchedProblem | None:
+        async with self._lock:
+            return self._load_slot_locked()
+
+    async def claim(self) -> PrefetchedProblem:
+        """Claim READY, waiting for the shared build task on a cold path."""
+        while True:
+            async with self._lock:
+                if self._claimed_slot_id is not None:
+                    raise RuntimeError("next-problem slot is already claimed")
+                slot = self._load_slot_locked()
+                if slot is not None:
+                    self._remove_slot_locked()
+                    self._claimed_slot_id = slot.slot_id
+                    logger.info(
+                        "[group_%s] next problem claimed pid=%s age=%ss",
+                        self.group_id,
+                        slot.problem.pid,
+                        max(0, int(time.time()) - slot.problem.prepared_at),
+                    )
+                    return slot
+                task = self._ensure_build_task_locked()
+            await asyncio.shield(task)
+
+    async def release(self, slot_id: str) -> None:
+        """Finish one publication attempt and allow the next refill."""
+        async with self._lock:
+            if self._claimed_slot_id != slot_id:
+                logger.warning(
+                    "[group_%s] ignored stale next-problem release token %s",
+                    self.group_id,
+                    slot_id,
+                )
+                return
+            self._claimed_slot_id = None
+            self._wake.set()
+
+    async def _ensure_ready(self) -> PrefetchedProblem | None:
+        while True:
+            async with self._lock:
+                if self._claimed_slot_id is not None:
+                    return None
+                slot = self._load_slot_locked()
+                if slot is not None:
+                    return slot
+                task = self._ensure_build_task_locked()
+            # Re-enter through validation instead of trusting the task result:
+            # group state or rating overrides may have changed during a slow build.
+            await asyncio.shield(task)
+
+    def _resume_cached_editorial_once(self, slot: PrefetchedProblem) -> None:
+        if slot.slot_id in self._resumed_slot_ids:
+            return
+        self._resumed_slot_ids.add(slot.slot_id)
+        # Never restart the crawler for a persisted READY slot.  This only
+        # finishes translation when tutorial JSON already reached disk.
+        schedule_prefetch_editorial(slot.problem.pid, run_agent=False)
+
+    async def _wait_for_wake_or_stop(self, stop_event: asyncio.Event) -> None:
+        wake_task = asyncio.create_task(self._wake.wait())
+        stop_task = asyncio.create_task(stop_event.wait())
+        try:
+            await asyncio.wait(
+                {wake_task, stop_task},
+                timeout=self._retry_interval_sec,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            for task in (wake_task, stop_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(wake_task, stop_task, return_exceptions=True)
+
+    async def run(self, *, stop_event: asyncio.Event) -> None:
+        """Worker-owned maintenance loop."""
+        logger.info("[group_%s] next-problem prefetcher started", self.group_id)
+        try:
+            while not stop_event.is_set():
+                # Clear before inspecting state so a release racing with the
+                # inspection cannot be lost before the wait.
+                async with self._lock:
+                    self._wake.clear()
+                try:
+                    slot = await self._ensure_ready()
+                    if slot is not None:
+                        self._resume_cached_editorial_once(slot)
+                except asyncio.CancelledError:
+                    if stop_event.is_set():
+                        break
+                    raise
+                except Exception as exc:
+                    logger.warning(
+                        "[group_%s] next-problem prefetch failed: %s",
+                        self.group_id,
+                        exc,
+                        exc_info=True,
+                    )
+                if not stop_event.is_set():
+                    await self._wait_for_wake_or_stop(stop_event)
+        finally:
+            await self.shutdown()
+            logger.info("[group_%s] next-problem prefetcher stopped", self.group_id)
+
+    async def shutdown(self) -> None:
+        """Cancel the coordinator-owned build task, if any."""
+        self._wake.set()
+        async with self._lock:
+            task = self._build_task
+        if task is not None and not task.done():
+            task.cancel()
+        if task is not None:
+            with suppress(asyncio.CancelledError, Exception):
+                await task
+
+
+_prefetchers: dict[int, NextProblemPrefetcher] = {}
+
+
+def get_next_problem_prefetcher(group_id: int) -> NextProblemPrefetcher:
+    group_id = int(group_id)
+    prefetcher = _prefetchers.get(group_id)
+    if prefetcher is None:
+        prefetcher = NextProblemPrefetcher(group_id)
+        _prefetchers[group_id] = prefetcher
+    return prefetcher
+
+
+def reset_prefetchers_for_tests() -> None:
+    """Drop idle module state between event-loop-isolated tests."""
+    _prefetchers.clear()

--- a/src/kouhai_bot/problem_preparation.py
+++ b/src/kouhai_bot/problem_preparation.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import sys
 import time
 from dataclasses import dataclass
@@ -19,19 +18,26 @@ from pathlib import Path
 from typing import Any
 
 from .config import get_config
-from .editorial_followup import schedule_prefetch_editorial
 from .handlers.shared import (
-    statement_images,
     summarize_problem,
     translate_sample_notes,
 )
-from .llm import strip_leaked_thinking
-from .problems.picker import _normalize_sample_block
+from .problem_content import (
+    build_notes_message as build_shared_notes_message,
+    build_sample_messages,
+    load_statement_json,
+    statement_fingerprint,
+    statement_images,
+)
+from .problem_summary import (
+    SummaryPreparationStatus,
+    prepare_problem_summary,
+)
+from .problems.picker import format_reveal as format_previous_problem_reveal
 
 logger = logging.getLogger("kouhai-bot.problem_preparation")
 
 PICKER_PATH = Path(__file__).resolve().parent / "problems" / "picker.py"
-STATEMENTS_FALLBACK_DIR = Path.home() / ".kouhai-bot" / "statements"
 PICK_ATTEMPTS = 3
 PICK_TIMEOUT_SEC = 120
 
@@ -42,7 +48,9 @@ class PreparedProblem:
 
     state: dict[str, Any]
     summary: str
+    summary_status: SummaryPreparationStatus
     model_tag: str
+    statement_sha256: str
     sample_messages: tuple[str, ...]
     notes_message: str
     min_rating: int
@@ -57,7 +65,9 @@ class PreparedProblem:
         return {
             "state": self.state,
             "summary": self.summary,
+            "summary_status": self.summary_status.value,
             "model_tag": self.model_tag,
+            "statement_sha256": self.statement_sha256,
             "sample_messages": list(self.sample_messages),
             "notes_message": self.notes_message,
             "min_rating": self.min_rating,
@@ -76,10 +86,15 @@ class PreparedProblem:
         if not all(isinstance(item, str) for item in samples):
             return None
         try:
+            summary = str(value.get("summary", "") or "")
+            model_tag = str(value.get("model_tag", "") or "")
+            summary_status = SummaryPreparationStatus(value["summary_status"])
             prepared = cls(
                 state=dict(state),
-                summary=str(value.get("summary", "") or ""),
-                model_tag=str(value.get("model_tag", "") or ""),
+                summary=summary,
+                summary_status=summary_status,
+                model_tag=model_tag,
+                statement_sha256=str(value["statement_sha256"]),
                 sample_messages=tuple(samples),
                 notes_message=str(value.get("notes_message", "") or ""),
                 min_rating=int(value["min_rating"]),
@@ -88,7 +103,11 @@ class PreparedProblem:
             )
         except (KeyError, TypeError, ValueError):
             return None
-        return prepared if prepared.pid else None
+        if not prepared.pid or len(prepared.statement_sha256) != 64:
+            return None
+        if summary_status is SummaryPreparationStatus.READY:
+            return prepared if summary else None
+        return prepared if not summary and not model_tag else None
 
 
 class ProblemPreparationError(RuntimeError):
@@ -165,70 +184,15 @@ def classify_pick_error(stderr_text: str) -> str:
     return "题目选取失败，稍后再试"
 
 
-def load_statement_json(group_id: int, pid: str) -> dict[str, Any]:
-    """Load the configured statement cache, with the legacy fallback."""
-    cfg = get_config()
-    candidate_paths = [
-        Path(cfg.data_dir) / "statements" / f"{pid}.json",
-        STATEMENTS_FALLBACK_DIR / f"{pid}.json",
-    ]
-    for path in candidate_paths:
-        if not path.exists():
-            continue
-        try:
-            with path.open(encoding="utf-8") as f:
-                statement = json.load(f)
-            if isinstance(statement, dict):
-                return statement
-            logger.warning("[group_%s] Statement at %s is not a dict", group_id, path)
-        except Exception as exc:
-            logger.warning(
-                "[group_%s] Failed to load statement %s: %s",
-                group_id,
-                path,
-                exc,
-            )
-    return {}
-
-
-def build_sample_messages(statement: dict[str, Any]) -> tuple[str, ...]:
-    """Build the same one-message-per-sample payload used by /newproblem."""
-    samples = statement.get("samples")
-    if not isinstance(samples, list):
-        return ()
-    messages: list[str] = []
-    for idx, sample in enumerate(samples, 1):
-        if not isinstance(sample, dict):
-            continue
-        sample_input = sample.get("input")
-        sample_output = sample.get("output")
-        if sample_input is None and sample_output is None:
-            continue
-        normalized_input = _normalize_sample_block(sample_input).rstrip("\n")
-        normalized_output = _normalize_sample_block(sample_output).rstrip("\n")
-        messages.append(
-            f"样例 {idx}\n"
-            f"Input:\n{normalized_input}\n\n"
-            f"Output:\n{normalized_output}"
-        )
-    return tuple(messages)
-
-
 async def build_notes_message(statement: dict[str, Any]) -> str:
     """Translate Notes with the existing group-post fallback behavior."""
-    normalized_notes = _normalize_sample_block(statement.get("notes"))
-    if not normalized_notes:
-        return ""
-    try:
-        translated_notes, _model_tag = await translate_sample_notes(
-            normalized_notes,
-            statement_images(statement),
-        )
-    except Exception as exc:
-        logger.warning("Notes translation failed, skipping notes node: %s", exc)
-        return ""
-    final_notes = strip_leaked_thinking(translated_notes or normalized_notes)
-    return f"样例解释：\n{final_notes}" if final_notes else ""
+    return await build_shared_notes_message(
+        statement,
+        translate_notes=translate_sample_notes,
+        images=statement_images(statement),
+        on_translate_exception="skip",
+        log_context="group problem preparation",
+    )
 
 
 async def _stop_process(process: asyncio.subprocess.Process) -> None:
@@ -325,73 +289,57 @@ async def prepare_problem(group_id: int) -> PreparedProblem:
     )
     pid = str(picked_state.get("today", "") or "")
 
-    summary = ""
-    model_tag = ""
-    sample_messages: tuple[str, ...] = ()
-    notes_message = ""
-    try:
-        if pid:
-            schedule_prefetch_editorial(pid)
-
-        statement = load_statement_json(group_id, pid) if pid else {}
-        statement_text = ""
-        input_text = ""
-        limits_text = ""
-        if statement:
-            statement_text = str(statement.get("description", "") or "")
-            input_text = str(statement.get("input", "") or "")
-            limits_text = (
-                f"Time: {statement.get('time_limit', '?')}, "
-                f"Memory: {statement.get('memory_limit', '?')}"
-            )
-            sample_messages = build_sample_messages(statement)
-            notes_message = await build_notes_message(statement)
-
-        images = statement_images(statement)
-        generated, model_tag = await summarize_problem(
-            statement_text,
-            input_text,
-            limits_text,
-            images,
+    statement = (
+        load_statement_json(
+            pid,
+            data_dir=get_config().data_dir,
+            include_legacy_fallback=True,
+            log_context=f"group_{group_id}",
         )
-        if not generated:
-            logger.warning("[group_%s] Summary 1st attempt failed, retrying...", group_id)
-            generated, model_tag = await summarize_problem(
-                statement_text,
-                input_text,
-                limits_text,
-                images,
-            )
-        if generated:
-            summary = generated.strip()
-        else:
-            logger.warning("[group_%s] Summary failed after retry", group_id)
-    except asyncio.CancelledError:
-        raise
-    except Exception as exc:
-        logger.warning("[group_%s] Summary error: %s", group_id, exc)
+        if pid
+        else {}
+    )
+    source_sha256 = statement_fingerprint(statement)
+    if not source_sha256:
+        raise ProblemPreparationError("题面缓存读取失败")
+
+    sample_messages = build_sample_messages(
+        statement,
+        include_explicit_empty=True,
+    )
+    notes_message = await build_notes_message(statement)
+    summary_result = await prepare_problem_summary(
+        statement,
+        generate=summarize_problem,
+        attempts=2,
+    )
+    if (
+        summary_result.status is SummaryPreparationStatus.READY
+        and summary_result.prepared is not None
+    ):
+        summary = summary_result.prepared.text
+        model_tag = summary_result.prepared.model_tag
+    else:
+        # Preserve the established availability policy: a fully fetched
+        # statement can still be posted without an LLM summary.  The explicit
+        # status prevents this degraded card from masquerading as a summary hit.
+        summary = ""
+        model_tag = ""
+        logger.warning(
+            "[group_%s] Summary unavailable after retries: %s",
+            group_id,
+            summary_result.reason,
+        )
 
     return PreparedProblem(
         state=dict(picked_state),
         summary=summary,
+        summary_status=summary_result.status,
         model_tag=model_tag,
+        statement_sha256=source_sha256,
         sample_messages=sample_messages,
         notes_message=notes_message,
         min_rating=min_rating,
         max_rating=max_rating,
         prepared_at=int(time.time()),
     )
-
-
-def format_previous_problem_reveal(problem: object) -> str:
-    """Format the existing reveal message without spawning the picker CLI."""
-    if not isinstance(problem, dict) or not problem:
-        return "还没有发过题哦"
-    parts = [f"CF{problem.get('today', '?')}"]
-    name = str(problem.get("name", "") or "")
-    rating = str(problem.get("rating", "") or "")
-    if name:
-        parts.append(name)
-    if rating:
-        parts.append(rating)
-    return f"上一道题来自 {' '.join(parts)}✨"

--- a/src/kouhai_bot/problem_preparation.py
+++ b/src/kouhai_bot/problem_preparation.py
@@ -1,0 +1,397 @@
+"""Prepare the complete user-visible content for the next group problem.
+
+The picker remains a subprocess boundary on purpose: it contains synchronous
+Codeforces/Playwright work and process-global path/rating configuration.  This
+module gives callers a typed async interface without leaking those CLI details
+into command handlers or the prefetch coordinator.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .config import get_config
+from .editorial_followup import schedule_prefetch_editorial
+from .handlers.shared import (
+    statement_images,
+    summarize_problem,
+    translate_sample_notes,
+)
+from .llm import strip_leaked_thinking
+from .problems.picker import _normalize_sample_block
+
+logger = logging.getLogger("kouhai-bot.problem_preparation")
+
+PICKER_PATH = Path(__file__).resolve().parent / "problems" / "picker.py"
+STATEMENTS_FALLBACK_DIR = Path.home() / ".kouhai-bot" / "statements"
+PICK_ATTEMPTS = 3
+PICK_TIMEOUT_SEC = 120
+
+
+@dataclass(frozen=True)
+class PreparedProblem:
+    """A problem whose blocking group-card preparation is complete."""
+
+    state: dict[str, Any]
+    summary: str
+    model_tag: str
+    sample_messages: tuple[str, ...]
+    notes_message: str
+    min_rating: int
+    max_rating: int
+    prepared_at: int
+
+    @property
+    def pid(self) -> str:
+        return str(self.state.get("today", "") or "")
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "state": self.state,
+            "summary": self.summary,
+            "model_tag": self.model_tag,
+            "sample_messages": list(self.sample_messages),
+            "notes_message": self.notes_message,
+            "min_rating": self.min_rating,
+            "max_rating": self.max_rating,
+            "prepared_at": self.prepared_at,
+        }
+
+    @classmethod
+    def from_json(cls, value: object) -> PreparedProblem | None:
+        if not isinstance(value, dict):
+            return None
+        state = value.get("state")
+        samples = value.get("sample_messages")
+        if not isinstance(state, dict) or not isinstance(samples, list):
+            return None
+        if not all(isinstance(item, str) for item in samples):
+            return None
+        try:
+            prepared = cls(
+                state=dict(state),
+                summary=str(value.get("summary", "") or ""),
+                model_tag=str(value.get("model_tag", "") or ""),
+                sample_messages=tuple(samples),
+                notes_message=str(value.get("notes_message", "") or ""),
+                min_rating=int(value["min_rating"]),
+                max_rating=int(value["max_rating"]),
+                prepared_at=int(value["prepared_at"]),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+        return prepared if prepared.pid else None
+
+
+class ProblemPreparationError(RuntimeError):
+    """Terminal result of one three-attempt picker/preparation run."""
+
+    def __init__(self, user_message: str) -> None:
+        super().__init__(user_message)
+        self.user_message = user_message
+
+
+def effective_rating_range(group_id: int) -> tuple[int, int]:
+    """Return config ratings with the existing scheduler override semantics."""
+    cfg = get_config()
+    min_rating = int(cfg.min_rating)
+    max_rating = int(cfg.max_rating)
+    try:
+        from .scheduler.engine import load_group_configs
+
+        group_cfg = load_group_configs().get(group_id)
+        if group_cfg:
+            if group_cfg.min_rating is not None:
+                min_rating = int(group_cfg.min_rating)
+            if group_cfg.max_rating is not None:
+                max_rating = int(group_cfg.max_rating)
+    except Exception:
+        logger.warning(
+            "[group_%s] Failed to load scheduler rating overrides; using config range",
+            group_id,
+            exc_info=True,
+        )
+    return min_rating, max_rating
+
+
+def picker_args(
+    command: str,
+    group_id: int,
+    *extra: str,
+    rating_range: tuple[int, int] | None = None,
+) -> list[str]:
+    min_rating, max_rating = (
+        rating_range
+        if rating_range is not None
+        else effective_rating_range(group_id)
+    )
+    return [
+        str(PICKER_PATH),
+        command,
+        "--group",
+        str(group_id),
+        "--data-dir",
+        str(get_config().data_dir),
+        "--min-rating",
+        str(min_rating),
+        "--max-rating",
+        str(max_rating),
+        *extra,
+    ]
+
+
+def classify_pick_error(stderr_text: str) -> str:
+    """Classify picker stderr into the existing user-facing error message."""
+    lower = stderr_text.lower()
+    if any(kw in stderr_text for kw in (
+        "codeforces.com", "SSL", "SSLEOFError", "SSLError",
+        "ConnectionError", "Max retries exceeded", "RemoteDisconnected",
+    )):
+        return "Codeforces 连接失败"
+    if any(kw in lower for kw in ("timeout", "timed out")):
+        return "Codeforces 请求超时"
+    if any(kw in lower for kw in (
+        "permission", "access denied", "ioerror", "filenotfound",
+    )):
+        return "本地数据读取异常"
+    return "题目选取失败，稍后再试"
+
+
+def load_statement_json(group_id: int, pid: str) -> dict[str, Any]:
+    """Load the configured statement cache, with the legacy fallback."""
+    cfg = get_config()
+    candidate_paths = [
+        Path(cfg.data_dir) / "statements" / f"{pid}.json",
+        STATEMENTS_FALLBACK_DIR / f"{pid}.json",
+    ]
+    for path in candidate_paths:
+        if not path.exists():
+            continue
+        try:
+            with path.open(encoding="utf-8") as f:
+                statement = json.load(f)
+            if isinstance(statement, dict):
+                return statement
+            logger.warning("[group_%s] Statement at %s is not a dict", group_id, path)
+        except Exception as exc:
+            logger.warning(
+                "[group_%s] Failed to load statement %s: %s",
+                group_id,
+                path,
+                exc,
+            )
+    return {}
+
+
+def build_sample_messages(statement: dict[str, Any]) -> tuple[str, ...]:
+    """Build the same one-message-per-sample payload used by /newproblem."""
+    samples = statement.get("samples")
+    if not isinstance(samples, list):
+        return ()
+    messages: list[str] = []
+    for idx, sample in enumerate(samples, 1):
+        if not isinstance(sample, dict):
+            continue
+        sample_input = sample.get("input")
+        sample_output = sample.get("output")
+        if sample_input is None and sample_output is None:
+            continue
+        normalized_input = _normalize_sample_block(sample_input).rstrip("\n")
+        normalized_output = _normalize_sample_block(sample_output).rstrip("\n")
+        messages.append(
+            f"样例 {idx}\n"
+            f"Input:\n{normalized_input}\n\n"
+            f"Output:\n{normalized_output}"
+        )
+    return tuple(messages)
+
+
+async def build_notes_message(statement: dict[str, Any]) -> str:
+    """Translate Notes with the existing group-post fallback behavior."""
+    normalized_notes = _normalize_sample_block(statement.get("notes"))
+    if not normalized_notes:
+        return ""
+    try:
+        translated_notes, _model_tag = await translate_sample_notes(
+            normalized_notes,
+            statement_images(statement),
+        )
+    except Exception as exc:
+        logger.warning("Notes translation failed, skipping notes node: %s", exc)
+        return ""
+    final_notes = strip_leaked_thinking(translated_notes or normalized_notes)
+    return f"样例解释：\n{final_notes}" if final_notes else ""
+
+
+async def _stop_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        return
+    try:
+        process.kill()
+    except ProcessLookupError:
+        pass
+    try:
+        await process.wait()
+    except ProcessLookupError:
+        pass
+
+
+async def _run_picker(
+    group_id: int,
+    *,
+    rating_range: tuple[int, int] | None = None,
+) -> dict[str, Any]:
+    pick_error_msg = ""
+    for attempt in range(1, PICK_ATTEMPTS + 1):
+        process: asyncio.subprocess.Process | None = None
+        try:
+            process = await asyncio.create_subprocess_exec(
+                sys.executable,
+                *picker_args(
+                    "pick-json",
+                    group_id,
+                    "--with-statement",
+                    rating_range=rating_range,
+                ),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(),
+                    timeout=PICK_TIMEOUT_SEC,
+                )
+            except BaseException:
+                await _stop_process(process)
+                raise
+            if process.returncode != 0:
+                err_text = stderr.decode(errors="replace")[:200]
+                logger.error(
+                    "Pick failed (group %s, attempt %s/%s): %s",
+                    group_id,
+                    attempt,
+                    PICK_ATTEMPTS,
+                    err_text,
+                )
+                pick_error_msg = classify_pick_error(err_text)
+            else:
+                picked_state = json.loads(stdout.decode())
+                if (
+                    isinstance(picked_state, dict)
+                    and str(picked_state.get("today", "") or "").strip()
+                ):
+                    return picked_state
+                logger.error(
+                    "Pick failed (group %s, attempt %s/%s): invalid picker payload",
+                    group_id,
+                    attempt,
+                    PICK_ATTEMPTS,
+                )
+                pick_error_msg = "题目选取结果异常"
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error(
+                "Pick error (group %s, attempt %s/%s): %s",
+                group_id,
+                attempt,
+                PICK_ATTEMPTS,
+                exc,
+            )
+            pick_error_msg = "Codeforces 连接失败"
+
+        if attempt < PICK_ATTEMPTS:
+            delay = 2 * attempt
+            logger.info("Retrying pick in %ss...", delay)
+            await asyncio.sleep(delay)
+
+    raise ProblemPreparationError(pick_error_msg or "题目选取失败，稍后再试")
+
+
+async def prepare_problem(group_id: int) -> PreparedProblem:
+    """Run the old blocking /newproblem preparation pipeline ahead of time."""
+    min_rating, max_rating = effective_rating_range(group_id)
+    picked_state = await _run_picker(
+        group_id,
+        rating_range=(min_rating, max_rating),
+    )
+    pid = str(picked_state.get("today", "") or "")
+
+    summary = ""
+    model_tag = ""
+    sample_messages: tuple[str, ...] = ()
+    notes_message = ""
+    try:
+        if pid:
+            schedule_prefetch_editorial(pid)
+
+        statement = load_statement_json(group_id, pid) if pid else {}
+        statement_text = ""
+        input_text = ""
+        limits_text = ""
+        if statement:
+            statement_text = str(statement.get("description", "") or "")
+            input_text = str(statement.get("input", "") or "")
+            limits_text = (
+                f"Time: {statement.get('time_limit', '?')}, "
+                f"Memory: {statement.get('memory_limit', '?')}"
+            )
+            sample_messages = build_sample_messages(statement)
+            notes_message = await build_notes_message(statement)
+
+        images = statement_images(statement)
+        generated, model_tag = await summarize_problem(
+            statement_text,
+            input_text,
+            limits_text,
+            images,
+        )
+        if not generated:
+            logger.warning("[group_%s] Summary 1st attempt failed, retrying...", group_id)
+            generated, model_tag = await summarize_problem(
+                statement_text,
+                input_text,
+                limits_text,
+                images,
+            )
+        if generated:
+            summary = generated.strip()
+        else:
+            logger.warning("[group_%s] Summary failed after retry", group_id)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        logger.warning("[group_%s] Summary error: %s", group_id, exc)
+
+    return PreparedProblem(
+        state=dict(picked_state),
+        summary=summary,
+        model_tag=model_tag,
+        sample_messages=sample_messages,
+        notes_message=notes_message,
+        min_rating=min_rating,
+        max_rating=max_rating,
+        prepared_at=int(time.time()),
+    )
+
+
+def format_previous_problem_reveal(problem: object) -> str:
+    """Format the existing reveal message without spawning the picker CLI."""
+    if not isinstance(problem, dict) or not problem:
+        return "还没有发过题哦"
+    parts = [f"CF{problem.get('today', '?')}"]
+    name = str(problem.get("name", "") or "")
+    rating = str(problem.get("rating", "") or "")
+    if name:
+        parts.append(name)
+    if rating:
+        parts.append(rating)
+    return f"上一道题来自 {' '.join(parts)}✨"

--- a/src/kouhai_bot/problem_summary.py
+++ b/src/kouhai_bot/problem_summary.py
@@ -1,0 +1,100 @@
+"""Complete, side-effect-free preparation of an audited problem summary."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from enum import Enum
+
+from .problem_content import statement_fingerprint, statement_images
+
+logger = logging.getLogger("kouhai-bot.problem_summary")
+
+SummaryGenerator = Callable[
+    [str, str, str, list[dict]],
+    Awaitable[tuple[str | None, str]],
+]
+
+
+class SummaryPreparationStatus(str, Enum):
+    READY = "ready"
+    INCOMPLETE = "incomplete"
+
+
+@dataclass(frozen=True)
+class PreparedSummary:
+    """A summary already accepted by the generator's semantic audit."""
+
+    text: str
+    model_tag: str
+    source_sha256: str
+
+
+@dataclass(frozen=True)
+class SummaryPreparationResult:
+    status: SummaryPreparationStatus
+    prepared: PreparedSummary | None = None
+    reason: str = ""
+
+
+async def prepare_problem_summary(
+    statement: dict,
+    *,
+    generate: SummaryGenerator,
+    attempts: int,
+) -> SummaryPreparationResult:
+    """Run the complete summary action without writing cache or publication state."""
+    source_sha256 = statement_fingerprint(statement)
+    if not source_sha256:
+        return SummaryPreparationResult(
+            SummaryPreparationStatus.INCOMPLETE,
+            reason="statement_missing",
+        )
+
+    statement_text = str(statement.get("description", "") or "")
+    input_text = str(statement.get("input", "") or "")
+    limits_text = (
+        f"Time: {statement.get('time_limit', '?')}, "
+        f"Memory: {statement.get('memory_limit', '?')}"
+    )
+    images = statement_images(statement)
+    attempt_count = max(1, int(attempts))
+    last_reason = "summary_unavailable"
+    for attempt in range(attempt_count):
+        try:
+            summary, model_tag = await generate(
+                statement_text,
+                input_text,
+                limits_text,
+                images,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            last_reason = f"summary_error:{type(exc).__name__}"
+            logger.warning(
+                "summary preparation attempt %s/%s failed: %s",
+                attempt + 1,
+                attempt_count,
+                exc,
+                exc_info=True,
+            )
+            continue
+        text = (summary or "").strip()
+        if text:
+            return SummaryPreparationResult(
+                SummaryPreparationStatus.READY,
+                prepared=PreparedSummary(
+                    text=text,
+                    model_tag=(model_tag or "").strip(),
+                    source_sha256=source_sha256,
+                ),
+            )
+        last_reason = "summary_generator_returned_no_verified_result"
+
+    return SummaryPreparationResult(
+        SummaryPreparationStatus.INCOMPLETE,
+        reason=last_reason,
+    )

--- a/src/kouhai_bot/problems/content.py
+++ b/src/kouhai_bot/problems/content.py
@@ -1,0 +1,23 @@
+"""Pure helpers for normalizing cached Codeforces statement content."""
+
+from __future__ import annotations
+
+import html
+import re
+
+
+def normalize_sample_block(raw_html: object) -> str:
+    """Convert a Codeforces sample/Notes HTML block to plain text."""
+    text = str(raw_html or "")
+    text = re.sub(r"(?i)<br\s*/?>", "\n", text)
+    text = re.sub(r"(?i)</div>\s*<div[^>]*>", "\n", text)
+    text = re.sub(r"(?i)<div[^>]*>", "", text)
+    text = re.sub(r"(?i)</div>", "\n", text)
+    text = re.sub(r"<[^>]+>", "", text)
+    text = html.unescape(text).replace("\r", "")
+    lines = [line.rstrip() for line in text.split("\n")]
+    while lines and lines[0] == "":
+        lines.pop(0)
+    while lines and lines[-1] == "":
+        lines.pop()
+    return "\n".join(lines)

--- a/src/kouhai_bot/problems/picker.py
+++ b/src/kouhai_bot/problems/picker.py
@@ -7,7 +7,6 @@ Usage:
 """
 
 import hashlib
-import html
 import json
 import os
 import random
@@ -18,10 +17,12 @@ from datetime import datetime, timezone, timedelta
 
 try:
     from . import cf_fetcher, fetcher as cf_statement
+    from .content import normalize_sample_block as _normalize_sample_block
 except ImportError:  # Support direct execution of this file.
     sys.path.insert(0, os.path.dirname(__file__))
     import cf_fetcher
     import fetcher as cf_statement
+    from content import normalize_sample_block as _normalize_sample_block
 
 import cloudscraper
 
@@ -235,27 +236,6 @@ def select_problem() -> dict:
 
 def _cache_path(pid: str) -> str:
     return os.path.join(CACHE_DIR, f"{pid}.json")
-
-
-def _normalize_sample_block(raw_html: str) -> str:
-    """Convert CF sample HTML block to plain text with newlines."""
-    text = raw_html or ""
-    # CF has two sample styles:
-    # - classic <br />
-    # - split lines wrapped by <div class="test-example-line ...">
-    text = re.sub(r"(?i)<br\s*/?>", "\n", text)
-    text = re.sub(r"(?i)</div>\s*<div[^>]*>", "\n", text)
-    text = re.sub(r"(?i)<div[^>]*>", "", text)
-    text = re.sub(r"(?i)</div>", "\n", text)
-    text = re.sub(r"<[^>]+>", "", text)
-    text = html.unescape(text).replace("\r", "")
-    # Keep internal blank lines if any; trim only edges and trailing spaces.
-    lines = [line.rstrip() for line in text.split("\n")]
-    while lines and lines[0] == "":
-        lines.pop(0)
-    while lines and lines[-1] == "":
-        lines.pop()
-    return "\n".join(lines)
 
 
 def _normalize_samples(samples: list[dict]) -> tuple[list[dict], bool]:
@@ -509,23 +489,28 @@ def format_problem_for_qq(p: dict) -> str:
     return f"CF{contest_id}{index} — {name} (rating {rating})"
 
 
-def reveal() -> str:
-    """Reveal the previous problem."""
-    if not os.path.exists(_state_file()):
+def format_reveal(problem: object) -> str:
+    """Format one current-problem state as the previous-problem reveal."""
+    if not isinstance(problem, dict) or not problem:
         return "还没有发过题哦"
 
-    with open(_state_file()) as f:
-        state = json.load(f)
-
-    cf_id = state.get("today", "?")
-    name = state.get("name", "")
-    rating = state.get("rating", "")
+    cf_id = problem.get("today", "?")
+    name = problem.get("name", "")
+    rating = problem.get("rating", "")
     parts = [f"CF{cf_id}"]
     if name:
         parts.append(name)
     if rating:
         parts.append(f"{rating}")
     return f"上一道题来自 {' '.join(parts)}✨"
+
+
+def reveal() -> str:
+    """Reveal the previous problem."""
+    if not os.path.exists(_state_file()):
+        return format_reveal(None)
+    with open(_state_file()) as f:
+        return format_reveal(json.load(f))
 
 
 # ── CLI ─────────────────────────────────────────────────────────────────

--- a/src/kouhai_bot/problems/picker.py
+++ b/src/kouhai_bot/problems/picker.py
@@ -117,6 +117,20 @@ def _load_solved_problem_ids() -> set[str]:
     }
 
 
+def _load_current_problem_id() -> str:
+    path = _state_file()
+    if not os.path.exists(path):
+        return ""
+    try:
+        with open(path) as f:
+            state = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return ""
+    if not isinstance(state, dict):
+        return ""
+    return str(state.get("today", "") or "").strip()
+
+
 def _problem_id(p: dict) -> str:
     return f"{p['contestId']}{p['index']}"
 
@@ -190,14 +204,24 @@ def select_problem() -> dict:
 
     used = _load_used()
     solved = _load_solved_problem_ids()
+    current = _load_current_problem_id()
+    excluded = used | solved
+    if current:
+        excluded.add(current)
 
     # Filter to unused and unsolved problems. solved comes from scoreboard.json so
     # historical solves remain excluded even if used.json is lost or rebuilt.
-    available = [p for p in problems if _problem_id(p) not in used | solved]
+    # state.json additionally protects the active unsolved problem if used.json
+    # is lost while the next-problem prefetcher is rebuilding.
+    available = [p for p in problems if _problem_id(p) not in excluded]
     if not available:
         # All unsolved problems have been used in this cycle - reset only used.
         _save_used(set())
-        available = [p for p in problems if _problem_id(p) not in solved]
+        available = [
+            p for p in problems
+            if _problem_id(p) not in solved
+            and _problem_id(p) != current
+        ]
         if not available:
             raise RuntimeError(
                 f"No unsolved problems found in range {RATING_MIN}-{RATING_MAX}"

--- a/src/kouhai_bot/runtime.py
+++ b/src/kouhai_bot/runtime.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import sys
 
-from .editorial_followup import schedule_prefetch_for_current_group
 from .handlers.registry import discover_commands
 from .scheduler.jobs import register_builtin_jobs
 
@@ -28,5 +27,4 @@ def bootstrap_runtime() -> None:
         return
     discover_commands()
     register_builtin_jobs()
-    schedule_prefetch_for_current_group()
     _BOOTSTRAPPED = True

--- a/src/kouhai_bot/tutorials.py
+++ b/src/kouhai_bot/tutorials.py
@@ -19,6 +19,7 @@ from .handlers.shared import translate_editorial_to_zh
 from .llm import strip_leaked_thinking
 
 MIN_EDITORIAL_LEN = 80
+NO_EDITORIAL_MARKER_VERSION = 1
 _REVIEW_EDITORIAL_MAX_LEN = 12000
 
 logger = logging.getLogger("kouhai-bot.tutorials")
@@ -168,17 +169,22 @@ def _tools_dir() -> Path:
     return Path(__file__).resolve().parents[2] / "tools"
 
 
-def _load_tutorial_agent() -> tuple[type[Exception], type[Exception], Any]:
+def _load_tutorial_agent() -> tuple[
+    type[Exception],
+    type[Exception],
+    type[Exception],
+    Any,
+]:
     tools_dir = _tools_dir()
     if tools_dir.is_dir():
         tools_dir_str = str(tools_dir)
         if tools_dir_str not in sys.path:
             sys.path.insert(0, tools_dir_str)
 
-    from cf_tutorial_agent import AgentNoMatch, run_agent_for_pid
+    from cf_tutorial_agent import AgentIncomplete, AgentNoMatch, run_agent_for_pid
     from scrape_cf_tutorial import ScrapeError
 
-    return AgentNoMatch, ScrapeError, run_agent_for_pid
+    return AgentNoMatch, AgentIncomplete, ScrapeError, run_agent_for_pid
 
 
 def _write_tutorial_bundle(pid: str, bundle: dict) -> None:
@@ -207,7 +213,12 @@ async def ensure_tutorial_json(pid: str) -> bool:
         return False
 
     try:
-        AgentNoMatch, ScrapeError, run_agent_for_pid = _load_tutorial_agent()
+        (
+            AgentNoMatch,
+            AgentIncomplete,
+            ScrapeError,
+            run_agent_for_pid,
+        ) = _load_tutorial_agent()
     except Exception as e:
         logger.warning("tutorial agent unavailable for %s: %s", pid, e, exc_info=True)
         return False
@@ -216,6 +227,10 @@ async def ensure_tutorial_json(pid: str) -> bool:
         result = await run_agent_for_pid(pid=pid, statements_dir=statements_dir)
     except AgentNoMatch as e:
         logger.info("tutorial agent found no official editorial for %s: %s", pid, e)
+        mark_no_official_editorial(pid, reason=f"agent_no_match:{e}")
+        return False
+    except AgentIncomplete as e:
+        logger.warning("tutorial agent did not finish reliably for %s: %s", pid, e)
         return False
     except ScrapeError as e:
         logger.warning("tutorial agent scrape failed for %s: %s", pid, e)
@@ -306,13 +321,37 @@ def _save_cached_translation(pid: str, text: str) -> None:
 
 
 def is_no_official_editorial(pid: str) -> bool:
-    return os.path.isfile(_no_editorial_marker_path(pid))
-
-
-def mark_no_official_editorial(pid: str) -> None:
     marker = _no_editorial_marker_path(pid)
-    with open(marker, "w", encoding="utf-8"):
-        pass
+    if not os.path.isfile(marker):
+        return False
+    try:
+        with open(marker, encoding="utf-8") as f:
+            payload = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        # Legacy zero-byte markers may represent transient failures from the
+        # old boolean pipeline, so they are deliberately not trusted.
+        return False
+    return (
+        isinstance(payload, dict)
+        and payload.get("format_version") == NO_EDITORIAL_MARKER_VERSION
+        and payload.get("status") == "no_editorial"
+        and bool(str(payload.get("reason", "") or "").strip())
+    )
+
+
+def mark_no_official_editorial(pid: str, *, reason: str = "confirmed_no_match") -> None:
+    marker = _no_editorial_marker_path(pid)
+    with open(marker, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "format_version": NO_EDITORIAL_MARKER_VERSION,
+                "status": "no_editorial",
+                "reason": reason,
+            },
+            f,
+            ensure_ascii=False,
+            indent=2,
+        )
     path = _translation_cache_path(pid)
     if os.path.isfile(path):
         os.remove(path)
@@ -356,7 +395,7 @@ async def prefetch_editorial_zh(pid: str, *, run_agent: bool = True) -> None:
             return
         clear_no_official_editorial_marker(pid)
     if not editorial:
-        mark_no_official_editorial(pid)
+        logger.info("editorial prefetch remains incomplete for %s", pid)
         return
     await get_editorial_zh_for_group(editorial, pid)
 
@@ -378,7 +417,10 @@ async def get_editorial_zh_for_group(editorial: OfficialEditorial, pid: str) -> 
         images=problem_images,
     )
     if matched is False:
-        mark_no_official_editorial(pid)
+        mark_no_official_editorial(
+            pid,
+            reason="translation_explicit_mismatch",
+        )
         return None, ""
     if not translated:
         return None, ""

--- a/src/kouhai_bot/tutorials.py
+++ b/src/kouhai_bot/tutorials.py
@@ -5,153 +5,35 @@ Extraction rules align with tools/scrape_cf_tutorial.py normalization (hint/solu
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
-import re
-import sys
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 from .config import get_config
-from .handlers.shared import translate_editorial_to_zh
+from .editorial_content import (
+    MIN_EDITORIAL_LEN,
+    OfficialEditorial,
+    bundle_for_editorial,
+    editorial_from_bundle,
+    extract_editorial,
+    is_placeholder as _is_placeholder,
+)
+from .editorial_preparation import (
+    EditorialPreparationStatus,
+    PreparedEditorial,
+    _load_tutorial_agent,
+    prepare_editorial,
+)
 from .llm import strip_leaked_thinking
+from .problem_content import load_statement_json, statement_fingerprint
 
-MIN_EDITORIAL_LEN = 80
-NO_EDITORIAL_MARKER_VERSION = 1
+NO_EDITORIAL_MARKER_VERSION = 3
+VERIFIED_EDITORIAL_MARKER_VERSION = 2
 _REVIEW_EDITORIAL_MAX_LEN = 12000
 
 logger = logging.getLogger("kouhai-bot.tutorials")
-
-_PLACEHOLDER_RE = re.compile(
-    r"Tutorial is loading|Will be added soon",
-    re.I,
-)
-_SHORT_SOLUTION_RE = re.compile(r"^.+solution$", re.I | re.S)
-_SECTION_MARKER_RE = re.compile(
-    r"Hint(?:\s*\d+)?|Solution(?:\s+with[\s\S]*)?|Solution\s*\([^)]*\)"
-    r"|Tutorial|Editorial|Code(?:\s*\([^)]+\))?",
-    re.I,
-)
-_AUTHOR_LINE_RE = re.compile(r"^authors?\s*&\s*preparation", re.I)
-
-
-@dataclass(frozen=True)
-class OfficialEditorial:
-    text: str
-    tutorial_url: str
-    tutorial_title: str
-
-
-def _is_placeholder(text: str) -> bool:
-    stripped = text.strip()
-    if not stripped:
-        return True
-    if _PLACEHOLDER_RE.search(stripped):
-        return True
-    if len(stripped) < 60 and _SHORT_SOLUTION_RE.fullmatch(stripped):
-        return True
-    return False
-
-
-def _is_section_marker(line: str) -> bool:
-    token = line.strip().strip("*").strip()
-    return bool(_SECTION_MARKER_RE.fullmatch(token))
-
-
-def _clean_raw_text(raw_text: str) -> str:
-    lines = raw_text.splitlines()
-    out: list[str] = []
-    for ln in lines:
-        t = ln.strip()
-        if not out and (_AUTHOR_LINE_RE.match(t) or t.lower() == "editorial"):
-            continue
-        if _is_section_marker(t):
-            continue
-        out.append(ln)
-    return "\n".join(out).strip()
-
-
-def _append_code_blocks(body: str, code_blocks: list[str]) -> str:
-    codes = [c.strip() for c in code_blocks if c and c.strip()]
-    if not codes:
-        return body
-    code_part = "\n\n".join(f"```\n{c}\n```" for c in codes)
-    if body:
-        return f"{body}\n\n{code_part}".strip()
-    return code_part
-
-
-def extract_editorial(section: dict) -> str:
-    """Extract editorial body from one tutorial section dict."""
-    hint = (section.get("hint") or "").strip()
-    solution = (section.get("solution") or "").strip()
-    raw_text = (section.get("raw_text") or "").strip()
-    code_blocks = section.get("code_blocks") or []
-
-    body = ""
-    if solution and not _is_placeholder(solution):
-        body = solution
-    elif hint and not _is_placeholder(hint):
-        body = hint
-    elif raw_text:
-        body = _clean_raw_text(raw_text)
-        if _is_placeholder(body):
-            body = ""
-
-    return _append_code_blocks(body, code_blocks)
-
-
-def _load_problem_statement_for_editorial(pid: str) -> str:
-    path = os.path.join(get_config().data_dir, "statements", f"{pid}.json")
-    if not os.path.isfile(path):
-        return ""
-    try:
-        with open(path, encoding="utf-8") as f:
-            stmt = json.load(f)
-    except (OSError, json.JSONDecodeError):
-        return ""
-
-    parts: list[str] = []
-    if stmt.get("name"):
-        parts.append(f"Problem: {stmt['name']}")
-    if stmt.get("time_limit"):
-        parts.append(f"Time limit: {stmt['time_limit']}")
-    if stmt.get("memory_limit"):
-        parts.append(f"Memory limit: {stmt['memory_limit']}")
-    for label, key in [
-        ("Description", "description"),
-        ("Input", "input"),
-        ("Output", "output"),
-        ("Note", "notes"),
-    ]:
-        value = (stmt.get(key) or "").strip()
-        if value:
-            parts.append(f"\n{label}:\n{value}")
-    samples = stmt.get("samples") or []
-    if isinstance(samples, list):
-        for sample in samples:
-            if not isinstance(sample, dict):
-                continue
-            parts.append(
-                f"\nInput:\n{sample.get('input', '')}\n"
-                f"Output:\n{sample.get('output', '')}"
-            )
-    return "\n".join(parts)
-
-
-def _load_problem_images_for_editorial(pid: str) -> list[dict]:
-    path = os.path.join(get_config().data_dir, "statements", f"{pid}.json")
-    if not os.path.isfile(path):
-        return []
-    try:
-        with open(path, encoding="utf-8") as f:
-            stmt = json.load(f)
-    except (OSError, json.JSONDecodeError):
-        return []
-    images = stmt.get("images", []) if isinstance(stmt, dict) else []
-    return [item for item in images if isinstance(item, dict) and item.get("src")]
 
 
 def load_tutorial(pid: str) -> dict | None:
@@ -165,28 +47,6 @@ def load_tutorial(pid: str) -> dict | None:
         return None
 
 
-def _tools_dir() -> Path:
-    return Path(__file__).resolve().parents[2] / "tools"
-
-
-def _load_tutorial_agent() -> tuple[
-    type[Exception],
-    type[Exception],
-    type[Exception],
-    Any,
-]:
-    tools_dir = _tools_dir()
-    if tools_dir.is_dir():
-        tools_dir_str = str(tools_dir)
-        if tools_dir_str not in sys.path:
-            sys.path.insert(0, tools_dir_str)
-
-    from cf_tutorial_agent import AgentIncomplete, AgentNoMatch, run_agent_for_pid
-    from scrape_cf_tutorial import ScrapeError
-
-    return AgentNoMatch, AgentIncomplete, ScrapeError, run_agent_for_pid
-
-
 def _write_tutorial_bundle(pid: str, bundle: dict) -> None:
     tutorials_dir = Path(get_config().data_dir) / "tutorials"
     tutorials_dir.mkdir(parents=True, exist_ok=True)
@@ -196,86 +56,24 @@ def _write_tutorial_bundle(pid: str, bundle: dict) -> None:
     os.replace(tmp_path, out_path)
 
 
+def _remove_tutorial_bundle(pid: str) -> None:
+    path = Path(get_config().data_dir) / "tutorials" / f"{pid}.json"
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.warning("failed to remove rejected tutorial JSON for %s: %s", pid, exc)
+
+
 async def ensure_tutorial_json(pid: str) -> bool:
-    """Run the CF tutorial agent if no usable tutorial JSON is cached."""
-    pid = (pid or "").strip()
-    if not pid:
-        return False
-    if get_official_editorial(pid) is not None:
-        clear_no_official_editorial_marker(pid)
-        return True
-
-    cfg = get_config()
-    statements_dir = Path(cfg.data_dir) / "statements"
-    statement_path = statements_dir / f"{pid}.json"
-    if not statement_path.is_file():
-        logger.info("tutorial agent skipped for %s: statement cache missing", pid)
-        return False
-
-    try:
-        (
-            AgentNoMatch,
-            AgentIncomplete,
-            ScrapeError,
-            run_agent_for_pid,
-        ) = _load_tutorial_agent()
-    except Exception as e:
-        logger.warning("tutorial agent unavailable for %s: %s", pid, e, exc_info=True)
-        return False
-
-    try:
-        result = await run_agent_for_pid(pid=pid, statements_dir=statements_dir)
-    except AgentNoMatch as e:
-        logger.info("tutorial agent found no official editorial for %s: %s", pid, e)
-        mark_no_official_editorial(pid, reason=f"agent_no_match:{e}")
-        return False
-    except AgentIncomplete as e:
-        logger.warning("tutorial agent did not finish reliably for %s: %s", pid, e)
-        return False
-    except ScrapeError as e:
-        logger.warning("tutorial agent scrape failed for %s: %s", pid, e)
-        return False
-    except Exception as e:
-        logger.warning("tutorial agent failed for %s: %s", pid, e, exc_info=True)
-        return False
-
-    try:
-        _write_tutorial_bundle(pid, result.bundle)
-    except OSError as e:
-        logger.warning("failed to write tutorial JSON for %s: %s", pid, e, exc_info=True)
-        return False
-
-    if get_official_editorial(pid) is None:
-        logger.warning("tutorial agent wrote unusable tutorial JSON for %s", pid)
-        return False
-
-    clear_no_official_editorial_marker(pid)
-    logger.info(
-        "tutorial agent cached official editorial for %s "
-        "candidate=%s confidence=%.2f elapsed=%.1fs",
-        pid,
-        result.selected_candidate_id,
-        result.confidence,
-        result.elapsed_sec,
-    )
-    return True
+    """Compatibility entry point: prepare and persist only a verified result."""
+    await prefetch_editorial_zh(pid, run_agent=True)
+    return has_cached_editorial_zh(pid)
 
 
 def get_official_editorial(pid: str) -> OfficialEditorial | None:
-    bundle = load_tutorial(pid)
-    if not bundle:
-        return None
-    sections = bundle.get("sections") or []
-    if not sections:
-        return None
-    text = extract_editorial(sections[0])
-    if len(text) < MIN_EDITORIAL_LEN:
-        return None
-    return OfficialEditorial(
-        text=text,
-        tutorial_url=(bundle.get("tutorial_url") or "").strip(),
-        tutorial_title=(bundle.get("tutorial_title") or "").strip(),
-    )
+    return editorial_from_bundle(load_tutorial(pid))
 
 
 def _translation_cache_dir() -> str:
@@ -296,6 +94,18 @@ def _verified_editorial_marker_path(pid: str) -> str:
     return os.path.join(_translation_cache_dir(), f"{pid}.verified")
 
 
+def _editorial_fingerprint(editorial: OfficialEditorial) -> str:
+    payload = "\0".join(
+        [editorial.tutorial_url, editorial.tutorial_title, editorial.text]
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _current_statement_fingerprint(pid: str) -> str:
+    statement = load_statement_json(pid, data_dir=get_config().data_dir)
+    return statement_fingerprint(statement)
+
+
 def _load_cached_translation(pid: str) -> str:
     path = _translation_cache_path(pid)
     if not os.path.isfile(path):
@@ -307,17 +117,66 @@ def _load_cached_translation(pid: str) -> str:
         return ""
 
 
-def _save_cached_translation(pid: str, text: str) -> None:
-    text = strip_leaked_thinking(text)
+def _save_cached_translation(
+    pid: str,
+    text: str,
+    editorial: OfficialEditorial,
+    *,
+    statement_sha256: str = "",
+) -> bool:
+    current_statement_sha256 = _current_statement_fingerprint(pid)
+    if (
+        not current_statement_sha256
+        or (
+            statement_sha256
+            and statement_sha256 != current_statement_sha256
+        )
+    ):
+        logger.warning(
+            "refusing to mark editorial translation verified for %s: "
+            "statement source does not match",
+            pid,
+        )
+        return False
+    persisted = get_official_editorial(pid)
+    if (
+        persisted is None
+        or _editorial_fingerprint(persisted) != _editorial_fingerprint(editorial)
+    ):
+        logger.warning(
+            "refusing to mark editorial translation verified for %s: "
+            "persisted source does not match",
+            pid,
+        )
+        return False
+    text = strip_leaked_thinking(text).strip()
+    if len(text) < MIN_EDITORIAL_LEN:
+        logger.warning(
+            "refusing to mark editorial translation verified for %s: "
+            "translated content is incomplete",
+            pid,
+        )
+        return False
     path = _translation_cache_path(pid)
     with open(path, "w", encoding="utf-8") as f:
         f.write(text)
     verified = _verified_editorial_marker_path(pid)
-    with open(verified, "w", encoding="utf-8"):
-        pass
+    with open(verified, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "format_version": VERIFIED_EDITORIAL_MARKER_VERSION,
+                "status": "verified",
+                "source_sha256": _editorial_fingerprint(editorial),
+                "statement_sha256": current_statement_sha256,
+            },
+            f,
+            ensure_ascii=False,
+            indent=2,
+        )
     marker = _no_editorial_marker_path(pid)
     if os.path.isfile(marker):
         os.remove(marker)
+    return True
 
 
 def is_no_official_editorial(pid: str) -> bool:
@@ -335,18 +194,36 @@ def is_no_official_editorial(pid: str) -> bool:
         isinstance(payload, dict)
         and payload.get("format_version") == NO_EDITORIAL_MARKER_VERSION
         and payload.get("status") == "no_editorial"
+        and payload.get("search_complete") is True
+        and payload.get("statement_sha256") == _current_statement_fingerprint(pid)
         and bool(str(payload.get("reason", "") or "").strip())
     )
 
 
-def mark_no_official_editorial(pid: str, *, reason: str = "confirmed_no_match") -> None:
+def mark_no_official_editorial(
+    pid: str,
+    *,
+    reason: str,
+    statement_sha256: str = "",
+) -> None:
+    """Persist only a completed, exhaustive no-editorial result."""
+    reason = (reason or "").strip()
+    if not reason:
+        raise ValueError(f"cannot mark no editorial for {pid}: reason missing")
+    current_statement_sha256 = _current_statement_fingerprint(pid)
+    if not current_statement_sha256:
+        raise ValueError(f"cannot mark no editorial for {pid}: statement missing")
+    if statement_sha256 and statement_sha256 != current_statement_sha256:
+        raise ValueError(f"cannot mark no editorial for stale statement {pid}")
     marker = _no_editorial_marker_path(pid)
     with open(marker, "w", encoding="utf-8") as f:
         json.dump(
             {
                 "format_version": NO_EDITORIAL_MARKER_VERSION,
                 "status": "no_editorial",
+                "search_complete": True,
                 "reason": reason,
+                "statement_sha256": current_statement_sha256,
             },
             f,
             ensure_ascii=False,
@@ -358,6 +235,7 @@ def mark_no_official_editorial(pid: str, *, reason: str = "confirmed_no_match") 
     verified = _verified_editorial_marker_path(pid)
     if os.path.isfile(verified):
         os.remove(verified)
+    _remove_tutorial_bundle(pid)
 
 
 def clear_no_official_editorial_marker(pid: str) -> None:
@@ -367,70 +245,144 @@ def clear_no_official_editorial_marker(pid: str) -> None:
 
 
 def has_cached_editorial_zh(pid: str) -> bool:
-    if not os.path.isfile(_verified_editorial_marker_path(pid)):
+    if is_no_official_editorial(pid):
         return False
-    return len(_load_cached_translation(pid)) >= MIN_EDITORIAL_LEN
+    translated = _load_cached_translation(pid)
+    if len(translated) < MIN_EDITORIAL_LEN:
+        return False
+    editorial = get_official_editorial(pid)
+    if editorial is None:
+        return False
+    try:
+        with open(_verified_editorial_marker_path(pid), encoding="utf-8") as f:
+            payload = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return False
+    return (
+        isinstance(payload, dict)
+        and payload.get("format_version") == VERIFIED_EDITORIAL_MARKER_VERSION
+        and payload.get("status") == "verified"
+        and payload.get("source_sha256") == _editorial_fingerprint(editorial)
+        and payload.get("statement_sha256") == _current_statement_fingerprint(pid)
+    )
 
 
 def load_cached_editorial_zh(pid: str) -> str:
     return _load_cached_translation(pid)
 
 
+def get_verified_official_editorial(pid: str) -> OfficialEditorial | None:
+    if not has_cached_editorial_zh(pid):
+        return None
+    return get_official_editorial(pid)
+
+
+def _commit_prepared_editorial(pid: str, prepared: PreparedEditorial) -> bool:
+    """Publish prepared assets, writing the verified marker strictly last."""
+    if _current_statement_fingerprint(pid) != prepared.statement_sha256:
+        logger.warning(
+            "refusing to persist editorial for %s: statement changed during preparation",
+            pid,
+        )
+        return False
+    try:
+        _write_tutorial_bundle(pid, prepared.bundle)
+        return _save_cached_translation(
+            pid,
+            prepared.translated_text,
+            prepared.editorial,
+            statement_sha256=prepared.statement_sha256,
+        )
+    except OSError as exc:
+        logger.warning(
+            "failed to persist verified editorial for %s: %s",
+            pid,
+            exc,
+            exc_info=True,
+        )
+        return False
+
+
 async def prefetch_editorial_zh(pid: str, *, run_agent: bool = True) -> None:
-    """Translate editorial ahead of first AC; does not send to the group."""
-    if not pid or has_cached_editorial_zh(pid):
+    """Prepare and commit a verified editorial ahead of first AC."""
+    pid = (pid or "").strip()
+    if not pid or has_cached_editorial_zh(pid) or is_no_official_editorial(pid):
         return
-    editorial = get_official_editorial(pid)
-    if is_no_official_editorial(pid) and not run_agent:
-        if editorial is None:
-            return
-        clear_no_official_editorial_marker(pid)
-    if not run_agent and editorial is None:
+
+    initial_bundle = load_tutorial(pid)
+    result = await prepare_editorial(
+        pid,
+        initial_bundle=initial_bundle,
+        run_agent=run_agent,
+        data_dir=get_config().data_dir,
+    )
+    if (
+        result.status is EditorialPreparationStatus.READY
+        and result.prepared is not None
+    ):
+        if _commit_prepared_editorial(pid, result.prepared):
+            logger.info(
+                "editorial prefetch verified candidate for %s url=%s",
+                pid,
+                result.prepared.editorial.tutorial_url or "(missing)",
+            )
         return
-    if run_agent and editorial is None:
-        await ensure_tutorial_json(pid)
-        editorial = get_official_editorial(pid)
-    if is_no_official_editorial(pid):
-        if editorial is None:
-            return
-        clear_no_official_editorial_marker(pid)
-    if not editorial:
-        logger.info("editorial prefetch remains incomplete for %s", pid)
+
+    if result.status is EditorialPreparationStatus.EXHAUSTIVE_NO_MATCH:
+        mark_no_official_editorial(
+            pid,
+            reason=f"agent_exhaustive_no_match:{result.reason}",
+            statement_sha256=result.statement_sha256,
+        )
         return
-    await get_editorial_zh_for_group(editorial, pid)
+
+    if result.rejected_initial_candidate:
+        _remove_tutorial_bundle(pid)
+        logger.info(
+            "removed rejected legacy editorial candidate for %s",
+            pid,
+        )
+    logger.info(
+        "editorial prefetch remains incomplete for %s: %s",
+        pid,
+        result.reason,
+    )
 
 
-async def get_editorial_zh_for_group(editorial: OfficialEditorial, pid: str) -> tuple[str | None, str]:
-    """Return Chinese editorial for group card; uses disk cache keyed by pid.
+async def get_editorial_zh_for_group(
+    editorial: OfficialEditorial,
+    pid: str,
+) -> tuple[str | None, str]:
+    """Compatibility entry point for validating one supplied editorial.
 
     Returns (translated_text, model_tag). model_tag is empty for cache hits.
     """
     if has_cached_editorial_zh(pid):
         return _load_cached_translation(pid), ""
 
-    problem_text = _load_problem_statement_for_editorial(pid)
-    problem_images = _load_problem_images_for_editorial(pid)
-    translated, model_tag, matched = await translate_editorial_to_zh(
-        editorial.text,
-        pid=pid,
-        problem_text=problem_text,
-        images=problem_images,
+    persisted_bundle = load_tutorial(pid)
+    persisted_editorial = editorial_from_bundle(persisted_bundle)
+    if (
+        persisted_editorial is not None
+        and _editorial_fingerprint(persisted_editorial)
+        == _editorial_fingerprint(editorial)
+    ):
+        initial_bundle = persisted_bundle
+    else:
+        initial_bundle = bundle_for_editorial(editorial)
+    result = await prepare_editorial(
+        pid,
+        initial_bundle=initial_bundle,
+        run_agent=False,
+        data_dir=get_config().data_dir,
     )
-    if matched is False:
-        mark_no_official_editorial(
-            pid,
-            reason="translation_explicit_mismatch",
-        )
+    if (
+        result.status is not EditorialPreparationStatus.READY
+        or result.prepared is None
+        or not _commit_prepared_editorial(pid, result.prepared)
+    ):
         return None, ""
-    if not translated:
-        return None, ""
-    translated = translated.strip()
-    if len(translated) < MIN_EDITORIAL_LEN:
-        return None, ""
-
-    full_text = (translated + model_tag).strip() if model_tag else translated
-    _save_cached_translation(pid, full_text)
-    return full_text, ""
+    return result.prepared.translated_text, ""
 
 
 def format_editorial_for_review(editorial: OfficialEditorial) -> str:

--- a/src/kouhai_bot/worker.py
+++ b/src/kouhai_bot/worker.py
@@ -11,6 +11,7 @@ from .config import get_config
 from .friend_requests import doubt_friend_request_loop
 from .handlers import process_event
 from .napcat.client import NapCatServer
+from .problem_prefetch import get_next_problem_prefetcher
 from .runtime import bootstrap_runtime, setup_logging
 from .scheduler.engine import scheduler_loop
 
@@ -24,8 +25,11 @@ class WorkerRuntime:
         self._shutdown = asyncio.Event()
         self._scheduler_stop = asyncio.Event()
         self._friend_request_stop = asyncio.Event()
+        self._problem_prefetch_stop = asyncio.Event()
         self._scheduler_task: asyncio.Task | None = None
         self._friend_request_task: asyncio.Task | None = None
+        self._problem_prefetch_task: asyncio.Task | None = None
+        self._problem_prefetcher = get_next_problem_prefetcher(self.cfg.current_group)
 
     async def run(self) -> None:
         bootstrap_runtime()
@@ -38,6 +42,10 @@ class WorkerRuntime:
             doubt_friend_request_loop(stop_event=self._friend_request_stop),
             name="worker_doubt_friend_requests",
         )
+        self._problem_prefetch_task = asyncio.create_task(
+            self._problem_prefetcher.run(stop_event=self._problem_prefetch_stop),
+            name="worker_next_problem_prefetch",
+        )
         self._install_signal_handlers()
         logger.info("Worker runtime is running. Press Ctrl+C to stop.")
         try:
@@ -49,13 +57,18 @@ class WorkerRuntime:
         self._shutdown.set()
         self._scheduler_stop.set()
         self._friend_request_stop.set()
+        self._problem_prefetch_stop.set()
         await self.napcat.stop()
+        await self._problem_prefetcher.shutdown()
         if self._scheduler_task is not None:
             with suppress(asyncio.CancelledError):
                 await self._scheduler_task
         if self._friend_request_task is not None:
             with suppress(asyncio.CancelledError):
                 await self._friend_request_task
+        if self._problem_prefetch_task is not None:
+            with suppress(asyncio.CancelledError):
+                await self._problem_prefetch_task
         await self._wait_for_background_tasks()
 
     async def _on_event(self, event: dict) -> None:
@@ -77,6 +90,7 @@ class WorkerRuntime:
                 if task is not current
                 and task is not self._scheduler_task
                 and task is not self._friend_request_task
+                and task is not self._problem_prefetch_task
                 and not task.done()
             ]
             if not pending:

--- a/src/kouhai_bot/worker.py
+++ b/src/kouhai_bot/worker.py
@@ -8,6 +8,10 @@ import signal
 from contextlib import suppress
 
 from .config import get_config
+from .editorial_followup import (
+    editorial_prefetch_maintenance_loop,
+    ensure_editorial_prefetch,
+)
 from .friend_requests import doubt_friend_request_loop
 from .handlers import process_event
 from .napcat.client import NapCatServer
@@ -26,10 +30,13 @@ class WorkerRuntime:
         self._scheduler_stop = asyncio.Event()
         self._friend_request_stop = asyncio.Event()
         self._problem_prefetch_stop = asyncio.Event()
+        self._editorial_prefetch_stop = asyncio.Event()
         self._scheduler_task: asyncio.Task | None = None
         self._friend_request_task: asyncio.Task | None = None
         self._problem_prefetch_task: asyncio.Task | None = None
+        self._editorial_prefetch_task: asyncio.Task | None = None
         self._problem_prefetcher = get_next_problem_prefetcher(self.cfg.current_group)
+        self._problem_prefetcher.set_ready_observer(ensure_editorial_prefetch)
 
     async def run(self) -> None:
         bootstrap_runtime()
@@ -46,6 +53,14 @@ class WorkerRuntime:
             self._problem_prefetcher.run(stop_event=self._problem_prefetch_stop),
             name="worker_next_problem_prefetch",
         )
+        self._editorial_prefetch_task = asyncio.create_task(
+            editorial_prefetch_maintenance_loop(
+                self.cfg.current_group,
+                get_next_problem_pid=self._problem_prefetcher.peek_pid,
+                stop_event=self._editorial_prefetch_stop,
+            ),
+            name="worker_editorial_prefetch_maintenance",
+        )
         self._install_signal_handlers()
         logger.info("Worker runtime is running. Press Ctrl+C to stop.")
         try:
@@ -58,6 +73,7 @@ class WorkerRuntime:
         self._scheduler_stop.set()
         self._friend_request_stop.set()
         self._problem_prefetch_stop.set()
+        self._editorial_prefetch_stop.set()
         await self.napcat.stop()
         await self._problem_prefetcher.shutdown()
         if self._scheduler_task is not None:
@@ -69,6 +85,9 @@ class WorkerRuntime:
         if self._problem_prefetch_task is not None:
             with suppress(asyncio.CancelledError):
                 await self._problem_prefetch_task
+        if self._editorial_prefetch_task is not None:
+            with suppress(asyncio.CancelledError):
+                await self._editorial_prefetch_task
         await self._wait_for_background_tasks()
 
     async def _on_event(self, event: dict) -> None:
@@ -91,6 +110,7 @@ class WorkerRuntime:
                 and task is not self._scheduler_task
                 and task is not self._friend_request_task
                 and task is not self._problem_prefetch_task
+                and task is not self._editorial_prefetch_task
                 and not task.done()
             ]
             if not pending:

--- a/tests/test_cf_tutorial_agent.py
+++ b/tests/test_cf_tutorial_agent.py
@@ -57,6 +57,104 @@ def test_extract_blog_links_prefers_tutorial_text():
     ]
 
 
+def test_collect_blog_documents_does_not_refetch_rejected_url():
+    problem_url = "https://codeforces.com/problemset/problem/1000/B"
+    rejected_url = "https://codeforces.com/blog/entry/2"
+    remaining_url = "https://codeforces.com/blog/entry/1"
+    pages = {
+        problem_url: _problem_page(),
+        remaining_url: _blog_page("<p>Remaining candidate body.</p>"),
+    }
+    fetched: list[str] = []
+
+    def fake_fetch(url, **_kwargs):
+        fetched.append(url)
+        if url == rejected_url:
+            raise AssertionError("rejected candidate must not be fetched again")
+        return pages[url]
+
+    with patch("cf_tutorial_agent.fetch_html", side_effect=fake_fetch), patch(
+        "cf_tutorial_agent.fetch_dynamic_editorial",
+        return_value=("", ""),
+    ):
+        _, _, blogs, incomplete = agent.collect_blog_documents(
+            pid="1000B",
+            fetcher="http",
+            pw_wait_ms=100,
+            blog_limit=2,
+            excluded_tutorial_urls=frozenset({rejected_url}),
+        )
+
+    assert fetched == [problem_url, remaining_url]
+    assert [blog.tutorial_url for blog in blogs] == [remaining_url]
+    assert incomplete == ()
+
+
+def test_collect_filters_rejected_urls_before_applying_candidate_limit():
+    problem_url = "https://codeforces.com/problemset/problem/1000/B"
+    rejected_urls = frozenset(
+        f"https://codeforces.com/blog/entry/{idx}" for idx in range(1, 4)
+    )
+    remaining_url = "https://codeforces.com/blog/entry/4"
+    problem_page = "".join(
+        f'<a href="/blog/entry/{idx}">Tutorial {idx}</a>'
+        for idx in range(1, 5)
+    )
+    fetched: list[str] = []
+
+    def fake_fetch(url, **_kwargs):
+        fetched.append(url)
+        if url == problem_url:
+            return problem_page
+        if url in rejected_urls:
+            raise AssertionError("rejected candidate must not consume the limit")
+        assert url == remaining_url
+        return _blog_page("<p>Remaining candidate body.</p>")
+
+    with patch("cf_tutorial_agent.fetch_html", side_effect=fake_fetch), patch(
+        "cf_tutorial_agent.fetch_dynamic_editorial",
+        return_value=("", ""),
+    ):
+        _, _, blogs, incomplete = agent.collect_blog_documents(
+            pid="1000B",
+            fetcher="http",
+            pw_wait_ms=100,
+            blog_limit=1,
+            excluded_tutorial_urls=rejected_urls,
+        )
+
+    assert fetched == [problem_url, remaining_url]
+    assert [blog.tutorial_url for blog in blogs] == [remaining_url]
+    assert incomplete == ()
+
+
+def test_collect_marks_bounded_candidate_search_incomplete():
+    problem_url = "https://codeforces.com/problemset/problem/1000/B"
+    pages = {
+        problem_url: _problem_page(),
+        "https://codeforces.com/blog/entry/2": _blog_page(
+            "<p>First candidate body.</p>"
+        ),
+    }
+
+    with patch(
+        "cf_tutorial_agent.fetch_html",
+        side_effect=lambda url, **_kwargs: pages[url],
+    ), patch(
+        "cf_tutorial_agent.fetch_dynamic_editorial",
+        return_value=("", ""),
+    ):
+        _, _, blogs, incomplete = agent.collect_blog_documents(
+            pid="1000B",
+            fetcher="http",
+            pw_wait_ms=100,
+            blog_limit=1,
+        )
+
+    assert len(blogs) == 1
+    assert incomplete == ("candidate_limit_reached",)
+
+
 def test_agent_extracts_editorial_from_full_blog_body(tmp_path):
     _write_statement(tmp_path)
     target_text = (
@@ -250,8 +348,14 @@ def test_agent_skips_placeholder_and_sends_only_valid_blog_to_llm(tmp_path):
 def test_agent_rejects_low_confidence_extraction(tmp_path):
     _write_statement(tmp_path)
     uncertain_text = ("Detailed but uncertain explanation with enough copied source text. " * 3) + "This is the unique final uncertain marker."
+    problem_page = """
+    <html><body>
+      <div class="title">B. Target Problem</div>
+      <a href="/blog/entry/2">Tutorial</a>
+    </body></html>
+    """
     pages = {
-        "https://codeforces.com/problemset/problem/1000/B": _problem_page(),
+        "https://codeforces.com/problemset/problem/1000/B": problem_page,
         "https://codeforces.com/blog/entry/2": _blog_page(f"<p>{uncertain_text}</p>"),
     }
 

--- a/tests/test_cf_tutorial_agent.py
+++ b/tests/test_cf_tutorial_agent.py
@@ -166,7 +166,7 @@ def test_agent_tries_next_blog_when_extractor_rejects_first(tmp_path):
     assert "prefix sums" in result.bundle["sections"][0]["solution"]
 
 
-def test_agent_rejects_placeholder_before_dynamic_fetch_or_llm(tmp_path):
+def test_agent_keeps_placeholder_retryable_without_dynamic_fetch_or_llm(tmp_path):
     _write_statement(tmp_path)
     pages = {
         "https://codeforces.com/problemset/problem/1000/B": _problem_page(),
@@ -179,7 +179,7 @@ def test_agent_rejects_placeholder_before_dynamic_fetch_or_llm(tmp_path):
     with patch("cf_tutorial_agent.fetch_html", side_effect=fake_fetch), \
             patch("cf_tutorial_agent.fetch_dynamic_editorial") as dynamic_fetch, \
             patch("cf_tutorial_agent.chat_completion") as llm_call:
-        with pytest.raises(agent.AgentNoMatch, match="no_readable_blog_bodies"):
+        with pytest.raises(agent.AgentIncomplete, match="invalid_blog_content"):
             asyncio.run(
                 agent.run_agent_for_pid(
                     pid="1000B",
@@ -289,6 +289,67 @@ def test_agent_rejects_low_confidence_extraction(tmp_path):
             assert "extractor_low_confidence" in str(exc)
         else:
             raise AssertionError("expected low confidence rejection")
+
+
+def test_agent_keeps_incomplete_extractor_failure_retryable(tmp_path, monkeypatch):
+    _write_statement(tmp_path)
+    blog = agent.BlogDocument(
+        blog_id="b1",
+        tutorial_url="https://codeforces.com/blog/entry/1",
+        tutorial_title="Editorial",
+        body="Detailed candidate body " * 10,
+    )
+
+    monkeypatch.setattr(
+        agent,
+        "collect_blog_documents",
+        lambda **_kwargs: (
+            "https://codeforces.com/problemset/problem/1000/B",
+            "Target Problem",
+            [blog],
+            (),
+        ),
+    )
+
+    async def incomplete(**_kwargs):
+        raise agent.AgentIncomplete("extractor_llm_failed:timeout")
+
+    monkeypatch.setattr(agent, "extract_editorial_from_blog", incomplete)
+
+    with pytest.raises(agent.AgentIncomplete, match="extractor_llm_failed"):
+        asyncio.run(
+            agent.run_agent_for_pid(
+                pid="1000B",
+                statements_dir=tmp_path,
+                deadline_sec=10,
+            )
+        )
+
+
+def test_extractor_empty_llm_result_is_incomplete(monkeypatch):
+    blog = agent.BlogDocument(
+        blog_id="b1",
+        tutorial_url="https://codeforces.com/blog/entry/1",
+        tutorial_title="Editorial",
+        body="Detailed official explanation " * 10,
+    )
+
+    async def empty_result(*_args, **_kwargs):
+        return ChatCompletionResult(text=None, failure_kind="timeout")
+
+    monkeypatch.setattr(agent, "chat_completion", empty_result)
+
+    with pytest.raises(agent.AgentIncomplete, match="extractor_llm_failed:timeout"):
+        asyncio.run(
+            agent.extract_editorial_from_blog(
+                pid="1000B",
+                problem_title="Target Problem",
+                problem_text="statement",
+                blog=blog,
+                timeout=5,
+                llm_text_limit=1000,
+            )
+        )
 
 
 def test_extractor_uses_json_repair(monkeypatch):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -118,6 +118,23 @@ def _write_group_file(group_id: int, filename: str, data: dict):
         json.dump(data, f, ensure_ascii=False, indent=2)
 
 
+def _verified_summary_record(pid: str, summary: str) -> dict:
+    from kouhai_bot.handlers.shared import PROBLEM_SUMMARY_FORMAT_VERSION
+    from kouhai_bot.problem_content import statement_fingerprint
+
+    with open(
+        os.path.join(_data_dir(), "statements", f"{pid}.json"),
+        encoding="utf-8",
+    ) as f:
+        source_sha256 = statement_fingerprint(json.load(f))
+    return {
+        "format_version": PROBLEM_SUMMARY_FORMAT_VERSION,
+        "status": "verified",
+        "source_sha256": source_sha256,
+        "summary_zh": summary,
+    }
+
+
 def _write_problem_ratings(group_id: int, data: dict):
     _write_group_file(group_id, "problem_ratings.json", data)
 
@@ -134,12 +151,39 @@ def _write_tutorial(pid: str, data: dict):
 
 
 def _write_editorial_translation(pid: str, text: str = "已验证中文题解。"):
+    from kouhai_bot.tutorials import (
+        VERIFIED_EDITORIAL_MARKER_VERSION,
+        _editorial_fingerprint,
+        get_official_editorial,
+    )
+    from kouhai_bot.problem_content import statement_fingerprint
+
     d = os.path.join(_data_dir(), "tutorial_translations")
     os.makedirs(d, exist_ok=True)
     with open(os.path.join(d, f"{pid}.txt"), "w", encoding="utf-8") as f:
         f.write(text * 20)
-    with open(os.path.join(d, f"{pid}.verified"), "w", encoding="utf-8"):
-        pass
+    with patch(
+        "kouhai_bot.tutorials.get_config",
+        return_value=SimpleNamespace(data_dir=_data_dir()),
+    ):
+        editorial = get_official_editorial(pid)
+        assert editorial is not None
+        fingerprint = _editorial_fingerprint(editorial)
+    with open(
+        os.path.join(_data_dir(), "statements", f"{pid}.json"),
+        encoding="utf-8",
+    ) as f:
+        problem_fingerprint = statement_fingerprint(json.load(f))
+    with open(os.path.join(d, f"{pid}.verified"), "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "format_version": VERIFIED_EDITORIAL_MARKER_VERSION,
+                "status": "verified",
+                "source_sha256": fingerprint,
+                "statement_sha256": problem_fingerprint,
+            },
+            f,
+        )
 
 
 def _fake_problem_prefetcher(
@@ -150,11 +194,18 @@ def _fake_problem_prefetcher(
     sample_messages: tuple[str, ...] = (),
     notes_message: str = "",
 ):
+    from kouhai_bot.problem_content import statement_fingerprint
+
+    pid = str(state.get("today", "") or "")
+    statement_path = os.path.join(_data_dir(), "statements", f"{pid}.json")
+    with open(statement_path, encoding="utf-8") as f:
+        source_sha256 = statement_fingerprint(json.load(f))
     prepared = SimpleNamespace(
         state=dict(state),
-        pid=str(state.get("today", "") or ""),
+        pid=pid,
         summary=summary,
         model_tag=model_tag,
+        statement_sha256=source_sha256,
         sample_messages=sample_messages,
         notes_message=notes_message,
     )
@@ -600,6 +651,7 @@ def test_submit_correct():
             "raw_text": editorial_body,
         }],
     })
+    _write_editorial_translation(PID, "官方题解中文翻译。")
     global _deepseek_response
     _deepseek_response = {"correct": True, "reason": "Correct divisor sum", "reply": ""}
 
@@ -629,7 +681,7 @@ def test_submit_correct():
 
     asyncio.run(_run_submit())
 
-    assert len(_second_judge_calls) == 0
+    assert len(_second_judge_calls) == 1
     assert _has_sent("恭喜") or _has_sent("通过") or _has_sent("solved"), \
         f"No congrats. Messages: {[_last_text()]}"
     assert _forwarded, f"Expected official tutorial forward, got: {_forwarded}"
@@ -1302,6 +1354,7 @@ def test_review_includes_editorial_in_llm_payload():
             "raw_text": editorial_body,
         }],
     })
+    _write_editorial_translation(PID)
     _write_scoreboard(GID, {
         "solves": [{
             "user_id": UID,
@@ -1326,6 +1379,48 @@ def test_review_includes_editorial_in_llm_payload():
     assert editorial_body[:40] in user_content
     _cleanup()
     print("✅ review: includes official editorial in LLM payload")
+
+
+def test_review_excludes_unverified_editorial_candidate():
+    _reset_state()
+    _setup_problem()
+    dirty_body = "known-wrong-editorial-" * 10
+    _write_tutorial(PID, {
+        "problem_id": PID,
+        "tutorial_url": "https://codeforces.com/blog/entry/wrong",
+        "tutorial_title": "Unverified",
+        "sections": [{
+            "label": "D",
+            "title": "Another Problem",
+            "hint": "",
+            "solution": dirty_body,
+            "code_blocks": [],
+            "raw_text": dirty_body,
+        }],
+    })
+    _write_scoreboard(GID, {
+        "solves": [{
+            "user_id": UID,
+            "nickname": "Alice",
+            "date": "2026-05-13",
+            "problem": PID,
+            "order": 1,
+        }],
+        "user_submissions": {},
+    })
+    global _deepseek_response
+    _deepseek_response = "只根据题面和用户记录复盘。"
+
+    with _all_patches():
+        from kouhai_bot.handlers.cmd.review import handle
+        asyncio.run(handle(**_kwargs(_make_event("/review 检查一下"))))
+
+    review_calls = [c for c in _deepseek_calls if c.get("task") == "review"]
+    assert review_calls
+    user_content = review_calls[-1]["messages"][-1]["content"]
+    assert "官方题解（仅你可见" not in user_content
+    assert dirty_body not in user_content
+    _cleanup()
 
 
 def test_review_includes_mentioned_user_context():
@@ -2090,7 +2185,7 @@ def test_private_clarify_uses_private_problem_summary():
         "samples": [{"input": "1", "output": "1"}],
     })
     _write_group_file(GID, "problem_summaries.json", {
-        PID2: {"summary_zh": "PRIVATE_PID_SUMMARY"},
+        PID2: _verified_summary_record(PID2, "PRIVATE_PID_SUMMARY"),
     })
     ctx_file = os.path.join(_data_dir(), "groups", f"groupctx_{GID}.json")
     with open(ctx_file, "w") as f:
@@ -4367,7 +4462,7 @@ def test_private_problem_card_hides_original_problem_identity():
         "samples": [{"input": "1", "output": "1"}],
     })
     _write_group_file(GID, "problem_summaries.json", {
-        PID: {"summary_zh": "SUMMARY_ONLY"},
+        PID: _verified_summary_record(PID, "SUMMARY_ONLY"),
     })
 
     with _all_patches():
@@ -4405,7 +4500,10 @@ def test_private_problem_card_strips_cached_problem_summary_thinking_tags():
         "samples": [],
     })
     _write_group_file(GID, "problem_summaries.json", {
-        PID: {"summary_zh": "<reasoning>hidden cached summary</reasoning>SUMMARY_ONLY"},
+        PID: _verified_summary_record(
+            PID,
+            "<reasoning>hidden cached summary</reasoning>SUMMARY_ONLY",
+        ),
     })
 
     with _all_patches():

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5,7 +5,8 @@ no-problem, with-problem, empty-input, cooldown.
 """
 
 import sys, os, json, asyncio, tempfile, shutil, time
-from contextlib import ExitStack
+from contextlib import ExitStack, suppress
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -65,6 +66,9 @@ def _reset_state():
         ],
     }
     _deepseek_calls.clear()
+    from kouhai_bot.problem_prefetch import reset_prefetchers_for_tests
+
+    reset_prefetchers_for_tests()
     _temp_dir = tempfile.mkdtemp(prefix="xcpc_test_")
     data_dir = os.path.join(_temp_dir, "data")
     os.makedirs(os.path.join(data_dir, "groups", str(GID)), exist_ok=True)
@@ -136,6 +140,29 @@ def _write_editorial_translation(pid: str, text: str = "已验证中文题解。
         f.write(text * 20)
     with open(os.path.join(d, f"{pid}.verified"), "w", encoding="utf-8"):
         pass
+
+
+def _fake_problem_prefetcher(
+    state: dict,
+    *,
+    summary: str = "summary",
+    model_tag: str = "",
+    sample_messages: tuple[str, ...] = (),
+    notes_message: str = "",
+):
+    prepared = SimpleNamespace(
+        state=dict(state),
+        pid=str(state.get("today", "") or ""),
+        summary=summary,
+        model_tag=model_tag,
+        sample_messages=sample_messages,
+        notes_message=notes_message,
+    )
+    slot = SimpleNamespace(slot_id="slot-1", problem=prepared)
+    return SimpleNamespace(
+        claim=AsyncMock(return_value=slot),
+        release=AsyncMock(),
+    )
 
 
 def _has_sent(substring: str) -> bool:
@@ -506,7 +533,9 @@ def _all_patches():
     stack.enter_context(patch("kouhai_bot.handlers.cmd.clear.react_emoji", _mock_react))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.newproblem.send_group_msg", _mock_send_group))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.newproblem.send_private_msg", _mock_send_private))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.newproblem.send_group_forward_msg", _mock_send_group_forward))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.newproblem.react_emoji", _mock_react))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.newproblem.schedule_prefetch_editorial"))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.stubs.send_group_msg", _mock_send_group))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.stubs.send_private_msg", _mock_send_private))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.setproblem.send_group_msg", _mock_send_group))
@@ -874,103 +903,180 @@ def test_submit_correct_schedules_editorial_without_blocking():
     print("✅ submit: editorial followup does not block coordinator")
 
 
-def test_newproblem_post_schedules_editorial_prefetch():
-  _reset_state()
-  pid = "542D"
-  state_dir = os.path.join(_data_dir(), "groups", str(GID))
-  os.makedirs(state_dir, exist_ok=True)
-  with open(os.path.join(state_dir, "state.json"), "w") as f:
-      json.dump({"today": pid}, f)
-  _write_statement(pid, {"description": "d", "input": "i", "time_limit": "1s", "memory_limit": "256MB"})
+def test_newproblem_post_uses_prepared_hot_path():
+    _reset_state()
+    pid = "542D"
+    state_dir = os.path.join(_data_dir(), "groups", str(GID))
+    os.makedirs(state_dir, exist_ok=True)
+    with open(os.path.join(state_dir, "state.json"), "w") as f:
+        json.dump({"today": "100A"}, f)
+    _write_statement(
+        pid,
+        {
+            "description": "d",
+            "input": "i",
+            "time_limit": "1s",
+            "memory_limit": "256MB",
+        },
+    )
 
-  scheduled: list[str] = []
-  summary_started = asyncio.Event()
+    payload = {
+        "today": pid,
+        "contestId": 542,
+        "index": "D",
+        "name": "Superhero's Job",
+        "rating": 2600,
+        "tags": [],
+        "date": "2026-05-22",
+    }
+    prefetcher = _fake_problem_prefetcher(payload, model_tag="『M』")
+    send_card = AsyncMock(return_value=(123, {}))
+    schedule_editorial = MagicMock()
 
-  def _record_prefetch(p):
-      scheduled.append(p)
+    async def _run():
+        with _all_patches(), \
+                patch(
+                    "kouhai_bot.handlers.cmd.newproblem.get_next_problem_prefetcher",
+                    return_value=prefetcher,
+                ), \
+                patch(
+                    "kouhai_bot.handlers.cmd.newproblem._send_problem_forward_card",
+                    send_card,
+                ), \
+                patch(
+                    "kouhai_bot.handlers.cmd.newproblem.save_problem_summary",
+                    side_effect=OSError("summary cache unavailable"),
+                ), \
+                patch(
+                    "kouhai_bot.handlers.cmd.newproblem.schedule_prefetch_editorial",
+                    schedule_editorial,
+                ), \
+                patch(
+                    "kouhai_bot.problem_preparation.prepare_problem",
+                    AsyncMock(side_effect=AssertionError("hot path must not prepare")),
+                ):
+            from kouhai_bot.handlers.cmd.newproblem import _post_new_problem_locked
+            await _post_new_problem_locked(GID, prefix="test")
 
-  async def _slow_summary(*args, **kwargs):
-      summary_started.set()
-      await asyncio.sleep(0.2)
-      return "summary", ""
-
-  async def _mock_picker_proc(*args, **kwargs):
-      proc = MagicMock()
-      proc.returncode = 0
-      payload = {
-          "today": pid,
-          "contestId": 542,
-          "index": "D",
-          "name": "Superhero's Job",
-          "rating": 2600,
-          "tags": [],
-          "date": "2026-05-22",
-      }
-      proc.communicate = AsyncMock(return_value=(json.dumps(payload).encode(), b""))
-      return proc
-
-  async def _run():
-      with _all_patches(), \
-              patch("kouhai_bot.handlers.cmd.newproblem._picker_args", return_value=["picker"]), \
-              patch("kouhai_bot.handlers.cmd.newproblem.asyncio.create_subprocess_exec", _mock_picker_proc), \
-              patch("kouhai_bot.handlers.cmd.newproblem.summarize_problem", _slow_summary), \
-              patch("kouhai_bot.handlers.cmd.newproblem._send_problem_forward_card", AsyncMock(return_value=(123, {}))), \
-              patch("kouhai_bot.handlers.cmd.newproblem.schedule_prefetch_editorial", _record_prefetch):
-          from kouhai_bot.handlers.cmd.newproblem import _post_new_problem_locked
-          await _post_new_problem_locked(GID, prefix="test")
-
-  asyncio.run(_run())
-  assert scheduled == [pid]
-  assert summary_started.is_set() and scheduled, \
-      "prefetch should run before summarize finishes"
-  _cleanup()
-  print("✅ newproblem: schedules editorial prefetch early")
+    asyncio.run(_run())
+    prefetcher.claim.assert_awaited_once()
+    prefetcher.release.assert_awaited_once_with("slot-1")
+    schedule_editorial.assert_called_once_with(pid)
+    assert "『M』" in send_card.await_args.kwargs["post_msg"]
+    _cleanup()
+    print("✅ newproblem: prepared hot path does no preparation work")
 
 
 def test_newproblem_post_does_not_switch_state_when_send_fails():
-  _reset_state()
-  old_pid = "542D"
-  new_pid = "100A"
-  state_dir = os.path.join(_data_dir(), "groups", str(GID))
-  os.makedirs(state_dir, exist_ok=True)
-  with open(os.path.join(state_dir, "state.json"), "w") as f:
-      json.dump({"today": old_pid, "contestId": 542, "index": "D"}, f)
-  _write_statement(new_pid, {"description": "d", "input": "i", "time_limit": "1s", "memory_limit": "256MB"})
+    _reset_state()
+    old_pid = "542D"
+    new_pid = "100A"
+    state_dir = os.path.join(_data_dir(), "groups", str(GID))
+    os.makedirs(state_dir, exist_ok=True)
+    with open(os.path.join(state_dir, "state.json"), "w") as f:
+        json.dump({"today": old_pid, "contestId": 542, "index": "D"}, f)
+    _write_statement(
+        new_pid,
+        {
+            "description": "d",
+            "input": "i",
+            "time_limit": "1s",
+            "memory_limit": "256MB",
+        },
+    )
 
-  async def _mock_picker_proc(*args, **kwargs):
-      proc = MagicMock()
-      proc.returncode = 0
-      payload = {
-          "today": new_pid,
-          "contestId": 100,
-          "index": "A",
-          "name": "New Problem",
-          "rating": 2000,
-          "tags": [],
-          "date": "2026-05-22",
-      }
-      proc.communicate = AsyncMock(return_value=(json.dumps(payload).encode(), b""))
-      return proc
+    payload = {
+        "today": new_pid,
+        "contestId": 100,
+        "index": "A",
+        "name": "New Problem",
+        "rating": 2000,
+        "tags": [],
+        "date": "2026-05-22",
+    }
+    prefetcher = _fake_problem_prefetcher(payload)
 
-  async def _fail_send_group(*args, **kwargs):
-      return False
+    async def _fail_send_group(*args, **kwargs):
+        return False
 
-  async def _run():
-      with _all_patches(), \
-              patch("kouhai_bot.handlers.cmd.newproblem._picker_args", return_value=["picker"]), \
-              patch("kouhai_bot.handlers.cmd.newproblem.asyncio.create_subprocess_exec", _mock_picker_proc), \
-              patch("kouhai_bot.handlers.cmd.newproblem.summarize_problem", AsyncMock(return_value=("summary", ""))), \
-              patch("kouhai_bot.handlers.cmd.newproblem._send_problem_forward_card", AsyncMock(return_value=(None, {}))), \
-              patch("kouhai_bot.handlers.cmd.newproblem.send_group_msg", _fail_send_group):
-          from kouhai_bot.handlers.cmd.newproblem import _post_new_problem_locked
-          await _post_new_problem_locked(GID, prefix="test")
+    async def _run():
+        with _all_patches(), \
+                patch(
+                    "kouhai_bot.handlers.cmd.newproblem.get_next_problem_prefetcher",
+                    return_value=prefetcher,
+                ), \
+                patch(
+                    "kouhai_bot.handlers.cmd.newproblem._send_problem_forward_card",
+                    AsyncMock(return_value=(None, {})),
+                ), \
+                patch(
+                    "kouhai_bot.handlers.cmd.newproblem.send_group_msg",
+                    _fail_send_group,
+                ):
+            from kouhai_bot.handlers.cmd.newproblem import _post_new_problem_locked
+            await _post_new_problem_locked(GID, prefix="test")
 
-  asyncio.run(_run())
-  with open(os.path.join(state_dir, "state.json")) as f:
-      state = json.load(f)
-  assert state["today"] == old_pid, f"Failed post should leave old state intact: {state}"
-  _cleanup()
-  print("✅ newproblem: failed delivery does not switch current problem")
+    asyncio.run(_run())
+    with open(os.path.join(state_dir, "state.json")) as f:
+        state = json.load(f)
+    assert state["today"] == old_pid, (
+        f"Failed post should leave old state intact: {state}"
+    )
+    prefetcher.release.assert_awaited_once_with("slot-1")
+    _cleanup()
+    print("✅ newproblem: failed delivery does not switch current problem")
+
+
+def test_newproblem_cancel_releases_claimed_prefetch_slot():
+    _reset_state()
+    old_pid = "542D"
+    new_pid = "100A"
+    _write_state(GID, {"today": old_pid, "contestId": 542, "index": "D"})
+    _write_statement(
+        new_pid,
+        {
+            "description": "d",
+            "input": "i",
+            "time_limit": "1s",
+            "memory_limit": "256MB",
+        },
+    )
+    prefetcher = _fake_problem_prefetcher({
+        "today": new_pid,
+        "contestId": 100,
+        "index": "A",
+        "name": "New Problem",
+        "rating": 2000,
+        "tags": [],
+    })
+    send_started = asyncio.Event()
+
+    async def _blocked_send(*_args, **_kwargs):
+        send_started.set()
+        await asyncio.Event().wait()
+
+    async def _run():
+        with _all_patches(), \
+                patch(
+                    "kouhai_bot.handlers.cmd.newproblem.get_next_problem_prefetcher",
+                    return_value=prefetcher,
+                ), \
+                patch(
+                    "kouhai_bot.handlers.cmd.newproblem._send_problem_forward_card",
+                    _blocked_send,
+                ):
+            from kouhai_bot.handlers.cmd.newproblem import _post_new_problem_locked
+
+            task = asyncio.create_task(_post_new_problem_locked(GID, prefix="test"))
+            await send_started.wait()
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+
+    asyncio.run(_run())
+    prefetcher.release.assert_awaited_once_with("slot-1")
+    _cleanup()
+    print("✅ newproblem: cancellation releases claimed prefetch slot")
 
 
 def test_submit_correct_no_editorial_sends_nothing():
@@ -2924,25 +3030,16 @@ def test_newproblem_notify_group_on_pick_failure():
     _setup_problem()
     _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
 
-    async def _mock_pick_fail(*args, **kwargs):
-        """Fail the pick-json subprocess, succeed reveal."""
-        cmd_args = args[1:]  # skip 'python' executable
-        if any("reveal" in str(a) for a in cmd_args):
-            proc = AsyncMock()
-            proc.returncode = 0
-            proc.communicate = AsyncMock(return_value=(b"", b""))
-            return proc
-        if any("pick-json" in str(a) for a in cmd_args):
-            proc = AsyncMock()
-            proc.returncode = 1
-            proc.communicate = AsyncMock(return_value=(b"", b"SSL EOF"))
-            return proc
-        raise RuntimeError(f"unexpected subprocess: {cmd_args}")
+    from kouhai_bot.problem_preparation import ProblemPreparationError
+
+    prefetcher = SimpleNamespace(
+        claim=AsyncMock(side_effect=ProblemPreparationError("Codeforces 连接失败")),
+        release=AsyncMock(),
+    )
 
     with _all_patches(), patch(
-        "asyncio.create_subprocess_exec", _mock_pick_fail
-    ), patch(
-        "asyncio.sleep", AsyncMock()
+        "kouhai_bot.handlers.cmd.newproblem.get_next_problem_prefetcher",
+        return_value=prefetcher,
     ):
         from kouhai_bot.handlers.cmd.newproblem import _post_new_problem_locked
 
@@ -2983,25 +3080,16 @@ def test_newproblem_fallback_direct_saves_daily_msg_for_current_pid():
         "rating": 2000,
         "tags": ["dp"],
     }
-
-    async def _mock_subprocess(*args, **kwargs):
-        cmd_args = args[1:]
-        proc = AsyncMock()
-        if any("reveal" in str(a) for a in cmd_args):
-            proc.returncode = 0
-            proc.communicate = AsyncMock(return_value=(b"", b""))
-            return proc
-        if any("pick-json" in str(a) for a in cmd_args):
-            proc.returncode = 0
-            proc.communicate = AsyncMock(return_value=(json.dumps(picked).encode(), b""))
-            return proc
-        raise RuntimeError(f"unexpected subprocess: {cmd_args}")
+    prefetcher = _fake_problem_prefetcher(picked)
 
     async def _fail_forward(group_id, messages):
         return None
 
     with _all_patches(), \
-            patch("asyncio.create_subprocess_exec", _mock_subprocess), \
+            patch(
+                "kouhai_bot.handlers.cmd.newproblem.get_next_problem_prefetcher",
+                return_value=prefetcher,
+            ), \
             patch("kouhai_bot.handlers.cmd.newproblem.send_group_forward_msg", _fail_forward), \
             patch("kouhai_bot.handlers.cmd.newproblem.asyncio.sleep", AsyncMock()):
         from kouhai_bot.handlers.cmd.newproblem import _post_new_problem_locked
@@ -3018,6 +3106,7 @@ def test_newproblem_fallback_direct_saves_daily_msg_for_current_pid():
     assert daily["post_msg"].startswith("刷新了一道新题"), daily
     assert "sample_messages" in daily
     assert "fwd_message_id" not in daily
+    prefetcher.release.assert_awaited_once_with("slot-1")
     _cleanup()
     print("✅ newproblem: fallback direct saves daily_msg for current pid")
 
@@ -3062,9 +3151,9 @@ def test_submit_scoreboard_update_settles_late_old_problem():
 def test_newproblem_picker_args_follow_env_rating_range():
     _reset_state()
     with _all_patches(), patch.dict(_LazyConfig._config, {"min_rating": 2100, "max_rating": 2900}):
-        from kouhai_bot.handlers.cmd.newproblem import _picker_args
+        from kouhai_bot.problem_preparation import picker_args
 
-        args = _picker_args("pick", GID, "--with-statement")
+        args = picker_args("pick", GID, "--with-statement")
 
     assert "--data-dir" in args, f"Missing data_dir flag: {args}"
     assert args[args.index("--data-dir") + 1] == _data_dir(), f"Wrong data_dir args: {args}"
@@ -3082,9 +3171,9 @@ def test_newproblem_picker_args_prefer_scheduler_override():
             patch("kouhai_bot.scheduler.engine.load_group_configs", return_value={
                 GID: MagicMock(min_rating=2300, max_rating=2700)
             }):
-        from kouhai_bot.handlers.cmd.newproblem import _picker_args
+        from kouhai_bot.problem_preparation import picker_args
 
-        args = _picker_args("pick", GID, "--with-statement")
+        args = picker_args("pick", GID, "--with-statement")
 
     assert args[args.index("--data-dir") + 1] == _data_dir(), f"Wrong data_dir args: {args}"
     assert args[args.index("--min-rating") + 1] == "2300", f"Scheduler min override ignored: {args}"

--- a/tests/test_newproblem_notes.py
+++ b/tests/test_newproblem_notes.py
@@ -7,16 +7,16 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 
 def test_build_notes_message_translates_and_formats():
-    from kouhai_bot.handlers.cmd import newproblem
+    from kouhai_bot import problem_preparation
 
     async def _run():
         stmt = {"notes": "Line A<br />Line B"}
         with patch.object(
-            newproblem,
+            problem_preparation,
             "translate_sample_notes",
             AsyncMock(return_value=("第一行\n第二行", "")),
         ) as mocked_translate:
-            result = await newproblem._build_notes_message(stmt)
+            result = await problem_preparation.build_notes_message(stmt)
         assert result == "样例解释：\n第一行\n第二行"
         mocked_translate.assert_awaited_once_with("Line A\nLine B", [])
 
@@ -24,7 +24,7 @@ def test_build_notes_message_translates_and_formats():
 
 
 def test_build_notes_message_falls_back_to_normalized_original():
-    from kouhai_bot.handlers.cmd import newproblem
+    from kouhai_bot import problem_preparation
 
     async def _run():
         stmt = {
@@ -34,18 +34,18 @@ def test_build_notes_message_falls_back_to_normalized_original():
             )
         }
         with patch.object(
-            newproblem,
+            problem_preparation,
             "translate_sample_notes",
             AsyncMock(return_value=(None, "")),
         ):
-            result = await newproblem._build_notes_message(stmt)
+            result = await problem_preparation.build_notes_message(stmt)
         assert result == "样例解释：\nFirst line\nSecond & line"
 
     asyncio.run(_run())
 
 
 def test_build_notes_message_strips_leaked_thinking_without_rewriting_text():
-    from kouhai_bot.handlers.cmd import newproblem
+    from kouhai_bot import problem_preparation
 
     async def _run():
         stmt = {"notes": "placeholder"}
@@ -59,27 +59,27 @@ def test_build_notes_message_strips_leaked_thinking_without_rewriting_text():
             "with p \\leq q \\ge r and s \\oplus t."
         )
         with patch.object(
-            newproblem,
+            problem_preparation,
             "translate_sample_notes",
             AsyncMock(return_value=(raw, "")),
         ):
-            result = await newproblem._build_notes_message(stmt)
+            result = await problem_preparation.build_notes_message(stmt)
         assert result == f"样例解释：\n{expected}"
 
     asyncio.run(_run())
 
 
 def test_build_notes_message_returns_empty_on_translate_exception():
-    from kouhai_bot.handlers.cmd import newproblem
+    from kouhai_bot import problem_preparation
 
     async def _run():
         stmt = {"notes": "Line A<br />Line B"}
         with patch.object(
-            newproblem,
+            problem_preparation,
             "translate_sample_notes",
             AsyncMock(side_effect=RuntimeError("llm down")),
         ):
-            result = await newproblem._build_notes_message(stmt)
+            result = await problem_preparation.build_notes_message(stmt)
         assert result == ""
 
     asyncio.run(_run())

--- a/tests/test_notice.py
+++ b/tests/test_notice.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import sys
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -41,10 +42,12 @@ def _poke_event(**overrides) -> dict:
 
 def _reset_newproblem_runtime():
     from kouhai_bot.handlers.cmd import newproblem
+    from kouhai_bot.problem_prefetch import reset_prefetchers_for_tests
 
     newproblem._cooldowns.clear()
     newproblem._newproblem_active.clear()
     newproblem._newproblem_locks.clear()
+    reset_prefetchers_for_tests()
     return newproblem
 
 
@@ -81,7 +84,6 @@ def test_bot_poke_is_returned_and_posts_when_eligible(monkeypatch):
 def test_quiet_poke_picker_failure_sends_no_group_message(monkeypatch, tmp_path):
     newproblem = _reset_newproblem_runtime()
     group_messages = []
-    pick_attempts = 0
 
     cfg = SimpleNamespace(
         bot_qq=BOT_QQ,
@@ -92,14 +94,6 @@ def test_quiet_poke_picker_failure_sends_no_group_message(monkeypatch, tmp_path)
         max_rating=3000,
     )
 
-    class FakeProcess:
-        def __init__(self, returncode, stdout=b"", stderr=b""):
-            self.returncode = returncode
-            self._result = (stdout, stderr)
-
-        async def communicate(self):
-            return self._result
-
     async def fake_poke(_group_id, _user_id):
         return True
 
@@ -107,29 +101,29 @@ def test_quiet_poke_picker_failure_sends_no_group_message(monkeypatch, tmp_path)
         group_messages.append((group_id, message))
         return True
 
-    async def fake_subprocess(*args, **_kwargs):
-        nonlocal pick_attempts
-        if "reveal" in args:
-            return FakeProcess(0)
-        if "pick-json" in args:
-            pick_attempts += 1
-            return FakeProcess(1, stderr=b"SSL EOF")
-        raise AssertionError(f"unexpected subprocess: {args}")
+    from kouhai_bot.problem_preparation import ProblemPreparationError
 
-    async def no_sleep(_delay):
-        return None
+    prefetcher = SimpleNamespace(
+        claim=AsyncMock(
+            side_effect=ProblemPreparationError("Codeforces 连接失败")
+        ),
+        release=AsyncMock(),
+    )
 
     monkeypatch.setattr("kouhai_bot.handlers.notice.get_config", lambda: cfg)
     monkeypatch.setattr(newproblem, "get_config", lambda: cfg)
     monkeypatch.setattr("kouhai_bot.handlers.notice.send_group_poke", fake_poke)
     monkeypatch.setattr(newproblem, "_has_unsolved_problem", lambda _gid: False)
     monkeypatch.setattr(newproblem, "send_group_msg", fake_send_group_msg)
-    monkeypatch.setattr(newproblem.asyncio, "create_subprocess_exec", fake_subprocess)
-    monkeypatch.setattr(newproblem.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(
+        newproblem,
+        "get_next_problem_prefetcher",
+        lambda _group_id: prefetcher,
+    )
 
     asyncio.run(process_event(_poke_event(), spawn_handlers=False))
 
-    assert pick_attempts == 3
+    prefetcher.claim.assert_awaited_once()
     assert group_messages == []
     assert GROUP_ID not in newproblem._cooldowns
 

--- a/tests/test_picker_selection.py
+++ b/tests/test_picker_selection.py
@@ -78,6 +78,38 @@ def test_select_problem_resets_used_but_keeps_solved_excluded(monkeypatch, tmp_p
     assert json.loads((group_dir / "used.json").read_text()) == []
 
 
+def test_select_problem_excludes_current_when_used_is_missing(monkeypatch, tmp_path):
+    _data_dir, group_dir = _configure_picker_tmp(tmp_path)
+    (group_dir / "state.json").write_text(json.dumps({"today": "1A"}))
+    monkeypatch.setattr(
+        picker,
+        "_get_cached_targets",
+        lambda: [_problem(1, "A"), _problem(2, "B")],
+    )
+    monkeypatch.setattr(picker.random, "choice", lambda seq: seq[0])
+
+    selected = picker.select_problem()
+
+    assert picker._problem_id(selected) == "2B"
+
+
+def test_select_problem_reset_keeps_current_excluded(monkeypatch, tmp_path):
+    _data_dir, group_dir = _configure_picker_tmp(tmp_path)
+    (group_dir / "state.json").write_text(json.dumps({"today": "1A"}))
+    (group_dir / "used.json").write_text(json.dumps(["2B"]))
+    monkeypatch.setattr(
+        picker,
+        "_get_cached_targets",
+        lambda: [_problem(1, "A"), _problem(2, "B")],
+    )
+    monkeypatch.setattr(picker.random, "choice", lambda seq: seq[0])
+
+    selected = picker.select_problem()
+
+    assert picker._problem_id(selected) == "2B"
+    assert json.loads((group_dir / "used.json").read_text()) == []
+
+
 def test_select_problem_raises_when_every_candidate_is_solved(monkeypatch, tmp_path):
     _data_dir, group_dir = _configure_picker_tmp(tmp_path)
     (group_dir / "scoreboard.json").write_text(json.dumps({

--- a/tests/test_problem_prefetch.py
+++ b/tests/test_problem_prefetch.py
@@ -1,0 +1,337 @@
+import asyncio
+import json
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from kouhai_bot import problem_prefetch
+from kouhai_bot.problem_prefetch import NextProblemPrefetcher
+from kouhai_bot.problem_preparation import PreparedProblem
+
+
+GROUP_ID = 123
+
+
+def _prepared(pid: str = "542D", *, min_rating: int = 2000, max_rating: int = 3000):
+    return PreparedProblem(
+        state={
+            "today": pid,
+            "contestId": 542,
+            "index": "D",
+            "name": "Prepared",
+            "rating": 2600,
+            "tags": [],
+            "date": "2026-01-01",
+        },
+        summary="中文题意",
+        model_tag="『M』",
+        sample_messages=("样例",),
+        notes_message="解释",
+        min_rating=min_rating,
+        max_rating=max_rating,
+        prepared_at=1,
+    )
+
+
+def _configure(tmp_path, monkeypatch, rating=(2000, 3000)):
+    cfg = SimpleNamespace(
+        data_dir=str(tmp_path),
+        llm_multimodal_providers=[],
+    )
+    statement_dir = tmp_path / "statements"
+    statement_dir.mkdir(parents=True, exist_ok=True)
+    (statement_dir / "542D.json").write_text(json.dumps({
+        "description": "statement",
+        "images": [],
+    }))
+    monkeypatch.setattr(problem_prefetch, "get_config", lambda: cfg)
+    monkeypatch.setattr(
+        problem_prefetch,
+        "effective_rating_range",
+        lambda _group_id: rating,
+    )
+    monkeypatch.setattr(problem_prefetch, "get_today_problem", lambda _group_id: None)
+    monkeypatch.setattr(
+        problem_prefetch,
+        "load_scoreboard",
+        lambda _group_id: {"solves": []},
+    )
+    monkeypatch.setattr(
+        problem_prefetch,
+        "load_statement_json",
+        lambda _group_id, _pid: {"description": "statement", "images": []},
+    )
+    monkeypatch.setattr(
+        problem_prefetch,
+        "schedule_prefetch_editorial",
+        lambda *_args, **_kwargs: None,
+    )
+    return cfg
+
+
+def test_maintenance_and_cold_claim_share_one_build(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    started = asyncio.Event()
+    finish = asyncio.Event()
+    calls = 0
+
+    async def prepare(_group_id):
+        nonlocal calls
+        calls += 1
+        started.set()
+        await finish.wait()
+        return _prepared()
+
+    async def run():
+        prefetcher = NextProblemPrefetcher(
+            GROUP_ID,
+            prepare=prepare,
+            retry_interval_sec=10,
+        )
+        stop = asyncio.Event()
+        runner = asyncio.create_task(prefetcher.run(stop_event=stop))
+        await started.wait()
+        claim_task = asyncio.create_task(prefetcher.claim())
+        finish.set()
+        slot = await claim_task
+        assert slot.problem.pid == "542D"
+        assert calls == 1
+        await prefetcher.release(slot.slot_id)
+        stop.set()
+        await runner
+
+    asyncio.run(run())
+
+
+def test_ready_slot_survives_coordinator_recreation(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    prepare = AsyncMock(return_value=_prepared())
+
+    async def run():
+        first = NextProblemPrefetcher(GROUP_ID, prepare=prepare)
+        slot = await first._ensure_ready()
+        assert slot is not None
+        assert first.slot_path.is_file()
+
+        second = NextProblemPrefetcher(
+            GROUP_ID,
+            prepare=AsyncMock(side_effect=AssertionError("must reuse disk slot")),
+        )
+        restored = await second.peek()
+        assert restored is not None
+        assert restored.slot_id == slot.slot_id
+
+    asyncio.run(run())
+    assert prepare.await_count == 1
+
+
+def test_rehydrated_slot_only_resumes_cached_editorial_work(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    scheduled: list[tuple[str, bool]] = []
+    resumed = asyncio.Event()
+
+    def schedule(pid, *, run_agent=True):
+        scheduled.append((pid, run_agent))
+        resumed.set()
+
+    monkeypatch.setattr(problem_prefetch, "schedule_prefetch_editorial", schedule)
+
+    async def run():
+        first = NextProblemPrefetcher(
+            GROUP_ID,
+            prepare=AsyncMock(return_value=_prepared()),
+        )
+        assert await first._ensure_ready() is not None
+
+        second = NextProblemPrefetcher(
+            GROUP_ID,
+            prepare=AsyncMock(side_effect=AssertionError("must reuse disk slot")),
+        )
+        stop = asyncio.Event()
+        runner = asyncio.create_task(second.run(stop_event=stop))
+        await asyncio.wait_for(resumed.wait(), timeout=1)
+        stop.set()
+        await runner
+
+    asyncio.run(run())
+    assert scheduled == [("542D", False)]
+
+
+def test_claim_blocks_refill_until_release(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    second_started = asyncio.Event()
+    finish_second = asyncio.Event()
+    calls = 0
+
+    async def prepare(_group_id):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return _prepared()
+        second_started.set()
+        await finish_second.wait()
+        return _prepared("100A")
+
+    async def run():
+        prefetcher = NextProblemPrefetcher(
+            GROUP_ID,
+            prepare=prepare,
+            retry_interval_sec=10,
+        )
+        await prefetcher._ensure_ready()
+        slot = await prefetcher.claim()
+        stop = asyncio.Event()
+        runner = asyncio.create_task(prefetcher.run(stop_event=stop))
+        await asyncio.sleep(0.02)
+        assert calls == 1
+
+        await prefetcher.release(slot.slot_id)
+        await asyncio.wait_for(second_started.wait(), timeout=1)
+        assert calls == 2
+        finish_second.set()
+        for _ in range(100):
+            ready = await prefetcher.peek()
+            if ready is not None and ready.problem.pid == "100A":
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("replacement slot never became READY")
+        stop.set()
+        await runner
+
+    asyncio.run(run())
+
+
+def test_maintenance_paces_retries_after_build_failure(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    calls = 0
+    first_attempt = asyncio.Event()
+
+    async def prepare(_group_id):
+        nonlocal calls
+        calls += 1
+        first_attempt.set()
+        raise RuntimeError("temporary failure")
+
+    async def run():
+        prefetcher = NextProblemPrefetcher(
+            GROUP_ID,
+            prepare=prepare,
+            retry_interval_sec=0.05,
+        )
+        stop = asyncio.Event()
+        runner = asyncio.create_task(prefetcher.run(stop_event=stop))
+        await first_attempt.wait()
+        await asyncio.sleep(0.01)
+        assert calls == 1
+        await asyncio.sleep(0.06)
+        assert calls >= 2
+        stop.set()
+        await runner
+
+    asyncio.run(run())
+
+
+def test_rating_change_invalidates_persisted_slot(tmp_path, monkeypatch):
+    rating = [2000, 3000]
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        problem_prefetch,
+        "effective_rating_range",
+        lambda _group_id: tuple(rating),
+    )
+
+    async def run():
+        first = NextProblemPrefetcher(
+            GROUP_ID,
+            prepare=AsyncMock(return_value=_prepared()),
+        )
+        assert await first._ensure_ready() is not None
+        rating[:] = [2500, 2700]
+
+        second = NextProblemPrefetcher(GROUP_ID)
+        assert await second.peek() is None
+        assert not second.slot_path.exists()
+
+    asyncio.run(run())
+
+
+def test_multimodal_config_change_invalidates_image_slot(tmp_path, monkeypatch):
+    cfg = _configure(tmp_path, monkeypatch)
+    cfg.llm_multimodal_providers = [object()]
+    monkeypatch.setattr(
+        problem_prefetch,
+        "load_statement_json",
+        lambda _group_id, _pid: {
+            "description": "statement",
+            "images": [{"src": "https://example.invalid/diagram.png"}],
+        },
+    )
+
+    async def run():
+        first = NextProblemPrefetcher(
+            GROUP_ID,
+            prepare=AsyncMock(return_value=_prepared()),
+        )
+        assert await first._ensure_ready() is not None
+        cfg.llm_multimodal_providers = []
+
+        second = NextProblemPrefetcher(GROUP_ID)
+        assert await second.peek() is None
+        assert not second.slot_path.exists()
+
+    asyncio.run(run())
+
+
+def test_current_or_solved_problem_invalidates_slot(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    current = [None]
+    scoreboard = {"solves": []}
+    monkeypatch.setattr(
+        problem_prefetch,
+        "get_today_problem",
+        lambda _group_id: current[0],
+    )
+    monkeypatch.setattr(
+        problem_prefetch,
+        "load_scoreboard",
+        lambda _group_id: scoreboard,
+    )
+
+    async def run():
+        prefetcher = NextProblemPrefetcher(
+            GROUP_ID,
+            prepare=AsyncMock(return_value=_prepared()),
+        )
+        assert await prefetcher._ensure_ready() is not None
+        current[0] = {"today": "542D"}
+        assert await prefetcher.peek() is None
+        current[0] = None
+        assert await prefetcher._ensure_ready() is not None
+        scoreboard["solves"].append({"problem": "542D"})
+        assert await prefetcher.peek() is None
+
+    asyncio.run(run())
+
+
+def test_persistence_failure_keeps_foreground_slot_available(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+
+    async def run():
+        prefetcher = NextProblemPrefetcher(
+            GROUP_ID,
+            prepare=AsyncMock(return_value=_prepared()),
+        )
+        monkeypatch.setattr(
+            prefetcher,
+            "_write_slot_locked",
+            lambda _slot: (_ for _ in ()).throw(OSError("disk full")),
+        )
+        slot = await prefetcher.claim()
+        assert slot.problem.pid == "542D"
+        await prefetcher.release(slot.slot_id)
+
+    asyncio.run(run())

--- a/tests/test_problem_prefetch.py
+++ b/tests/test_problem_prefetch.py
@@ -8,14 +8,23 @@ from unittest.mock import AsyncMock
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from kouhai_bot import problem_prefetch
+from kouhai_bot.problem_content import statement_fingerprint
 from kouhai_bot.problem_prefetch import NextProblemPrefetcher
 from kouhai_bot.problem_preparation import PreparedProblem
+from kouhai_bot.problem_summary import SummaryPreparationStatus
 
 
 GROUP_ID = 123
 
 
-def _prepared(pid: str = "542D", *, min_rating: int = 2000, max_rating: int = 3000):
+def _prepared(
+    pid: str = "542D",
+    *,
+    min_rating: int = 2000,
+    max_rating: int = 3000,
+    statement: dict | None = None,
+):
+    source = statement or {"description": "statement", "images": []}
     return PreparedProblem(
         state={
             "today": pid,
@@ -27,7 +36,9 @@ def _prepared(pid: str = "542D", *, min_rating: int = 2000, max_rating: int = 30
             "date": "2026-01-01",
         },
         summary="中文题意",
+        summary_status=SummaryPreparationStatus.READY,
         model_tag="『M』",
+        statement_sha256=statement_fingerprint(source),
         sample_messages=("样例",),
         notes_message="解释",
         min_rating=min_rating,
@@ -62,12 +73,7 @@ def _configure(tmp_path, monkeypatch, rating=(2000, 3000)):
     monkeypatch.setattr(
         problem_prefetch,
         "load_statement_json",
-        lambda _group_id, _pid: {"description": "statement", "images": []},
-    )
-    monkeypatch.setattr(
-        problem_prefetch,
-        "ensure_editorial_prefetch",
-        lambda *_args, **_kwargs: None,
+        lambda _pid, **_kwargs: {"description": "statement", "images": []},
     )
     return cfg
 
@@ -106,6 +112,26 @@ def test_maintenance_and_cold_claim_share_one_build(tmp_path, monkeypatch):
     asyncio.run(run())
 
 
+def test_ready_observer_is_notified_after_complete_slot_is_stored(
+    tmp_path,
+    monkeypatch,
+):
+    _configure(tmp_path, monkeypatch)
+    observed: list[str] = []
+
+    async def run():
+        prefetcher = NextProblemPrefetcher(
+            GROUP_ID,
+            prepare=AsyncMock(return_value=_prepared()),
+        )
+        prefetcher.set_ready_observer(observed.append)
+        slot = await prefetcher._ensure_ready()
+        assert slot is not None
+
+    asyncio.run(run())
+    assert observed == ["542D"]
+
+
 def test_ready_slot_survives_coordinator_recreation(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     prepare = AsyncMock(return_value=_prepared())
@@ -126,72 +152,6 @@ def test_ready_slot_survives_coordinator_recreation(tmp_path, monkeypatch):
 
     asyncio.run(run())
     assert prepare.await_count == 1
-
-
-def test_rehydrated_slot_restarts_full_editorial_prefetch(tmp_path, monkeypatch):
-    _configure(tmp_path, monkeypatch)
-    scheduled: list[str] = []
-    resumed = asyncio.Event()
-
-    def ensure(pid):
-        scheduled.append(pid)
-        resumed.set()
-
-    monkeypatch.setattr(problem_prefetch, "ensure_editorial_prefetch", ensure)
-
-    async def run():
-        first = NextProblemPrefetcher(
-            GROUP_ID,
-            prepare=AsyncMock(return_value=_prepared()),
-        )
-        assert await first._ensure_ready() is not None
-
-        second = NextProblemPrefetcher(
-            GROUP_ID,
-            prepare=AsyncMock(side_effect=AssertionError("must reuse disk slot")),
-        )
-        stop = asyncio.Event()
-        runner = asyncio.create_task(second.run(stop_event=stop))
-        await asyncio.wait_for(resumed.wait(), timeout=1)
-        stop.set()
-        await runner
-
-    asyncio.run(run())
-    assert scheduled == ["542D"]
-
-
-def test_ready_slot_retries_unsettled_editorial_maintenance(tmp_path, monkeypatch):
-    _configure(tmp_path, monkeypatch)
-    calls: list[str] = []
-    retried = asyncio.Event()
-
-    def ensure(pid):
-        calls.append(pid)
-        if len(calls) >= 2:
-            retried.set()
-
-    monkeypatch.setattr(problem_prefetch, "ensure_editorial_prefetch", ensure)
-
-    async def run():
-        first = NextProblemPrefetcher(
-            GROUP_ID,
-            prepare=AsyncMock(return_value=_prepared()),
-        )
-        assert await first._ensure_ready() is not None
-
-        restored = NextProblemPrefetcher(
-            GROUP_ID,
-            prepare=AsyncMock(side_effect=AssertionError("must reuse disk slot")),
-            retry_interval_sec=0.01,
-        )
-        stop = asyncio.Event()
-        runner = asyncio.create_task(restored.run(stop_event=stop))
-        await asyncio.wait_for(retried.wait(), timeout=1)
-        stop.set()
-        await runner
-
-    asyncio.run(run())
-    assert calls[:2] == ["542D", "542D"]
 
 
 def test_claim_blocks_refill_until_release(tmp_path, monkeypatch):
@@ -296,23 +256,48 @@ def test_rating_change_invalidates_persisted_slot(tmp_path, monkeypatch):
 def test_multimodal_config_change_invalidates_image_slot(tmp_path, monkeypatch):
     cfg = _configure(tmp_path, monkeypatch)
     cfg.llm_multimodal_providers = [object()]
+    image_statement = {
+        "description": "statement",
+        "images": [{"src": "https://example.invalid/diagram.png"}],
+    }
     monkeypatch.setattr(
         problem_prefetch,
         "load_statement_json",
-        lambda _group_id, _pid: {
-            "description": "statement",
-            "images": [{"src": "https://example.invalid/diagram.png"}],
-        },
+        lambda _pid, **_kwargs: image_statement,
     )
 
     async def run():
         first = NextProblemPrefetcher(
             GROUP_ID,
-            prepare=AsyncMock(return_value=_prepared()),
+            prepare=AsyncMock(return_value=_prepared(statement=image_statement)),
         )
         assert await first._ensure_ready() is not None
         cfg.llm_multimodal_providers = []
 
+        second = NextProblemPrefetcher(GROUP_ID)
+        assert await second.peek() is None
+        assert not second.slot_path.exists()
+
+    asyncio.run(run())
+
+
+def test_statement_change_invalidates_persisted_slot(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    statement = {"description": "original statement", "images": []}
+    monkeypatch.setattr(
+        problem_prefetch,
+        "load_statement_json",
+        lambda _pid, **_kwargs: statement,
+    )
+
+    async def run():
+        first = NextProblemPrefetcher(
+            GROUP_ID,
+            prepare=AsyncMock(return_value=_prepared(statement=statement)),
+        )
+        assert await first._ensure_ready() is not None
+
+        statement["description"] = "changed statement"
         second = NextProblemPrefetcher(GROUP_ID)
         assert await second.peek() is None
         assert not second.slot_path.exists()

--- a/tests/test_problem_prefetch.py
+++ b/tests/test_problem_prefetch.py
@@ -66,7 +66,7 @@ def _configure(tmp_path, monkeypatch, rating=(2000, 3000)):
     )
     monkeypatch.setattr(
         problem_prefetch,
-        "schedule_prefetch_editorial",
+        "ensure_editorial_prefetch",
         lambda *_args, **_kwargs: None,
     )
     return cfg
@@ -128,16 +128,16 @@ def test_ready_slot_survives_coordinator_recreation(tmp_path, monkeypatch):
     assert prepare.await_count == 1
 
 
-def test_rehydrated_slot_only_resumes_cached_editorial_work(tmp_path, monkeypatch):
+def test_rehydrated_slot_restarts_full_editorial_prefetch(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
-    scheduled: list[tuple[str, bool]] = []
+    scheduled: list[str] = []
     resumed = asyncio.Event()
 
-    def schedule(pid, *, run_agent=True):
-        scheduled.append((pid, run_agent))
+    def ensure(pid):
+        scheduled.append(pid)
         resumed.set()
 
-    monkeypatch.setattr(problem_prefetch, "schedule_prefetch_editorial", schedule)
+    monkeypatch.setattr(problem_prefetch, "ensure_editorial_prefetch", ensure)
 
     async def run():
         first = NextProblemPrefetcher(
@@ -157,7 +157,41 @@ def test_rehydrated_slot_only_resumes_cached_editorial_work(tmp_path, monkeypatc
         await runner
 
     asyncio.run(run())
-    assert scheduled == [("542D", False)]
+    assert scheduled == ["542D"]
+
+
+def test_ready_slot_retries_unsettled_editorial_maintenance(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    calls: list[str] = []
+    retried = asyncio.Event()
+
+    def ensure(pid):
+        calls.append(pid)
+        if len(calls) >= 2:
+            retried.set()
+
+    monkeypatch.setattr(problem_prefetch, "ensure_editorial_prefetch", ensure)
+
+    async def run():
+        first = NextProblemPrefetcher(
+            GROUP_ID,
+            prepare=AsyncMock(return_value=_prepared()),
+        )
+        assert await first._ensure_ready() is not None
+
+        restored = NextProblemPrefetcher(
+            GROUP_ID,
+            prepare=AsyncMock(side_effect=AssertionError("must reuse disk slot")),
+            retry_interval_sec=0.01,
+        )
+        stop = asyncio.Event()
+        runner = asyncio.create_task(restored.run(stop_event=stop))
+        await asyncio.wait_for(retried.wait(), timeout=1)
+        stop.set()
+        await runner
+
+    asyncio.run(run())
+    assert calls[:2] == ["542D", "542D"]
 
 
 def test_claim_blocks_refill_until_release(tmp_path, monkeypatch):

--- a/tests/test_problem_preparation.py
+++ b/tests/test_problem_preparation.py
@@ -14,6 +14,7 @@ from kouhai_bot.problem_preparation import (
     ProblemPreparationError,
     format_previous_problem_reveal,
 )
+from kouhai_bot.problem_summary import SummaryPreparationStatus
 
 
 def _state(pid: str = "542D") -> dict:
@@ -28,7 +29,7 @@ def _state(pid: str = "542D") -> dict:
     }
 
 
-def test_prepare_problem_starts_editorial_before_summary(tmp_path, monkeypatch):
+def test_prepare_problem_returns_complete_card_content(tmp_path, monkeypatch):
     cfg = SimpleNamespace(data_dir=str(tmp_path))
     statement_dir = tmp_path / "statements"
     statement_dir.mkdir()
@@ -40,8 +41,6 @@ def test_prepare_problem_starts_editorial_before_summary(tmp_path, monkeypatch):
         "samples": [{"input": "1", "output": "2"}],
         "images": [],
     }))
-    scheduled = []
-
     monkeypatch.setattr(problem_preparation, "get_config", lambda: cfg)
     monkeypatch.setattr(
         problem_preparation,
@@ -55,17 +54,11 @@ def test_prepare_problem_starts_editorial_before_summary(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(
         problem_preparation,
-        "schedule_prefetch_editorial",
-        scheduled.append,
-    )
-    monkeypatch.setattr(
-        problem_preparation,
         "build_notes_message",
         AsyncMock(return_value=""),
     )
 
     async def summarize(*_args, **_kwargs):
-        assert scheduled == ["542D"]
         return "中文题意", "『M』"
 
     monkeypatch.setattr(problem_preparation, "summarize_problem", summarize)
@@ -74,12 +67,17 @@ def test_prepare_problem_starts_editorial_before_summary(tmp_path, monkeypatch):
 
     assert prepared.pid == "542D"
     assert prepared.summary == "中文题意"
+    assert prepared.summary_status is SummaryPreparationStatus.READY
     assert prepared.model_tag == "『M』"
+    assert len(prepared.statement_sha256) == 64
     assert prepared.sample_messages == ("样例 1\nInput:\n1\n\nOutput:\n2",)
     assert (prepared.min_rating, prepared.max_rating) == (2500, 2700)
 
 
-def test_prepare_problem_keeps_empty_summary_after_existing_retry(tmp_path, monkeypatch):
+def test_prepare_problem_marks_summary_incomplete_after_existing_retry(
+    tmp_path,
+    monkeypatch,
+):
     cfg = SimpleNamespace(data_dir=str(tmp_path))
     statement_dir = tmp_path / "statements"
     statement_dir.mkdir()
@@ -101,12 +99,13 @@ def test_prepare_problem_keeps_empty_summary_after_existing_retry(tmp_path, monk
         "_run_picker",
         AsyncMock(return_value=_state()),
     )
-    monkeypatch.setattr(problem_preparation, "schedule_prefetch_editorial", lambda _pid: None)
     monkeypatch.setattr(problem_preparation, "summarize_problem", summarize)
 
     prepared = asyncio.run(problem_preparation.prepare_problem(1))
 
     assert prepared.summary == ""
+    assert prepared.summary_status is SummaryPreparationStatus.INCOMPLETE
+    assert prepared.model_tag == ""
     assert summarize.await_count == 2
 
 

--- a/tests/test_problem_preparation.py
+++ b/tests/test_problem_preparation.py
@@ -1,0 +1,193 @@
+import asyncio
+import json
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from kouhai_bot import problem_preparation
+from kouhai_bot.problem_preparation import (
+    ProblemPreparationError,
+    format_previous_problem_reveal,
+)
+
+
+def _state(pid: str = "542D") -> dict:
+    return {
+        "today": pid,
+        "contestId": 542,
+        "index": "D",
+        "name": "Prepared",
+        "rating": 2600,
+        "tags": ["dp"],
+        "date": "2026-01-01",
+    }
+
+
+def test_prepare_problem_starts_editorial_before_summary(tmp_path, monkeypatch):
+    cfg = SimpleNamespace(data_dir=str(tmp_path))
+    statement_dir = tmp_path / "statements"
+    statement_dir.mkdir()
+    (statement_dir / "542D.json").write_text(json.dumps({
+        "description": "statement",
+        "input": "n",
+        "time_limit": "2s",
+        "memory_limit": "256MB",
+        "samples": [{"input": "1", "output": "2"}],
+        "images": [],
+    }))
+    scheduled = []
+
+    monkeypatch.setattr(problem_preparation, "get_config", lambda: cfg)
+    monkeypatch.setattr(
+        problem_preparation,
+        "effective_rating_range",
+        lambda _group_id: (2500, 2700),
+    )
+    monkeypatch.setattr(
+        problem_preparation,
+        "_run_picker",
+        AsyncMock(return_value=_state()),
+    )
+    monkeypatch.setattr(
+        problem_preparation,
+        "schedule_prefetch_editorial",
+        scheduled.append,
+    )
+    monkeypatch.setattr(
+        problem_preparation,
+        "build_notes_message",
+        AsyncMock(return_value=""),
+    )
+
+    async def summarize(*_args, **_kwargs):
+        assert scheduled == ["542D"]
+        return "中文题意", "『M』"
+
+    monkeypatch.setattr(problem_preparation, "summarize_problem", summarize)
+
+    prepared = asyncio.run(problem_preparation.prepare_problem(1))
+
+    assert prepared.pid == "542D"
+    assert prepared.summary == "中文题意"
+    assert prepared.model_tag == "『M』"
+    assert prepared.sample_messages == ("样例 1\nInput:\n1\n\nOutput:\n2",)
+    assert (prepared.min_rating, prepared.max_rating) == (2500, 2700)
+
+
+def test_prepare_problem_keeps_empty_summary_after_existing_retry(tmp_path, monkeypatch):
+    cfg = SimpleNamespace(data_dir=str(tmp_path))
+    statement_dir = tmp_path / "statements"
+    statement_dir.mkdir()
+    (statement_dir / "542D.json").write_text(json.dumps({
+        "description": "statement",
+        "input": "n",
+        "images": [],
+    }))
+    summarize = AsyncMock(return_value=(None, ""))
+
+    monkeypatch.setattr(problem_preparation, "get_config", lambda: cfg)
+    monkeypatch.setattr(
+        problem_preparation,
+        "effective_rating_range",
+        lambda _group_id: (2000, 3000),
+    )
+    monkeypatch.setattr(
+        problem_preparation,
+        "_run_picker",
+        AsyncMock(return_value=_state()),
+    )
+    monkeypatch.setattr(problem_preparation, "schedule_prefetch_editorial", lambda _pid: None)
+    monkeypatch.setattr(problem_preparation, "summarize_problem", summarize)
+
+    prepared = asyncio.run(problem_preparation.prepare_problem(1))
+
+    assert prepared.summary == ""
+    assert summarize.await_count == 2
+
+
+def test_run_picker_preserves_three_attempt_error(monkeypatch):
+    attempts = 0
+
+    class FailedProcess:
+        returncode = 1
+
+        async def communicate(self):
+            return b"", b"SSL EOF"
+
+    async def create_process(*_args, **_kwargs):
+        nonlocal attempts
+        attempts += 1
+        return FailedProcess()
+
+    monkeypatch.setattr(
+        problem_preparation.asyncio,
+        "create_subprocess_exec",
+        create_process,
+    )
+    monkeypatch.setattr(problem_preparation.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(
+        problem_preparation,
+        "picker_args",
+        lambda *_args, **_kwargs: ["picker"],
+    )
+
+    with pytest.raises(ProblemPreparationError) as exc_info:
+        asyncio.run(problem_preparation._run_picker(1))
+
+    assert attempts == 3
+    assert exc_info.value.user_message == "Codeforces 连接失败"
+
+
+def test_run_picker_cancellation_kills_child_process(monkeypatch):
+    communicate_started = asyncio.Event()
+
+    class HangingProcess:
+        returncode = None
+        killed = False
+
+        async def communicate(self):
+            communicate_started.set()
+            await asyncio.Event().wait()
+
+        def kill(self):
+            self.killed = True
+            self.returncode = -9
+
+        async def wait(self):
+            return self.returncode
+
+    process = HangingProcess()
+
+    monkeypatch.setattr(
+        problem_preparation.asyncio,
+        "create_subprocess_exec",
+        AsyncMock(return_value=process),
+    )
+    monkeypatch.setattr(
+        problem_preparation,
+        "picker_args",
+        lambda *_args, **_kwargs: ["picker"],
+    )
+
+    async def run():
+        task = asyncio.create_task(problem_preparation._run_picker(1))
+        await communicate_started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(run())
+    assert process.killed is True
+
+
+def test_format_previous_problem_reveal_is_pure_and_compatible():
+    assert format_previous_problem_reveal(None) == "还没有发过题哦"
+    assert format_previous_problem_reveal([]) == "还没有发过题哦"
+    assert format_previous_problem_reveal(_state()) == (
+        "上一道题来自 CF542D Prepared 2600✨"
+    )

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -167,6 +167,9 @@ def test_second_judge_prompt_rejects_repaired_greedy_for_teleporters():
 
 
 class _DummySession:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
     async def __aenter__(self):
         return self
 

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -5,6 +5,8 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from kouhai_bot.config import BotConfig
@@ -22,10 +24,12 @@ from kouhai_bot.handlers.shared import (
     get_judge_prompt,
     call_chat_completion_result,
     doublecheck_problem_summary,
+    get_problem_summary,
     judge_submission,
     judge_submission_result,
     parse_json_with_llm_repair,
     robust_json_parse,
+    save_problem_summary,
     summarize_problem,
     translate_editorial_to_zh,
     translate_sample_notes,
@@ -37,6 +41,52 @@ from kouhai_bot.llm import (
     strip_leaked_thinking,
 )
 from tools import summary_doublecheck as summary_doublecheck_tool
+
+
+def test_problem_summary_cache_is_bound_to_statement_source(tmp_path):
+    cfg = BotConfig(data_dir=str(tmp_path))
+    statement_dir = tmp_path / "statements"
+    statement_dir.mkdir()
+    statement_path = statement_dir / "542D.json"
+    statement_path.write_text(
+        json.dumps({"description": "original", "images": []}),
+        encoding="utf-8",
+    )
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), patch(
+        "kouhai_bot.problem_content.get_config",
+        return_value=cfg,
+    ):
+        save_problem_summary(1, "542D", "已审计题意")
+        assert get_problem_summary(1, "542D") == "已审计题意"
+
+        statement_path.write_text(
+            json.dumps({"description": "changed", "images": []}),
+            encoding="utf-8",
+        )
+        assert get_problem_summary(1, "542D") == ""
+
+
+def test_problem_summary_cache_rejects_stale_prepared_source(tmp_path):
+    cfg = BotConfig(data_dir=str(tmp_path))
+    statement_dir = tmp_path / "statements"
+    statement_dir.mkdir()
+    (statement_dir / "542D.json").write_text(
+        json.dumps({"description": "current", "images": []}),
+        encoding="utf-8",
+    )
+
+    with patch("kouhai_bot.handlers.shared.get_config", return_value=cfg), patch(
+        "kouhai_bot.problem_content.get_config",
+        return_value=cfg,
+    ):
+        with pytest.raises(ValueError, match="stale summary source"):
+            save_problem_summary(
+                1,
+                "542D",
+                "旧题面对应的题意",
+                source_sha256="0" * 64,
+            )
 
 
 def test_judge_prompt_rejects_repaired_greedy_and_unbatched_simulation():

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -411,6 +411,44 @@ def test_prefetch_editorial_zh_caches_translation(tmp_path, monkeypatch):
     assert cached.startswith("预取译文")
 
 
+def test_ensure_editorial_prefetch_runs_full_pipeline_and_respects_terminal_state(
+    monkeypatch,
+):
+    from kouhai_bot import editorial_followup
+
+    cached = False
+    no_editorial = False
+    scheduled: list[tuple[str, bool]] = []
+
+    monkeypatch.setattr(
+        editorial_followup,
+        "has_cached_editorial_zh",
+        lambda _pid: cached,
+    )
+    monkeypatch.setattr(
+        editorial_followup,
+        "is_no_official_editorial",
+        lambda _pid: no_editorial,
+    )
+    monkeypatch.setattr(
+        editorial_followup,
+        "schedule_prefetch_editorial",
+        lambda pid, *, run_agent=True: scheduled.append((pid, run_agent)),
+    )
+
+    editorial_followup.ensure_editorial_prefetch("542D")
+    assert scheduled == [("542D", True)]
+
+    cached = True
+    editorial_followup.ensure_editorial_prefetch("542D")
+    assert scheduled == [("542D", True)]
+
+    cached = False
+    no_editorial = True
+    editorial_followup.ensure_editorial_prefetch("542D")
+    assert scheduled == [("542D", True)]
+
+
 def test_deliver_uses_prefetch_cache_without_translate(tmp_path, monkeypatch):
     from kouhai_bot.config import BotConfig
     from kouhai_bot.editorial_followup import deliver_official_tutorial_forward

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -42,6 +42,53 @@ def _long_text(prefix: str = "x") -> str:
     return prefix * (MIN_EDITORIAL_LEN + 10)
 
 
+def _write_statement(tmp_path, pid: str) -> None:
+    statements_dir = tmp_path / "statements"
+    statements_dir.mkdir(exist_ok=True)
+    statement_path = statements_dir / f"{pid}.json"
+    if not statement_path.exists():
+        statement_path.write_text(
+            json.dumps({"description": f"statement for {pid}", "images": []}),
+            encoding="utf-8",
+        )
+
+
+def _write_tutorial_for_editorial(tmp_path, pid: str, editorial: OfficialEditorial) -> None:
+    _write_statement(tmp_path, pid)
+    tutorials_dir = tmp_path / "tutorials"
+    tutorials_dir.mkdir(exist_ok=True)
+    (tutorials_dir / f"{pid}.json").write_text(
+        json.dumps(
+            {
+                "tutorial_url": editorial.tutorial_url,
+                "tutorial_title": editorial.tutorial_title,
+                "sections": [
+                    {
+                        "hint": "",
+                        "solution": editorial.text,
+                        "raw_text": editorial.text,
+                        "code_blocks": [],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_verified_cache(
+    tmp_path,
+    pid: str,
+    editorial: OfficialEditorial,
+    text: str = "已验证中文题解。" * 20,
+) -> None:
+    from kouhai_bot.tutorials import _save_cached_translation
+
+    _write_statement(tmp_path, pid)
+    _write_tutorial_for_editorial(tmp_path, pid, editorial)
+    _save_cached_translation(pid, text, editorial)
+
+
 def test_extract_editorial_from_hint():
     section = {
         "hint": _long_text("hint-"),
@@ -136,10 +183,11 @@ def test_get_editorial_zh_for_group_uses_translation(tmp_path, monkeypatch):
         tutorial_url="https://example.com/e",
         tutorial_title="T",
     )
+    _write_tutorial_for_editorial(tmp_path, "542D", editorial)
 
     async def _run():
         with patch(
-            "kouhai_bot.tutorials.translate_editorial_to_zh",
+            "kouhai_bot.editorial_preparation.translate_editorial_to_zh",
             AsyncMock(return_value=("中文题解译文。" * 20, "", True)),
         ):
             return await get_editorial_zh_for_group(editorial, "542D")
@@ -151,12 +199,13 @@ def test_get_editorial_zh_for_group_uses_translation(tmp_path, monkeypatch):
     assert (tmp_path / "tutorial_translations" / "542D.verified").is_file()
 
 
-def test_get_editorial_zh_for_group_marks_mismatched_editorial_missing(tmp_path, monkeypatch):
+def test_get_editorial_zh_for_group_keeps_single_mismatch_non_terminal(tmp_path, monkeypatch):
     import json
     from kouhai_bot.config import BotConfig
 
     cfg = BotConfig(data_dir=str(tmp_path))
     monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    _write_statement(tmp_path, "542D")
     tutorials_dir = tmp_path / "tutorials"
     tutorials_dir.mkdir()
     body = _long_text("wrong-editorial-")
@@ -172,7 +221,7 @@ def test_get_editorial_zh_for_group_marks_mismatched_editorial_missing(tmp_path,
 
     async def _run():
         with patch(
-            "kouhai_bot.tutorials.translate_editorial_to_zh",
+            "kouhai_bot.editorial_preparation.translate_editorial_to_zh",
             AsyncMock(return_value=(None, "", False)),
         ):
             return await get_editorial_zh_for_group(editorial, "542D")
@@ -180,7 +229,7 @@ def test_get_editorial_zh_for_group_marks_mismatched_editorial_missing(tmp_path,
     zh, tag = asyncio.run(_run())
     assert zh is None
     assert tag == ""
-    assert is_no_official_editorial("542D")
+    assert not is_no_official_editorial("542D")
     editorial_after_marker = get_official_editorial("542D")
     assert editorial_after_marker is not None
     assert editorial_after_marker.text.startswith("wrong-editorial-")
@@ -199,6 +248,55 @@ def test_unverified_editorial_translation_cache_is_not_warm(tmp_path, monkeypatc
     assert not has_cached_editorial_zh("317C")
 
 
+def test_verified_cache_is_bound_to_the_persisted_editorial_source(
+    tmp_path,
+    monkeypatch,
+):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    original = OfficialEditorial(
+        text=_long_text("original-"),
+        tutorial_url="https://example.com/e",
+        tutorial_title="T",
+    )
+    _write_verified_cache(tmp_path, "542D", original)
+    assert has_cached_editorial_zh("542D")
+
+    replacement = OfficialEditorial(
+        text=_long_text("replacement-"),
+        tutorial_url=original.tutorial_url,
+        tutorial_title=original.tutorial_title,
+    )
+    _write_tutorial_for_editorial(tmp_path, "542D", replacement)
+
+    assert not has_cached_editorial_zh("542D")
+
+
+def test_verified_cache_is_bound_to_the_problem_statement(
+    tmp_path,
+    monkeypatch,
+):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    editorial = OfficialEditorial(
+        text=_long_text("source-"),
+        tutorial_url="https://example.com/e",
+        tutorial_title="T",
+    )
+    _write_verified_cache(tmp_path, "542D", editorial)
+    assert has_cached_editorial_zh("542D")
+
+    (tmp_path / "statements" / "542D.json").write_text(
+        json.dumps({"description": "corrected statement", "images": []}),
+        encoding="utf-8",
+    )
+    assert not has_cached_editorial_zh("542D")
+
+
 def test_get_editorial_zh_for_group_revalidates_unverified_cache(tmp_path, monkeypatch):
     from kouhai_bot.config import BotConfig
 
@@ -212,10 +310,14 @@ def test_get_editorial_zh_for_group_revalidates_unverified_cache(tmp_path, monke
         tutorial_url="https://example.com/e",
         tutorial_title="T",
     )
+    _write_tutorial_for_editorial(tmp_path, "317C", editorial)
     translate = AsyncMock(return_value=("新缓存译文。" * 20, "", True))
 
     async def _run():
-        with patch("kouhai_bot.tutorials.translate_editorial_to_zh", translate):
+        with patch(
+            "kouhai_bot.editorial_preparation.translate_editorial_to_zh",
+            translate,
+        ):
             return await get_editorial_zh_for_group(editorial, "317C")
 
     zh, tag = asyncio.run(_run())
@@ -232,22 +334,24 @@ def test_get_editorial_zh_for_group_strips_verified_cache_thinking_tags(tmp_path
 
     cfg = BotConfig(data_dir=str(tmp_path))
     monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
-    cache_dir = tmp_path / "tutorial_translations"
-    cache_dir.mkdir()
-    (cache_dir / "542D.txt").write_text(
-        ("<thinking>hidden cached editorial</thinking>中文题解。" * 20),
-        encoding="utf-8",
-    )
-    (cache_dir / "542D.verified").write_text("", encoding="utf-8")
     editorial = OfficialEditorial(
         text=_long_text("english-"),
         tutorial_url="https://example.com/e",
         tutorial_title="T",
     )
+    _write_verified_cache(
+        tmp_path,
+        "542D",
+        editorial,
+        "<thinking>hidden cached editorial</thinking>" + ("中文题解。" * 20),
+    )
     translate = AsyncMock(return_value=("不应重新翻译。" * 20, "", True))
 
     async def _run():
-        with patch("kouhai_bot.tutorials.translate_editorial_to_zh", translate):
+        with patch(
+            "kouhai_bot.editorial_preparation.translate_editorial_to_zh",
+            translate,
+        ):
             return await get_editorial_zh_for_group(editorial, "542D")
 
     zh, tag = asyncio.run(_run())
@@ -265,9 +369,21 @@ def test_prefetch_editorial_zh_recovers_after_rescrape(tmp_path, monkeypatch):
 
     cfg = BotConfig(data_dir=str(tmp_path))
     monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
-    mark_no_official_editorial("542D")
+    marker_dir = tmp_path / "tutorial_translations"
+    marker_dir.mkdir()
+    (marker_dir / "542D.no_editorial").write_text(
+        json.dumps(
+            {
+                "format_version": 1,
+                "status": "no_editorial",
+                "reason": "old_translation_mismatch",
+            }
+        ),
+        encoding="utf-8",
+    )
     tutorials_dir = tmp_path / "tutorials"
     tutorials_dir.mkdir()
+    _write_statement(tmp_path, "542D")
     body = _long_text("rescued-")
     (tutorials_dir / "542D.json").write_text(
         json.dumps({
@@ -279,7 +395,7 @@ def test_prefetch_editorial_zh_recovers_after_rescrape(tmp_path, monkeypatch):
 
     async def _run():
         with patch(
-            "kouhai_bot.tutorials.translate_editorial_to_zh",
+            "kouhai_bot.editorial_preparation.translate_editorial_to_zh",
             AsyncMock(return_value=("恢复后的译文。" * 20, "", True)),
         ):
             await prefetch_editorial_zh("542D")
@@ -299,12 +415,74 @@ def test_legacy_no_editorial_marker_is_not_a_trusted_terminal_state(
     monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
     marker_dir = tmp_path / "tutorial_translations"
     marker_dir.mkdir()
+    statement_dir = tmp_path / "statements"
+    statement_dir.mkdir()
+    (statement_dir / "542D.json").write_text(
+        json.dumps({"description": "statement", "images": []}),
+        encoding="utf-8",
+    )
     (marker_dir / "542D.no_editorial").write_text("", encoding="utf-8")
 
     assert not is_no_official_editorial("542D")
 
     mark_no_official_editorial("542D", reason="agent_no_match:test")
     assert is_no_official_editorial("542D")
+
+
+def test_no_editorial_marker_is_bound_to_the_problem_statement(
+    tmp_path,
+    monkeypatch,
+):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    _write_statement(tmp_path, "542D")
+
+    mark_no_official_editorial("542D", reason="agent_exhaustive_no_match:test")
+    assert is_no_official_editorial("542D")
+
+    (tmp_path / "statements" / "542D.json").write_text(
+        json.dumps({"description": "corrected statement", "images": []}),
+        encoding="utf-8",
+    )
+    assert not is_no_official_editorial("542D")
+
+
+def test_no_editorial_marker_requires_completed_failure_reason(
+    tmp_path,
+    monkeypatch,
+):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    _write_statement(tmp_path, "542D")
+
+    with pytest.raises(ValueError, match="reason missing"):
+        mark_no_official_editorial("542D", reason="")
+    assert not is_no_official_editorial("542D")
+
+
+def test_short_translation_cannot_create_verified_marker(tmp_path, monkeypatch):
+    from kouhai_bot.config import BotConfig
+    from kouhai_bot.tutorials import _save_cached_translation
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    editorial = OfficialEditorial(
+        text=_long_text("official-"),
+        tutorial_url="https://example.com/editorial",
+        tutorial_title="Editorial",
+    )
+    _write_statement(tmp_path, "542D")
+    _write_tutorial_for_editorial(tmp_path, "542D", editorial)
+
+    assert not _save_cached_translation("542D", "too short", editorial)
+    assert not has_cached_editorial_zh("542D")
+    assert not (
+        tmp_path / "tutorial_translations" / "542D.verified"
+    ).exists()
 
 
 def test_prefetch_editorial_zh_without_statement_stays_incomplete(tmp_path, monkeypatch):
@@ -331,7 +509,7 @@ def test_prefetch_editorial_zh_no_agent_leaves_missing_unknown(tmp_path, monkeyp
             "kouhai_bot.tutorials.ensure_tutorial_json",
             AsyncMock(side_effect=AssertionError("agent should not run")),
         ), patch(
-            "kouhai_bot.tutorials.translate_editorial_to_zh",
+            "kouhai_bot.editorial_preparation.translate_editorial_to_zh",
             AsyncMock(side_effect=AssertionError("translate should not run")),
         ):
             await prefetch_editorial_zh("999Z", run_agent=False)
@@ -364,11 +542,17 @@ def test_prefetch_editorial_zh_runs_agent_before_translate(tmp_path, monkeypatch
         json.dumps({"name": "P", "description": "D", "input": "I", "output": "O"}),
         encoding="utf-8",
     )
-    mark_no_official_editorial("542D")
-
-    async def _fake_run_agent_for_pid(*, pid, statements_dir):
+    async def _fake_run_agent_for_pid(
+        *,
+        pid,
+        statements_dir,
+        blog_limit,
+        excluded_tutorial_urls,
+    ):
         assert pid == "542D"
         assert (statements_dir / "542D.json").is_file()
+        assert blog_limit == 0
+        assert excluded_tutorial_urls == frozenset()
         body = _long_text("agent editorial ")
         return SimpleNamespace(
             bundle={
@@ -385,7 +569,7 @@ def test_prefetch_editorial_zh_runs_agent_before_translate(tmp_path, monkeypatch
 
     async def _run():
         with patch(
-            "kouhai_bot.tutorials._load_tutorial_agent",
+            "kouhai_bot.editorial_preparation._load_tutorial_agent",
             return_value=(
                 _FakeAgentNoMatch,
                 _FakeAgentIncomplete,
@@ -393,7 +577,7 @@ def test_prefetch_editorial_zh_runs_agent_before_translate(tmp_path, monkeypatch
                 _fake_run_agent_for_pid,
             ),
         ), patch(
-            "kouhai_bot.tutorials.translate_editorial_to_zh",
+            "kouhai_bot.editorial_preparation.translate_editorial_to_zh",
             AsyncMock(return_value=("自动抓取后的译文。" * 12, "", True)),
         ):
             await prefetch_editorial_zh("542D")
@@ -404,6 +588,161 @@ def test_prefetch_editorial_zh_runs_agent_before_translate(tmp_path, monkeypatch
     assert has_cached_editorial_zh("542D")
 
 
+def test_prefetch_rejects_wrong_candidate_and_uses_next_blog(tmp_path, monkeypatch):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    statements_dir = tmp_path / "statements"
+    statements_dir.mkdir()
+    (statements_dir / "542D.json").write_text(
+        json.dumps({"description": "statement", "images": []}),
+        encoding="utf-8",
+    )
+    wrong = OfficialEditorial(
+        text=_long_text("wrong-"),
+        tutorial_url="https://codeforces.com/blog/entry/1",
+        tutorial_title="Wrong",
+    )
+    _write_tutorial_for_editorial(tmp_path, "542D", wrong)
+    correct_body = _long_text("correct-")
+    agent_calls: list[frozenset[str]] = []
+
+    async def find_alternative(**kwargs):
+        excluded = kwargs["excluded_tutorial_urls"]
+        agent_calls.append(excluded)
+        assert excluded == frozenset({wrong.tutorial_url})
+        return SimpleNamespace(
+            bundle={
+                "tutorial_url": "https://codeforces.com/blog/entry/2",
+                "tutorial_title": "Correct",
+                "sections": [{
+                    "hint": "",
+                    "solution": correct_body,
+                    "raw_text": correct_body,
+                    "code_blocks": [],
+                }],
+            },
+            selected_candidate_id="b2",
+            confidence=0.95,
+            elapsed_sec=1.0,
+        )
+
+    translate = AsyncMock(side_effect=[
+        (None, "", False),
+        ("正确候选的中文题解。" * 12, "", True),
+    ])
+    with patch(
+        "kouhai_bot.editorial_preparation._load_tutorial_agent",
+        return_value=(
+            _FakeAgentNoMatch,
+            _FakeAgentIncomplete,
+            _FakeScrapeError,
+            find_alternative,
+        ),
+    ), patch(
+        "kouhai_bot.editorial_preparation.translate_editorial_to_zh",
+        translate,
+    ):
+        asyncio.run(prefetch_editorial_zh("542D"))
+
+    assert agent_calls == [frozenset({wrong.tutorial_url})]
+    assert translate.await_count == 2
+    assert not is_no_official_editorial("542D")
+    editorial = get_official_editorial("542D")
+    assert editorial is not None
+    assert editorial.tutorial_url.endswith("/2")
+    assert has_cached_editorial_zh("542D")
+
+
+def test_prefetch_mismatch_then_incomplete_search_stays_retryable(
+    tmp_path,
+    monkeypatch,
+):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    statements_dir = tmp_path / "statements"
+    statements_dir.mkdir()
+    (statements_dir / "542D.json").write_text(
+        json.dumps({"description": "statement", "images": []}),
+        encoding="utf-8",
+    )
+    wrong = OfficialEditorial(
+        text=_long_text("wrong-"),
+        tutorial_url="https://codeforces.com/blog/entry/1",
+        tutorial_title="Wrong",
+    )
+    _write_tutorial_for_editorial(tmp_path, "542D", wrong)
+
+    async def incomplete(**kwargs):
+        assert kwargs["excluded_tutorial_urls"] == frozenset({wrong.tutorial_url})
+        raise _FakeAgentIncomplete("second blog timed out")
+
+    with patch(
+        "kouhai_bot.editorial_preparation._load_tutorial_agent",
+        return_value=(
+            _FakeAgentNoMatch,
+            _FakeAgentIncomplete,
+            _FakeScrapeError,
+            incomplete,
+        ),
+    ), patch(
+        "kouhai_bot.editorial_preparation.translate_editorial_to_zh",
+        AsyncMock(return_value=(None, "", False)),
+    ):
+        asyncio.run(prefetch_editorial_zh("542D"))
+
+    assert not is_no_official_editorial("542D")
+    assert get_official_editorial("542D") is None
+    assert not has_cached_editorial_zh("542D")
+
+
+def test_prefetch_marks_terminal_only_after_mismatch_and_exhaustive_search(
+    tmp_path,
+    monkeypatch,
+):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    statements_dir = tmp_path / "statements"
+    statements_dir.mkdir()
+    (statements_dir / "542D.json").write_text(
+        json.dumps({"description": "statement", "images": []}),
+        encoding="utf-8",
+    )
+    wrong = OfficialEditorial(
+        text=_long_text("wrong-"),
+        tutorial_url="https://codeforces.com/blog/entry/1",
+        tutorial_title="Wrong",
+    )
+    _write_tutorial_for_editorial(tmp_path, "542D", wrong)
+
+    async def no_remaining_match(**kwargs):
+        assert kwargs["excluded_tutorial_urls"] == frozenset({wrong.tutorial_url})
+        raise _FakeAgentNoMatch("all remaining blogs explicitly rejected")
+
+    with patch(
+        "kouhai_bot.editorial_preparation._load_tutorial_agent",
+        return_value=(
+            _FakeAgentNoMatch,
+            _FakeAgentIncomplete,
+            _FakeScrapeError,
+            no_remaining_match,
+        ),
+    ), patch(
+        "kouhai_bot.editorial_preparation.translate_editorial_to_zh",
+        AsyncMock(return_value=(None, "", False)),
+    ):
+        asyncio.run(prefetch_editorial_zh("542D"))
+
+    assert is_no_official_editorial("542D")
+    assert get_official_editorial("542D") is None
+    assert not has_cached_editorial_zh("542D")
+
+
 def test_prefetch_editorial_zh_marks_only_completed_no_match(tmp_path, monkeypatch):
     from kouhai_bot.config import BotConfig
 
@@ -411,14 +750,17 @@ def test_prefetch_editorial_zh_marks_only_completed_no_match(tmp_path, monkeypat
     monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
     statements_dir = tmp_path / "statements"
     statements_dir.mkdir()
-    (statements_dir / "542D.json").write_text("{}", encoding="utf-8")
+    (statements_dir / "542D.json").write_text(
+        json.dumps({"description": "statement", "images": []}),
+        encoding="utf-8",
+    )
 
     async def no_match(**_kwargs):
         raise _FakeAgentNoMatch("complete search found no matching editorial")
 
     async def _run():
         with patch(
-            "kouhai_bot.tutorials._load_tutorial_agent",
+            "kouhai_bot.editorial_preparation._load_tutorial_agent",
             return_value=(
                 _FakeAgentNoMatch,
                 _FakeAgentIncomplete,
@@ -442,14 +784,17 @@ def test_prefetch_editorial_zh_incomplete_attempt_remains_retryable(
     monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
     statements_dir = tmp_path / "statements"
     statements_dir.mkdir()
-    (statements_dir / "542D.json").write_text("{}", encoding="utf-8")
+    (statements_dir / "542D.json").write_text(
+        json.dumps({"description": "statement", "images": []}),
+        encoding="utf-8",
+    )
 
     async def incomplete(**_kwargs):
         raise _FakeAgentIncomplete("deadline exceeded")
 
     async def _run():
         with patch(
-            "kouhai_bot.tutorials._load_tutorial_agent",
+            "kouhai_bot.editorial_preparation._load_tutorial_agent",
             return_value=(
                 _FakeAgentNoMatch,
                 _FakeAgentIncomplete,
@@ -474,7 +819,10 @@ def test_prefetch_editorial_zh_cancellation_remains_incomplete(
     monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
     statements_dir = tmp_path / "statements"
     statements_dir.mkdir()
-    (statements_dir / "542D.json").write_text("{}", encoding="utf-8")
+    (statements_dir / "542D.json").write_text(
+        json.dumps({"description": "statement", "images": []}),
+        encoding="utf-8",
+    )
     started = asyncio.Event()
 
     async def blocked(**_kwargs):
@@ -483,7 +831,7 @@ def test_prefetch_editorial_zh_cancellation_remains_incomplete(
 
     async def _run():
         with patch(
-            "kouhai_bot.tutorials._load_tutorial_agent",
+            "kouhai_bot.editorial_preparation._load_tutorial_agent",
             return_value=(
                 _FakeAgentNoMatch,
                 _FakeAgentIncomplete,
@@ -519,6 +867,7 @@ def test_prefetch_editorial_zh_caches_translation(tmp_path, monkeypatch):
 
     cfg = BotConfig(data_dir=str(tmp_path))
     monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    _write_statement(tmp_path, "542D")
     tutorials_dir = tmp_path / "tutorials"
     tutorials_dir.mkdir()
     body = _long_text("prefetch-")
@@ -532,7 +881,7 @@ def test_prefetch_editorial_zh_caches_translation(tmp_path, monkeypatch):
 
     async def _run():
         with patch(
-            "kouhai_bot.tutorials.translate_editorial_to_zh",
+            "kouhai_bot.editorial_preparation.translate_editorial_to_zh",
             AsyncMock(return_value=("预取译文 \\(x \\le n\\)。" * 15, "", True)),
         ):
             await prefetch_editorial_zh("542D")
@@ -606,6 +955,52 @@ def test_startup_resumes_full_prefetch_for_current_problem(tmp_path, monkeypatch
     assert scheduled == ["542D"]
 
 
+def test_editorial_maintenance_retries_both_current_and_ready_problem(
+    tmp_path,
+    monkeypatch,
+):
+    from kouhai_bot import editorial_followup
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    state_dir = tmp_path / "groups" / "1"
+    state_dir.mkdir(parents=True)
+    (state_dir / "state.json").write_text(
+        json.dumps({"today": "CURRENT"}),
+        encoding="utf-8",
+    )
+    calls: list[str] = []
+    retried = asyncio.Event()
+
+    def ensure(pid):
+        calls.append(pid)
+        if calls.count("CURRENT") >= 2 and calls.count("NEXT") >= 2:
+            retried.set()
+
+    async def next_pid():
+        return "NEXT"
+
+    monkeypatch.setattr(editorial_followup, "get_config", lambda: cfg)
+    monkeypatch.setattr(editorial_followup, "ensure_editorial_prefetch", ensure)
+
+    async def run():
+        stop = asyncio.Event()
+        task = asyncio.create_task(
+            editorial_followup.editorial_prefetch_maintenance_loop(
+                1,
+                get_next_problem_pid=next_pid,
+                stop_event=stop,
+                interval_seconds=0.01,
+            )
+        )
+        await asyncio.wait_for(retried.wait(), timeout=1)
+        stop.set()
+        await task
+
+    asyncio.run(run())
+    assert calls[:4] == ["CURRENT", "NEXT", "CURRENT", "NEXT"]
+
+
 def test_post_solve_missing_editorial_does_not_create_terminal_marker(
     tmp_path,
     monkeypatch,
@@ -635,22 +1030,27 @@ def test_deliver_uses_prefetch_cache_without_translate(tmp_path, monkeypatch):
     cfg = BotConfig(data_dir=str(tmp_path))
     monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
     monkeypatch.setattr("kouhai_bot.editorial_followup.get_config", lambda: cfg)
-    cache_dir = tmp_path / "tutorial_translations"
-    cache_dir.mkdir()
-    (cache_dir / "542D.txt").write_text("预取译文。" * 20, encoding="utf-8")
-    (cache_dir / "542D.verified").write_text("", encoding="utf-8")
+    editorial = OfficialEditorial(
+        text=_long_text("source-"),
+        tutorial_url="https://example.com/e",
+        tutorial_title="T",
+    )
+    _write_verified_cache(tmp_path, "542D", editorial, "预取译文。" * 20)
 
     async def _fail_translate(*args, **kwargs):
         raise AssertionError("translate should not run when cache is warm")
 
     async def _run():
-        with patch("kouhai_bot.tutorials.translate_editorial_to_zh", _fail_translate), \
+        with patch(
+                "kouhai_bot.editorial_preparation.translate_editorial_to_zh",
+                _fail_translate,
+        ), \
                 patch("kouhai_bot.editorial_followup.send_private_msg", AsyncMock(return_value=1)), \
                 patch("kouhai_bot.editorial_followup.send_group_forward_msg", AsyncMock(return_value=99)):
             await deliver_official_tutorial_forward(
                 1,
                 "542D",
-                OfficialEditorial(text="x", tutorial_url="", tutorial_title=""),
+                editorial,
             )
 
     asyncio.run(_run())
@@ -662,10 +1062,12 @@ def test_run_post_solve_skips_prefetch_wait_when_cache_warm(tmp_path, monkeypatc
     cfg = BotConfig(data_dir=str(tmp_path))
     monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
     monkeypatch.setattr("kouhai_bot.editorial_followup.get_config", lambda: cfg)
-    cache_dir = tmp_path / "tutorial_translations"
-    cache_dir.mkdir()
-    (cache_dir / "542D.txt").write_text("预取译文。" * 20, encoding="utf-8")
-    (cache_dir / "542D.verified").write_text("", encoding="utf-8")
+    editorial = OfficialEditorial(
+        text=_long_text("source-"),
+        tutorial_url="https://example.com/e",
+        tutorial_title="T",
+    )
+    _write_verified_cache(tmp_path, "542D", editorial, "预取译文。" * 20)
 
     async def _fail_await(pid):
         raise AssertionError("should not wait for prefetch when cache is warm")

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -6,6 +6,8 @@ import os
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from unittest.mock import AsyncMock, patch
@@ -22,6 +24,18 @@ from kouhai_bot.tutorials import (
     mark_no_official_editorial,
     prefetch_editorial_zh,
 )
+
+
+class _FakeAgentNoMatch(Exception):
+    pass
+
+
+class _FakeAgentIncomplete(Exception):
+    pass
+
+
+class _FakeScrapeError(Exception):
+    pass
 
 
 def _long_text(prefix: str = "x") -> str:
@@ -275,7 +289,25 @@ def test_prefetch_editorial_zh_recovers_after_rescrape(tmp_path, monkeypatch):
     assert has_cached_editorial_zh("542D")
 
 
-def test_prefetch_editorial_zh_marks_missing(tmp_path, monkeypatch):
+def test_legacy_no_editorial_marker_is_not_a_trusted_terminal_state(
+    tmp_path,
+    monkeypatch,
+):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    marker_dir = tmp_path / "tutorial_translations"
+    marker_dir.mkdir()
+    (marker_dir / "542D.no_editorial").write_text("", encoding="utf-8")
+
+    assert not is_no_official_editorial("542D")
+
+    mark_no_official_editorial("542D", reason="agent_no_match:test")
+    assert is_no_official_editorial("542D")
+
+
+def test_prefetch_editorial_zh_without_statement_stays_incomplete(tmp_path, monkeypatch):
     from kouhai_bot.config import BotConfig
 
     cfg = BotConfig(data_dir=str(tmp_path))
@@ -285,7 +317,7 @@ def test_prefetch_editorial_zh_marks_missing(tmp_path, monkeypatch):
         await prefetch_editorial_zh("999Z")
 
     asyncio.run(_run())
-    assert is_no_official_editorial("999Z")
+    assert not is_no_official_editorial("999Z")
 
 
 def test_prefetch_editorial_zh_no_agent_leaves_missing_unknown(tmp_path, monkeypatch):
@@ -312,8 +344,11 @@ def test_prefetch_editorial_zh_no_agent_leaves_missing_unknown(tmp_path, monkeyp
 def test_tutorial_agent_importable_from_runtime():
     from kouhai_bot.tutorials import _load_tutorial_agent
 
-    AgentNoMatch, ScrapeError, run_agent_for_pid = _load_tutorial_agent()
+    AgentNoMatch, AgentIncomplete, ScrapeError, run_agent_for_pid = (
+        _load_tutorial_agent()
+    )
     assert issubclass(AgentNoMatch, Exception)
+    assert issubclass(AgentIncomplete, Exception)
     assert issubclass(ScrapeError, Exception)
     assert run_agent_for_pid.__name__ == "run_agent_for_pid"
 
@@ -330,12 +365,6 @@ def test_prefetch_editorial_zh_runs_agent_before_translate(tmp_path, monkeypatch
         encoding="utf-8",
     )
     mark_no_official_editorial("542D")
-
-    class FakeAgentNoMatch(Exception):
-        pass
-
-    class FakeScrapeError(Exception):
-        pass
 
     async def _fake_run_agent_for_pid(*, pid, statements_dir):
         assert pid == "542D"
@@ -357,7 +386,12 @@ def test_prefetch_editorial_zh_runs_agent_before_translate(tmp_path, monkeypatch
     async def _run():
         with patch(
             "kouhai_bot.tutorials._load_tutorial_agent",
-            return_value=(FakeAgentNoMatch, FakeScrapeError, _fake_run_agent_for_pid),
+            return_value=(
+                _FakeAgentNoMatch,
+                _FakeAgentIncomplete,
+                _FakeScrapeError,
+                _fake_run_agent_for_pid,
+            ),
         ), patch(
             "kouhai_bot.tutorials.translate_editorial_to_zh",
             AsyncMock(return_value=("自动抓取后的译文。" * 12, "", True)),
@@ -368,6 +402,104 @@ def test_prefetch_editorial_zh_runs_agent_before_translate(tmp_path, monkeypatch
     assert not is_no_official_editorial("542D")
     assert get_official_editorial("542D") is not None
     assert has_cached_editorial_zh("542D")
+
+
+def test_prefetch_editorial_zh_marks_only_completed_no_match(tmp_path, monkeypatch):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    statements_dir = tmp_path / "statements"
+    statements_dir.mkdir()
+    (statements_dir / "542D.json").write_text("{}", encoding="utf-8")
+
+    async def no_match(**_kwargs):
+        raise _FakeAgentNoMatch("complete search found no matching editorial")
+
+    async def _run():
+        with patch(
+            "kouhai_bot.tutorials._load_tutorial_agent",
+            return_value=(
+                _FakeAgentNoMatch,
+                _FakeAgentIncomplete,
+                _FakeScrapeError,
+                no_match,
+            ),
+        ):
+            await prefetch_editorial_zh("542D")
+
+    asyncio.run(_run())
+    assert is_no_official_editorial("542D")
+
+
+def test_prefetch_editorial_zh_incomplete_attempt_remains_retryable(
+    tmp_path,
+    monkeypatch,
+):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    statements_dir = tmp_path / "statements"
+    statements_dir.mkdir()
+    (statements_dir / "542D.json").write_text("{}", encoding="utf-8")
+
+    async def incomplete(**_kwargs):
+        raise _FakeAgentIncomplete("deadline exceeded")
+
+    async def _run():
+        with patch(
+            "kouhai_bot.tutorials._load_tutorial_agent",
+            return_value=(
+                _FakeAgentNoMatch,
+                _FakeAgentIncomplete,
+                _FakeScrapeError,
+                incomplete,
+            ),
+        ):
+            await prefetch_editorial_zh("542D")
+
+    asyncio.run(_run())
+    assert not is_no_official_editorial("542D")
+    assert not has_cached_editorial_zh("542D")
+
+
+def test_prefetch_editorial_zh_cancellation_remains_incomplete(
+    tmp_path,
+    monkeypatch,
+):
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    statements_dir = tmp_path / "statements"
+    statements_dir.mkdir()
+    (statements_dir / "542D.json").write_text("{}", encoding="utf-8")
+    started = asyncio.Event()
+
+    async def blocked(**_kwargs):
+        started.set()
+        await asyncio.Event().wait()
+
+    async def _run():
+        with patch(
+            "kouhai_bot.tutorials._load_tutorial_agent",
+            return_value=(
+                _FakeAgentNoMatch,
+                _FakeAgentIncomplete,
+                _FakeScrapeError,
+                blocked,
+            ),
+        ):
+            task = asyncio.create_task(prefetch_editorial_zh("542D"))
+            await started.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+    asyncio.run(_run())
+    assert not is_no_official_editorial("542D")
+    assert not has_cached_editorial_zh("542D")
 
 
 def test_ensure_tutorial_json_returns_false_without_statement(tmp_path, monkeypatch):
@@ -447,6 +579,53 @@ def test_ensure_editorial_prefetch_runs_full_pipeline_and_respects_terminal_stat
     no_editorial = True
     editorial_followup.ensure_editorial_prefetch("542D")
     assert scheduled == [("542D", True)]
+
+
+def test_startup_resumes_full_prefetch_for_current_problem(tmp_path, monkeypatch):
+    from kouhai_bot import editorial_followup
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    state_dir = tmp_path / "groups" / "1"
+    state_dir.mkdir(parents=True)
+    (state_dir / "state.json").write_text(
+        json.dumps({"today": "542D"}),
+        encoding="utf-8",
+    )
+    scheduled: list[str] = []
+
+    monkeypatch.setattr(editorial_followup, "get_config", lambda: cfg)
+    monkeypatch.setattr(
+        editorial_followup,
+        "ensure_editorial_prefetch",
+        scheduled.append,
+    )
+
+    editorial_followup.schedule_prefetch_for_group_today(1)
+
+    assert scheduled == ["542D"]
+
+
+def test_post_solve_missing_editorial_does_not_create_terminal_marker(
+    tmp_path,
+    monkeypatch,
+):
+    from kouhai_bot import editorial_followup
+    from kouhai_bot.config import BotConfig
+
+    cfg = BotConfig(data_dir=str(tmp_path))
+    monkeypatch.setattr("kouhai_bot.tutorials.get_config", lambda: cfg)
+    monkeypatch.setattr(editorial_followup, "get_config", lambda: cfg)
+    monkeypatch.setattr(
+        editorial_followup,
+        "_await_prefetch_if_running",
+        AsyncMock(),
+    )
+
+    asyncio.run(editorial_followup.run_post_solve_editorial_followup(1, "542D"))
+
+    assert not is_no_official_editorial("542D")
+    assert not has_cached_editorial_zh("542D")
 
 
 def test_deliver_uses_prefetch_cache_without_translate(tmp_path, monkeypatch):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import sys
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
@@ -36,9 +36,23 @@ def test_worker_owns_next_problem_prefetch_lifecycle(monkeypatch):
         await stop_event.wait()
         calls.append("prefetch_stop")
 
+    async def run_editorial(
+        group_id,
+        *,
+        get_next_problem_pid,
+        stop_event,
+    ):
+        assert group_id == 123
+        assert await get_next_problem_pid() == "542D"
+        calls.append("editorial_start")
+        await stop_event.wait()
+        calls.append("editorial_stop")
+
     prefetcher = SimpleNamespace(
         run=run_prefetch,
+        peek_pid=AsyncMock(return_value="542D"),
         shutdown=AsyncMock(),
+        set_ready_observer=MagicMock(),
     )
 
     monkeypatch.setattr(
@@ -50,6 +64,11 @@ def test_worker_owns_next_problem_prefetch_lifecycle(monkeypatch):
     monkeypatch.setattr(worker, "bootstrap_runtime", lambda: calls.append("bootstrap"))
     monkeypatch.setattr(worker, "scheduler_loop", wait_for_stop)
     monkeypatch.setattr(worker, "doubt_friend_request_loop", wait_for_stop)
+    monkeypatch.setattr(
+        worker,
+        "editorial_prefetch_maintenance_loop",
+        run_editorial,
+    )
     monkeypatch.setattr(
         worker,
         "get_next_problem_prefetcher",
@@ -72,10 +91,16 @@ def test_worker_owns_next_problem_prefetch_lifecycle(monkeypatch):
         "bootstrap",
         "napcat_start",
         "prefetch_start",
+        "editorial_start",
         "napcat_stop",
         "prefetch_stop",
+        "editorial_stop",
     ]
     assert runtime._scheduler_stop.is_set()
     assert runtime._friend_request_stop.is_set()
     assert runtime._problem_prefetch_stop.is_set()
+    assert runtime._editorial_prefetch_stop.is_set()
     prefetcher.shutdown.assert_awaited_once()
+    prefetcher.set_ready_observer.assert_called_once_with(
+        worker.ensure_editorial_prefetch,
+    )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,81 @@
+"""Worker lifecycle coverage for the next-problem prefetch loop."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from kouhai_bot import worker
+
+
+def test_worker_owns_next_problem_prefetch_lifecycle(monkeypatch):
+    calls: list[str] = []
+    prefetch_started = asyncio.Event()
+
+    class FakeNapCat:
+        def __init__(self, *, on_event):
+            self.on_event = on_event
+
+        async def start(self):
+            calls.append("napcat_start")
+
+        async def stop(self):
+            calls.append("napcat_stop")
+
+    async def wait_for_stop(*, stop_event):
+        await stop_event.wait()
+
+    async def run_prefetch(*, stop_event):
+        calls.append("prefetch_start")
+        prefetch_started.set()
+        await stop_event.wait()
+        calls.append("prefetch_stop")
+
+    prefetcher = SimpleNamespace(
+        run=run_prefetch,
+        shutdown=AsyncMock(),
+    )
+
+    monkeypatch.setattr(
+        worker,
+        "get_config",
+        lambda: SimpleNamespace(current_group=123),
+    )
+    monkeypatch.setattr(worker, "NapCatServer", FakeNapCat)
+    monkeypatch.setattr(worker, "bootstrap_runtime", lambda: calls.append("bootstrap"))
+    monkeypatch.setattr(worker, "scheduler_loop", wait_for_stop)
+    monkeypatch.setattr(worker, "doubt_friend_request_loop", wait_for_stop)
+    monkeypatch.setattr(
+        worker,
+        "get_next_problem_prefetcher",
+        lambda group_id: prefetcher if group_id == 123 else None,
+    )
+
+    async def run():
+        runtime = worker.WorkerRuntime()
+        monkeypatch.setattr(runtime, "_install_signal_handlers", lambda: None)
+        monkeypatch.setattr(runtime, "_wait_for_background_tasks", AsyncMock())
+        task = asyncio.create_task(runtime.run())
+        await asyncio.wait_for(prefetch_started.wait(), timeout=1)
+        runtime._shutdown.set()
+        await asyncio.wait_for(task, timeout=1)
+        return runtime
+
+    runtime = asyncio.run(run())
+
+    assert calls == [
+        "bootstrap",
+        "napcat_start",
+        "prefetch_start",
+        "napcat_stop",
+        "prefetch_stop",
+    ]
+    assert runtime._scheduler_stop.is_set()
+    assert runtime._friend_request_stop.is_set()
+    assert runtime._problem_prefetch_stop.is_set()
+    prefetcher.shutdown.assert_awaited_once()

--- a/tools/cf_tutorial_agent.py
+++ b/tools/cf_tutorial_agent.py
@@ -22,7 +22,7 @@ from urllib.parse import urldefrag, urljoin
 from kouhai_bot.handlers.shared import parse_json_with_llm_repair
 from kouhai_bot.llm import chat_completion
 from kouhai_bot.problems.cf_fetcher import content_valid
-from kouhai_bot.tutorials import MIN_EDITORIAL_LEN, extract_editorial
+from kouhai_bot.editorial_content import MIN_EDITORIAL_LEN, extract_editorial
 
 from scrape_cf_tutorial import ScrapeError
 from scrape_cf_tutorial import Section
@@ -134,7 +134,7 @@ def statement_to_text(stmt: dict[str, Any], *, limit: int = 12000) -> str:
     return text
 
 
-def extract_blog_links(problem_html: str, base_url: str, *, limit: int) -> list[str]:
+def extract_blog_links(problem_html: str, base_url: str, *, limit: int = 0) -> list[str]:
     anchor_re = re.compile(
         r"<a[^>]+href\s*=\s*['\"](?P<href>[^'\"]+)['\"][^>]*>(?P<text>[\s\S]*?)</a>",
         re.I,
@@ -158,7 +158,10 @@ def extract_blog_links(problem_html: str, base_url: str, *, limit: int) -> list[
             score -= 20
         scored.append((-score, pos, url))
     scored.sort()
-    return [url for _, _, url in scored[: max(1, limit)]]
+    urls = [url for _, _, url in scored]
+    if limit > 0:
+        return urls[:limit]
+    return urls
 
 
 def _section_from_text(label: str, title: str, text: str) -> Section:
@@ -193,16 +196,31 @@ def collect_blog_documents(
     fetcher: str,
     pw_wait_ms: int,
     blog_limit: int,
+    excluded_tutorial_urls: frozenset[str] = frozenset(),
 ) -> tuple[str, str, list[BlogDocument], tuple[str, ...]]:
     problem_url = build_problem_url_from_pid(pid)
     problem_html = fetch_html(problem_url, fetcher=fetcher, pw_wait_ms=pw_wait_ms)
     problem_title = extract_problem_title(problem_html)
-    blog_urls = extract_blog_links(problem_html, problem_url, limit=blog_limit)
-    if not blog_urls:
+    all_blog_urls = extract_blog_links(problem_html, problem_url)
+    if not all_blog_urls:
         raise AgentNoMatch("problem_page_has_no_blog_entry_links")
+    remaining_blog_urls = [
+        url for url in all_blog_urls if url not in excluded_tutorial_urls
+    ]
+    if not remaining_blog_urls:
+        raise AgentNoMatch("all_blog_entry_links_excluded")
+
+    search_truncated = blog_limit > 0 and len(remaining_blog_urls) > blog_limit
+    blog_urls = (
+        remaining_blog_urls[:blog_limit]
+        if blog_limit > 0
+        else remaining_blog_urls
+    )
 
     blogs: list[BlogDocument] = []
-    incomplete_failures: list[str] = []
+    incomplete_failures: list[str] = (
+        ["candidate_limit_reached"] if search_truncated else []
+    )
     for idx, blog_url in enumerate(blog_urls, start=1):
         try:
             tutorial_html = fetch_html(blog_url, fetcher=fetcher, pw_wait_ms=pw_wait_ms)
@@ -425,6 +443,7 @@ async def run_agent_for_pid(
     selector_timeout_sec: int = DEFAULT_SELECTOR_TIMEOUT_SEC,
     confidence_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD,
     llm_text_limit: int = DEFAULT_LLM_TEXT_LIMIT,
+    excluded_tutorial_urls: frozenset[str] = frozenset(),
 ) -> AgentResult:
     started = time.monotonic()
     stmt = load_statement(statements_dir / f"{pid}.json")
@@ -442,6 +461,7 @@ async def run_agent_for_pid(
             fetcher=fetcher,
             pw_wait_ms=pw_wait_ms,
             blog_limit=blog_limit,
+            excluded_tutorial_urls=excluded_tutorial_urls,
         )
         no_match_failures: list[str] = []
         incomplete_failures = list(collection_incomplete)

--- a/tools/cf_tutorial_agent.py
+++ b/tools/cf_tutorial_agent.py
@@ -47,6 +47,10 @@ class AgentNoMatch(RuntimeError):
     """Expected no-result outcome. The caller should not write a tutorial JSON."""
 
 
+class AgentIncomplete(RuntimeError):
+    """The search did not reach a reliable terminal result and may be retried."""
+
+
 @dataclass(frozen=True)
 class EditorialCandidate:
     candidate_id: str
@@ -189,7 +193,7 @@ def collect_blog_documents(
     fetcher: str,
     pw_wait_ms: int,
     blog_limit: int,
-) -> tuple[str, str, list[BlogDocument]]:
+) -> tuple[str, str, list[BlogDocument], tuple[str, ...]]:
     problem_url = build_problem_url_from_pid(pid)
     problem_html = fetch_html(problem_url, fetcher=fetcher, pw_wait_ms=pw_wait_ms)
     problem_title = extract_problem_title(problem_html)
@@ -198,10 +202,12 @@ def collect_blog_documents(
         raise AgentNoMatch("problem_page_has_no_blog_entry_links")
 
     blogs: list[BlogDocument] = []
+    incomplete_failures: list[str] = []
     for idx, blog_url in enumerate(blog_urls, start=1):
         try:
             tutorial_html = fetch_html(blog_url, fetcher=fetcher, pw_wait_ms=pw_wait_ms)
             if not content_valid(tutorial_html):
+                incomplete_failures.append(f"b{idx}:invalid_blog_content")
                 continue
             tutorial_title = extract_page_title(tutorial_html)
             body_html = extract_blog_body_html(tutorial_html)
@@ -218,7 +224,8 @@ def collect_blog_documents(
                     f"[Codeforces dynamic tutorial fragment for {pid} - {title}]\n"
                     f"{dynamic_text.strip()}"
                 ).strip()
-        except ScrapeError:
+        except ScrapeError as exc:
+            incomplete_failures.append(f"b{idx}:scrape_error:{exc}")
             continue
         if body.strip():
             blogs.append(
@@ -231,8 +238,10 @@ def collect_blog_documents(
             )
 
     if not blogs:
+        if incomplete_failures:
+            raise AgentIncomplete("; ".join(incomplete_failures))
         raise AgentNoMatch("no_readable_blog_bodies")
-    return problem_url, problem_title, blogs
+    return problem_url, problem_title, blogs, tuple(incomplete_failures)
 
 
 def _build_extractor_messages(
@@ -331,7 +340,7 @@ async def extract_editorial_from_blog(
         send_reasoning_effort=False,
     )
     if not result.text:
-        raise AgentNoMatch(f"extractor_llm_failed:{result.failure_kind}")
+        raise AgentIncomplete(f"extractor_llm_failed:{result.failure_kind}")
 
     parsed, _repair_tag = await parse_json_with_llm_repair(
         result.text,
@@ -344,14 +353,17 @@ async def extract_editorial_from_blog(
         task="summary",
         timeout=timeout,
     )
-    if parsed.get("match") is not True:
+    match = parsed.get("match")
+    if match is False:
         raise AgentNoMatch(str(parsed.get("reason") or "extractor_no_match"))
+    if match is not True:
+        raise AgentIncomplete("extractor_invalid_match_result")
 
     start_text = str(parsed.get("start_text") or "").strip()
     end_text = str(parsed.get("end_text") or "").strip()
     editorial_text = _extract_body_span(blog.body, start_text, end_text)
     if len(editorial_text) < MIN_EDITORIAL_LEN:
-        raise AgentNoMatch("extractor_span_not_found_or_too_short")
+        raise AgentIncomplete("extractor_span_not_found_or_too_short")
 
     try:
         confidence = float(parsed.get("confidence"))
@@ -419,14 +431,20 @@ async def run_agent_for_pid(
     problem_text = statement_to_text(stmt)
 
     async def _run() -> AgentResult:
-        problem_url, problem_title, blogs = await asyncio.to_thread(
+        (
+            problem_url,
+            problem_title,
+            blogs,
+            collection_incomplete,
+        ) = await asyncio.to_thread(
             collect_blog_documents,
             pid=pid,
             fetcher=fetcher,
             pw_wait_ms=pw_wait_ms,
             blog_limit=blog_limit,
         )
-        failures: list[str] = []
+        no_match_failures: list[str] = []
+        incomplete_failures = list(collection_incomplete)
         selected: EditorialCandidate | None = None
         confidence = 0.0
         reason = ""
@@ -441,11 +459,14 @@ async def run_agent_for_pid(
                     timeout=selector_timeout_sec,
                     llm_text_limit=llm_text_limit,
                 )
+            except AgentIncomplete as exc:
+                incomplete_failures.append(f"{blog.blog_id}:{exc}")
+                continue
             except AgentNoMatch as exc:
-                failures.append(f"{blog.blog_id}:{exc}")
+                no_match_failures.append(f"{blog.blog_id}:{exc}")
                 continue
             if candidate_confidence < confidence_threshold:
-                failures.append(
+                no_match_failures.append(
                     f"{blog.blog_id}:extractor_low_confidence:{candidate_confidence:.2f}:"
                     f"{candidate_reason or candidate.title}"
                 )
@@ -456,7 +477,10 @@ async def run_agent_for_pid(
             break
 
         if selected is None:
-            detail = "; ".join(failures) if failures else "extractor_no_match"
+            all_failures = [*no_match_failures, *incomplete_failures]
+            detail = "; ".join(all_failures) if all_failures else "extractor_no_match"
+            if incomplete_failures:
+                raise AgentIncomplete(detail)
             raise AgentNoMatch(detail)
 
         elapsed = time.monotonic() - started
@@ -482,4 +506,4 @@ async def run_agent_for_pid(
     try:
         return await asyncio.wait_for(_run(), timeout=max(1, deadline_sec))
     except asyncio.TimeoutError as exc:
-        raise AgentNoMatch(f"deadline_exceeded:{deadline_sec}s") from exc
+        raise AgentIncomplete(f"deadline_exceeded:{deadline_sec}s") from exc

--- a/tools/tutorial_tools.py
+++ b/tools/tutorial_tools.py
@@ -24,7 +24,11 @@ sys.path.insert(0, str(ROOT / "src"))
 from kouhai_bot.config import get_config
 from kouhai_bot.handlers.shared import robust_json_parse, translate_editorial_to_zh
 from kouhai_bot.llm import chat_completion
-from kouhai_bot.tutorials import MIN_EDITORIAL_LEN, _is_placeholder, extract_editorial
+from kouhai_bot.editorial_content import (
+    MIN_EDITORIAL_LEN,
+    extract_editorial,
+    is_placeholder as _is_placeholder,
+)
 
 from cf_tutorial_agent import AgentNoMatch
 from cf_tutorial_agent import DEFAULT_CANDIDATE_LIMIT


### PR DESCRIPTION
## Summary

- Keep one durable, source-bound next-problem slot warm so `/np` normally only claims prepared content, sends the QQ card, and commits state.
- Preserve selection, retries, summary fallback, notes, cooldown/force, delivery fallback, and post-commit behavior. `/sp` and `/sp random` remain live-fetch paths.
- Prefetch official-editorial work independently for both the current problem and the READY next problem, without making editorial latency block `/np`.

## Concurrency and lifecycle

The problem slot follows `EMPTY -> BUILDING -> READY -> CLAIMED -> EMPTY`:

- A short coordinator lock protects only task/slot handoff. Picker, Playwright, LLM work, QQ delivery, and filesystem preparation do not run under it.
- Background maintenance and a cold `/np` share one shielded single-flight build.
- CLAIMED prevents refill until publication finishes; cancellation-safe release wakes the worker refill loop.
- The worker owns separate problem and editorial maintenance loops. A generic READY observer starts editorial work immediately, while the periodic loop retries incomplete work for both current and next pid.
- In-flight editorial work is deduplicated by pid. First AC only delivers verified cached content or awaits an already-running prefetch; it never starts the expensive pipeline.

## Transactional readiness

Preparation and persistence now have explicit boundaries:

- `editorial_content.py` owns pure normalized models/extraction rules.
- `editorial_preparation.py` performs the complete side-effect-free action: exhaustive candidate discovery, statement-based validation, and translation.
- `tutorials.py` is the persistence/read boundary. It writes source and translation first, then writes the statement/editorial-bound verified marker last.
- Cancellation, deadline expiry, scraper failures, LLM failures, and capped/non-exhaustive search remain `INCOMPLETE`; they never create a failure marker.
- A no-editorial marker requires a completed exhaustive search, a non-empty failure reason, and the current statement fingerprint.
- Only verified editorials are available to delivery, `/review`, and submit follow-up judging. Unverified legacy/raw candidates cannot leak into user-visible or judge context.

The same pattern is applied to problem summaries:

- `problem_summary.py` owns the complete side-effect-free audited summary action.
- Persisted summaries and READY problem slots are bound to the exact semantic statement fingerprint.
- The existing availability policy remains: after both summary attempts fail, the problem may still be posted without a summary, explicitly represented as `summary_status=incomplete`.

## Maintainability

- `problem_content.py` centralizes statement loading/fingerprinting and card sample/notes formatting.
- `problems/content.py` is the single sample-block normalizer; picker reveal formatting is also shared instead of reimplemented.
- Dependencies now flow from pure content helpers, to complete preparation actions, to persistence, to worker lifecycle orchestration. The scraper no longer imports the runtime preparation action.
- `AGENTS.md` documents ownership, terminal-state rules, source binding, current/next maintenance, and `/sp` non-participation.

## Correctness and failure behavior

- READY slots are revalidated against rating overrides, current/solved problems, statement presence and fingerprint, and multimodal availability.
- Picker cancellation kills and reaps its subprocess.
- A process termination can lose or redo uncommitted work, but cannot make incomplete content look READY or turn a cancelled crawl into a confirmed no-editorial result.
- `state.json` is still committed only after successful forward-card or direct-fallback delivery.

## Verification

- `pytest -q` — **422 passed**
- `python -m compileall -q src tools tests`
- `git diff --check`
- PR review threads checked: none open or unresolved
