### PR TITLE
feat: add face 314 reaction on first-judge pass before second judge

### DIFF
--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -81,6 +81,7 @@ from ...tutorials import (
 )
 from ...napcat.client import (
     build_at,
+    build_face,
     build_private_reaction_message,
     build_plain_message,
     build_text,
@@ -830,6 +831,10 @@ class GroupCoordinator:
             _log_preview(parsed.get("reason", "")),
         )
         if parsed.get("correct", False) and parsed.get("reaction", "") != "123":
+            if req.is_private:
+                await send_private_msg(req.user_id, [build_face("314")])
+            else:
+                await react_emoji(req.message_id, "314")
             editorial = get_verified_official_editorial(pid)
             if editorial:
                 source = "\n".join(

--- a/src/kouhai_bot/napcat/client.py
+++ b/src/kouhai_bot/napcat/client.py
@@ -220,6 +220,8 @@ def build_private_reaction_message(emoji_id: str | int) -> list[dict]:
         return [build_face("289")]
     if emoji == "123":
         return [build_face("123")]
+    if emoji == "314":
+        return [build_face("314")]
     text = {
         "10060": "👌",
     }.get(emoji, "收到～")


### PR DESCRIPTION
## Summary
- react with QQ face 314 immediately after the first judge passes and before editorial/second-judge work
- send face 314 as a private message for private-judge submissions
- map private reaction 314 to a native QQ face segment

## Tests
- `uv run pytest tests/test_commands.py -x -k 'submit' -v`\n- `uv run pytest tests/test_napcat.py -v`