### PR TITLE
Show full problem details in private judge success

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -597,11 +597,12 @@ visible to the poller.
 
 Private `/submit` uses the same judge path and private history, but a correct result
 only marks the problem solved in `private_judge/users/<uid>.json`; it does not update
-the group scoreboard. The private success message includes the
-problem id (for example `做对了 1234A！`) so users can tell which private problem was
-accepted. If the private problem is the current group problem, the success message
-tells the user they can `/sync` in the service group to score it if the group has not
-already solved it.
+the group scoreboard. The private success message includes the full available problem
+identity (`CF{pid} {name} {rating}`, for example `做对了 CF33C Wonderful Randomized
+Sum 1800！`) so users can tell which private problem was accepted. Missing name/rating
+metadata is omitted gracefully. If the private problem is the current group problem,
+the success message tells the user they can `/sync` in the service group to score it
+if the group has not already solved it.
 
 ### `/clarify` — Anti-Spoiler Clarification
 

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -1044,30 +1044,34 @@ class GroupCoordinator:
         await _send_req_plain(req, text)
         req.submit_waiting_reply_sent = True
 
-    def _problem_source_from_snapshot(self, req: PendingRequest, pid: str) -> str:
+    def _problem_label_from_snapshot(self, req: PendingRequest, pid: str) -> str:
         problem = req.submit_problem or {}
-        name = str(problem.get("name", "") or "")
-        rating = str(problem.get("rating", "") or "")
+        name = str(problem.get("name", "") or "").strip()
+        rating = str(problem.get("rating", "") or "").strip()
         parts = [f"CF{pid}"]
         if name:
             parts.append(name)
         if rating and rating != "?":
             parts.append(rating)
-        return f"本题来自 {' '.join(parts)}✨" if parts else ""
+        return " ".join(parts)
+
+    def _problem_source_from_snapshot(self, req: PendingRequest, pid: str) -> str:
+        return f"本题来自 {self._problem_label_from_snapshot(req, pid)}✨"
 
     async def _send_private_success(self, req: PendingRequest, pid: str, model_tag: str = "") -> None:
         mark_private_solved(req.user_id, pid, source="private")
+        problem_label = self._problem_label_from_snapshot(req, pid)
         current_pid = ""
         current = get_today_problem(req.group_id)
         if current:
             current_pid = str(current.get("today", "") or "")
         if current_pid and current_pid == pid:
             text = (
-                f"做对了 {pid}！🎉 private judge 不直接加分。"
+                f"做对了 {problem_label}！🎉 private judge 不直接加分。"
                 "如果群里还没人通过这题，可以到服务群发 /sync，把这次通过同步到群榜。"
             )
         else:
-            text = f"做对了 {pid}！🎉 这次通过只记录在 private judge，不计入群榜。"
+            text = f"做对了 {problem_label}！🎉 这次通过只记录在 private judge，不计入群榜。"
         if model_tag:
             text = text.rstrip() + model_tag
         self._log_finished(req, "correct", problem=pid, extra={"scope": PRIVATE_SCOPE})

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2151,7 +2151,7 @@ def test_clarify_with_problem():
     print("✅ clarify: with problem")
 
 
-def test_private_submit_correct_message_includes_problem_id():
+def test_private_submit_correct_message_includes_full_problem_details():
     _reset_state()
     _setup_problem_for(GID, PID)
     global _deepseek_response
@@ -2166,10 +2166,48 @@ def test_private_submit_correct_message_includes_problem_id():
         asyncio.run(handle(**_kwargs(_make_private_event("/submit valid private solution"))))
 
     private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
-    assert f"做对了 {PID}" in private_text, private_text
+    assert f"做对了 CF{PID} Superhero's Job 2600！🎉" in private_text, private_text
     assert "/sync" in private_text, private_text
     _cleanup()
-    print("✅ private submit: correct message includes pid")
+    print("✅ private submit: correct message includes full problem details")
+
+
+def test_private_submit_correct_non_group_problem_includes_full_problem_details():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _write_statement("33C", {
+        "name": "C. Wonderful Randomized Sum",
+        "time_limit": "2s",
+        "memory_limit": "256MB",
+        "description": "Find the maximum randomized subarray sum.",
+        "input": "An array of integers.",
+        "samples": [{"input": "1\n0", "output": "0"}],
+    })
+    global _deepseek_response
+    _deepseek_response = {"correct": True, "reason": "ok", "reply": ""}
+
+    with _all_patches():
+        from kouhai_bot.handlers.cmd.submit import handle
+        from kouhai_bot.private_judge import set_private_current_problem
+
+        set_private_current_problem(UID, {
+            "today": "33C",
+            "contestId": 33,
+            "index": "C",
+            "name": "Wonderful Randomized Sum",
+            "rating": 1800,
+            "tags": ["dp"],
+            "date": "2026-05-14",
+        })
+        asyncio.run(handle(**_kwargs(_make_private_event("/submit valid private solution"))))
+
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent if item["user_id"] == UID)
+    assert (
+        "做对了 CF33C Wonderful Randomized Sum 1800！🎉 "
+        "这次通过只记录在 private judge，不计入群榜。"
+    ) in private_text, private_text
+    _cleanup()
+    print("✅ private submit: non-group success includes full problem details")
 
 
 def test_private_clarify_uses_private_problem_summary():
@@ -5219,7 +5257,8 @@ if __name__ == "__main__":
     test_private_clear_invalid_usage_sends_text_ack_instead_of_face()
     test_submit_no_problem()
     test_clarify_with_problem()
-    test_private_submit_correct_message_includes_problem_id()
+    test_private_submit_correct_message_includes_full_problem_details()
+    test_private_submit_correct_non_group_problem_includes_full_problem_details()
     test_clarify_no_problem()
     test_clarify_alias_dispatches_to_clarify_handler()
     test_problem_with_data()


### PR DESCRIPTION
## Summary

- Show private judge success messages as `CF{pid} {name} {rating}` in both current-group and standalone-private problem paths.
- Reuse the admission-time problem snapshot and gracefully omit unavailable title/rating metadata.
- Update the development guide and add regression coverage for both success-message variants.

## Why

Private judge AC replies previously showed only the raw problem ID, which made it harder to identify the accepted problem at a glance.

## User impact

A reply such as `做对了 2059E2！` now includes the CF prefix, title, and rating when available, for example `做对了 CF33C Wonderful Randomized Sum 1800！`.

## Validation

- `uv run pytest tests/test_commands.py` — 131 passed
- `git diff --check`