### PR TITLE
fix: only react face 314 when a second judge actually runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -596,6 +596,11 @@ visible to the poller.
     not-counted message and **do not** send the official tutorial again.
 15. If incorrect: reply with judge's reason.
 
+The face 314 reaction (group `react_emoji` / private `face` 314) is sent only when a
+first-pass correct verdict is followed by an actual second judge — i.e. a verified
+official editorial is cached (`get_verified_official_editorial` returns non-None).
+Without a cached editorial there is no second judge and no 314 reaction.
+
 Private `/submit` uses the same judge path and private history, but a correct result
 only marks the problem solved in `private_judge/users/<uid>.json`; it does not update
 the group scoreboard. The private success message includes the full available problem

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -831,12 +831,12 @@ class GroupCoordinator:
             _log_preview(parsed.get("reason", "")),
         )
         if parsed.get("correct", False) and parsed.get("reaction", "") != "123":
-            if req.is_private:
-                await send_private_msg(req.user_id, [build_face("314")])
-            else:
-                await react_emoji(req.message_id, "314")
             editorial = get_verified_official_editorial(pid)
             if editorial:
+                if req.is_private:
+                    await send_private_msg(req.user_id, [build_face("314")])
+                else:
+                    await react_emoji(req.message_id, "314")
                 source = "\n".join(
                     part for part in [editorial.tutorial_title, editorial.tutorial_url]
                     if part


### PR DESCRIPTION
## Problem

The face 314 reaction (#76) is the 'first-judge pass, second judge incoming' signal, but it was sent unconditionally on first-pass correct — even when no verified editorial is cached, meaning no second judge runs at all. Users saw the 314 reaction on submissions with no editorial (e.g. 894B/145E/1980G) and expected a second judge / editorial to follow.

## Fix

Move the 314 reaction inside the `get_verified_official_editorial(pid)` check, so it fires only when a second judge is actually triggered.

## Verification

- `uv run pytest`: 428 passed
- Behavior: with cached verified editorial → 314 + second judge (unchanged); without → verdict finalizes directly, no 314 (new)