### PR TITLE
fix: treat CF 'browser is being checked' interstitial as challenge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,12 @@ NapCat (QQ) ──WS──> worker.py
   `content_valid()` helper is the shared usability gate. Normal Codeforces pages may
   contain an injected `challenge-platform` asset, so that marker is only treated as a
   challenge when no problem/blog content container is present; strong challenge-page
-  markers remain invalid. The Playwright path uses the async API, derives its user agent
+  markers remain invalid. The `browser is being checked` interstitial (a Cloudflare
+  JS-challenge variant that returns HTTP 200 with no content container) is treated as
+  a strong challenge marker too. In `tools/cf_tutorial_agent.py`, a problem page with
+  no blog links is only a terminal no-editorial verdict when `content_valid()` passes;
+  an unusable page (challenge/placeholder) raises `AgentIncomplete` so prefetch stays
+  retryable instead of writing a permanent `no_editorial` marker. The Playwright path uses the async API, derives its user agent
   from the bundled Chromium major version, and keeps synchronous compatibility callers
   safe when an asyncio loop is already running. `picker.fetch_statement()`
   fetches each uncached statement once and passes that HTML into

--- a/src/kouhai_bot/problems/cf_fetcher.py
+++ b/src/kouhai_bot/problems/cf_fetcher.py
@@ -45,7 +45,8 @@ _CF_CONTENT_RE = re.compile(
 )
 _STRONG_CHALLENGE_RE = re.compile(
     r"_cf_chl_opt|cf-browser-verify|"
-    r"<title[^>]*>\s*just\s+a\s+moment|performing\s+security\s+verification",
+    r"<title[^>]*>\s*just\s+a\s+moment|performing\s+security\s+verification|"
+    r"browser\s+is\s+being\s+checked",
     re.I,
 )
 _CHALLENGE_ASSET_RE = re.compile(r"(?:cdn-cgi/)?challenge-platform", re.I)

--- a/tests/test_cf_fetcher.py
+++ b/tests/test_cf_fetcher.py
@@ -115,6 +115,11 @@ class _FakePage:
         "<div id='cf-browser-verify'>Checking your browser</div>",
         "<div class='ttypography'>Tutorial is loading...</div>",
         "<div>Tutorial is loading</div>",
+        (
+            "<style>p{height:100vh}</style>"
+            "<p>Please wait. Your browser is being checked. It may take a few"
+            " seconds...</p><script>var _0x3e09e3=_0x4bf8;</script>"
+        ),
     ],
 )
 def test_content_valid_rejects_unusable_responses(body):

--- a/tests/test_cf_tutorial_agent.py
+++ b/tests/test_cf_tutorial_agent.py
@@ -57,6 +57,45 @@ def test_extract_blog_links_prefers_tutorial_text():
     ]
 
 
+def test_collect_challenge_page_is_incomplete_not_no_match():
+    """A Cloudflare 'browser is being checked' page must stay retryable, never
+    become a terminal no-editorial verdict."""
+    challenge_page = (
+        "<style>p{height:100vh}</style>"
+        "<p>Please wait. Your browser is being checked. It may take a few"
+        " seconds...</p><script>var _0x3e09e3=_0x4bf8;</script>"
+    )
+
+    def fake_fetch(url, **_kwargs):
+        return challenge_page
+
+    with patch("cf_tutorial_agent.fetch_html", side_effect=fake_fetch):
+        with pytest.raises(agent.AgentIncomplete, match="problem_page_invalid_content"):
+            agent.collect_blog_documents(
+                pid="1000B",
+                fetcher="http",
+                pw_wait_ms=100,
+                blog_limit=2,
+            )
+
+
+def test_collect_valid_page_without_links_is_no_match():
+    """A valid problem page with genuinely no blog links stays terminal."""
+    valid_page = "<div class='problem-statement'>A real statement without links.</div>"
+
+    def fake_fetch(url, **_kwargs):
+        return valid_page
+
+    with patch("cf_tutorial_agent.fetch_html", side_effect=fake_fetch):
+        with pytest.raises(agent.AgentNoMatch, match="problem_page_has_no_blog_entry_links"):
+            agent.collect_blog_documents(
+                pid="1000B",
+                fetcher="http",
+                pw_wait_ms=100,
+                blog_limit=2,
+            )
+
+
 def test_collect_blog_documents_does_not_refetch_rejected_url():
     problem_url = "https://codeforces.com/problemset/problem/1000/B"
     rejected_url = "https://codeforces.com/blog/entry/2"

--- a/tools/cf_tutorial_agent.py
+++ b/tools/cf_tutorial_agent.py
@@ -203,6 +203,10 @@ def collect_blog_documents(
     problem_title = extract_problem_title(problem_html)
     all_blog_urls = extract_blog_links(problem_html, problem_url)
     if not all_blog_urls:
+        if not content_valid(problem_html):
+            # Unusable page (challenge / placeholder) — retryable work, never a
+            # terminal "no editorial" verdict.
+            raise AgentIncomplete("problem_page_invalid_content")
         raise AgentNoMatch("problem_page_has_no_blog_entry_links")
     remaining_blog_urls = [
         url for url in all_blog_urls if url not in excluded_tutorial_urls


### PR DESCRIPTION
## Problem

cloudscraper intermittently receives a Cloudflare JS-challenge page (HTTP 200, `Please wait. Your browser is being checked...`, ~10KB, no content container) instead of the real Codeforces problem page. `content_valid()` did not recognize this variant, so the interstitial was parsed as a valid problem page; `extract_blog_links` found zero `/blog/entry/` links and the tutorial agent raised `AgentNoMatch` → a **permanent** `no_editorial` marker was written for problems that actually have official editorials.

Verified victims: 894B, 145E, 2086E, 1408F (all have Tutorial links on their CF pages) and 1980G (editorial blog 130135 was missed). Post-AC editorial delivery then skipped forever.

## Fix

1. `content_valid()`: treat `browser is being checked` as a strong challenge marker → fetch falls back to headless Playwright, which renders past the interstitial and returns the real page.
2. `collect_blog_documents()`: a problem page with no blog links is only a terminal no-editorial verdict when `content_valid()` passes. Unusable pages raise `AgentIncomplete` (retryable), never a permanent marker — defense in depth against future challenge variants.

## Verification

- Unit: `uv run pytest` → **431 passed** (3 new: content_valid rejects the new interstitial; collect raises AgentIncomplete on challenge page; valid no-link page still AgentNoMatch)
- E2E replay against real CF with the fixed code: **20/20 fetches** across 894B/145E/1980G/2086E/1408F returned real pages (60–180KB) with full blog-link lists (1980G now sees 2 links incl. the Tutorial entry)
- Full repair run (real agent crawl + LLM translate + commit verified caches for all 5 pids) running against live data; results reported separately