### PR TITLE
feat: load proxy env from ~/.proxy_env when HTTPS_PROXY is unset

### DIFF
--- a/src/kouhai_bot/main.py
+++ b/src/kouhai_bot/main.py
@@ -139,8 +139,44 @@ def _wait_for_port_bind(port: int, timeout_sec: float) -> bool:
     return _port_has_listener(port)
 
 
+def _load_proxy_env() -> dict[str, str]:
+    """Load proxy variables from ~/.proxy_env, returning a dict suitable for env=."""
+    proxy_env_path = Path.home() / ".proxy_env"
+    if not proxy_env_path.is_file():
+        return {}
+    env_vars: dict[str, str] = {}
+    for line in proxy_env_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Match "export KEY=value" or "export KEY="value""
+        m = re.match(r"export\s+(\w+)=(.*)", line)
+        if not m:
+            continue
+        key = m.group(1)
+        value = m.group(2).strip()
+        # Strip surrounding quotes if present
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        # Resolve $var references (single level only, enough for proxy_env)
+        value = re.sub(
+            r"[$](\w+)",
+            lambda m2: env_vars.get(m2.group(1), os.environ.get(m2.group(1), "")),
+            value,
+        )
+        env_vars[key] = value
+    return env_vars
+
+
 def _spawn_detached_bot(port: int, group_id: int, data_dir: str) -> tuple[int, Path]:
     log_path = _bot_log_path(group_id, data_dir)
+    env = os.environ.copy()
+    if not env.get("HTTPS_PROXY") and not env.get("https_proxy"):
+        proxy_vars = _load_proxy_env()
+        for key in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY",
+                     "NO_PROXY", "no_proxy"):
+            if key in proxy_vars:
+                env[key] = proxy_vars[key]
     with open(log_path, "ab") as log_file:
         proc = subprocess.Popen(
             ["nohup", sys.executable, "-m", "kouhai_bot.worker"],
@@ -150,6 +186,7 @@ def _spawn_detached_bot(port: int, group_id: int, data_dir: str) -> tuple[int, P
             stderr=subprocess.STDOUT,
             start_new_session=True,
             close_fds=True,
+            env=env,
         )
     return proc.pid, log_path
 

--- a/src/kouhai_bot/main.py
+++ b/src/kouhai_bot/main.py
@@ -144,8 +144,12 @@ def _load_proxy_env() -> dict[str, str]:
     proxy_env_path = Path.home() / ".proxy_env"
     if not proxy_env_path.is_file():
         return {}
+    try:
+        lines = proxy_env_path.read_text().splitlines()
+    except OSError:
+        return {}
     env_vars: dict[str, str] = {}
-    for line in proxy_env_path.read_text().splitlines():
+    for line in lines:
         line = line.strip()
         if not line or line.startswith("#"):
             continue
@@ -161,7 +165,7 @@ def _load_proxy_env() -> dict[str, str]:
         # Resolve $var references (single level only, enough for proxy_env)
         value = re.sub(
             r"[$](\w+)",
-            lambda m2: env_vars.get(m2.group(1), os.environ.get(m2.group(1), "")),
+            lambda m2: env_vars.get(m2.group(1), ""),
             value,
         )
         env_vars[key] = value

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,6 +19,30 @@ def test_bot_log_path_uses_group_and_local_date(tmp_path):
     assert path == tmp_path / "logs" / "123456" / f"{expected_date}.log"
 
 
+def test_load_proxy_env_does_not_resolve_forward_refs_from_process_env(tmp_path):
+    (tmp_path / ".proxy_env").write_text(
+        "export HTTPS_PROXY=$PROXY_URL\n"
+        "export PROXY_URL=http://proxy.example:8080\n"
+    )
+
+    with patch("kouhai_bot.main.Path.home", return_value=tmp_path), \
+            patch.dict(os.environ, {"PROXY_URL": "http://unrelated.example:3128"}):
+        proxy_vars = main._load_proxy_env()
+
+    assert proxy_vars == {
+        "HTTPS_PROXY": "",
+        "PROXY_URL": "http://proxy.example:8080",
+    }
+
+
+def test_load_proxy_env_returns_empty_when_file_cannot_be_read(tmp_path):
+    (tmp_path / ".proxy_env").touch()
+
+    with patch("kouhai_bot.main.Path.home", return_value=tmp_path), \
+            patch("kouhai_bot.main.Path.read_text", side_effect=PermissionError):
+        assert main._load_proxy_env() == {}
+
+
 def test_start_reports_already_running_without_spawning():
     cfg = SimpleNamespace(napcat_ws_port=8097, current_group=123456, data_dir="/tmp/data")
     printed = []


### PR DESCRIPTION
## Summary

After `uv run restart`, the detached bot process may not inherit HTTPS_PROXY/HTTP_PROXY because the invoking shell (often a non-interactive, non-login shell) doesn't source `.zshrc` / `.bashrc`.

This PR adds `_load_proxy_env()` which parses `~/.proxy_env` (if present) to extract proxy variables. In `_spawn_detached_bot()`, if `HTTPS_PROXY` is unset, the function loads proxy variables and passes them explicitly via `env=` to `Popen`.

## Changes

- `src/kouhai_bot/main.py`: new `_load_proxy_env()` function that parses shell `export KEY=VALUE` lines from `~/.proxy_env`, resolves single-level $var references
- `_spawn_detached_bot()`: builds an explicit `env` dict with proxy variables when missing

## Why

Without this, the bot connects to external LLM providers (e.g. zenmux.ai) directly instead of through the proxy, causing TCP SYN-SENT hangs and multi-minute timeouts on every LLM call. Symptoms: /clarify hangs, prefetch fails with "Missing dependencies for SOCKS support".