### PR TITLE
fix: exponential backoff for incomplete editorial prefetch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -808,6 +808,10 @@ uv run python tools/tutorial_tools.py validate --heuristic-only
   to tutorial code.
 - `editorial_prefetch_maintenance_loop()` continuously covers both `state.json.today`
   and the READY slot; this resumes interrupted work and retries INCOMPLETE results.
+  Consecutive incomplete attempts back off exponentially (60s base, capped at 6h,
+  in-memory) so a persistently failing pid (challenge pages, LLM outage) is not
+  re-crawled every maintenance tick; a verified cache or confirmed no-editorial
+  marker resets the backoff.
 - Background `prefetch_editorial_zh(pid)` writes no candidate or transient-failure
   marker. It commits only verified source+translation or an exhaustive no-match result.
 - `/newproblem` publication idempotently reasserts the current pid trigger.

--- a/src/kouhai_bot/editorial_followup.py
+++ b/src/kouhai_bot/editorial_followup.py
@@ -32,9 +32,41 @@ logger = logging.getLogger("kouhai-bot.editorial_followup")
 
 _TUTORIAL_FORWARD_CHUNK_SIZE = 5000
 _PREFETCH_WAIT_TIMEOUT_SEC = 600
+_PREFETCH_BACKOFF_BASE_SEC = 60.0
+_PREFETCH_BACKOFF_MAX_SEC = 6 * 3600.0
 
 _background_tasks: set[asyncio.Task] = set()
 _prefetch_tasks: dict[str, asyncio.Task] = {}
+_prefetch_attempts: dict[str, int] = {}
+_prefetch_last_attempt_at: dict[str, float] = {}
+
+
+def _prefetch_backoff_remaining(pid: str) -> float:
+    """Seconds until the next prefetch attempt is allowed (0.0 = allowed now).
+
+    Exponential backoff on consecutive incomplete attempts: 60s, 2m, 4m, ...
+    capped at 6h. A successful terminal state (verified cache or confirmed
+    no-editorial marker) resets the counter.
+    """
+    attempts = _prefetch_attempts.get(pid, 0)
+    if attempts <= 0:
+        return 0.0
+    delay = min(
+        _PREFETCH_BACKOFF_BASE_SEC * (2 ** (attempts - 1)),
+        _PREFETCH_BACKOFF_MAX_SEC,
+    )
+    elapsed = time.monotonic() - _prefetch_last_attempt_at.get(pid, 0.0)
+    return max(0.0, delay - elapsed)
+
+
+def _mark_prefetch_failed(pid: str) -> None:
+    _prefetch_attempts[pid] = _prefetch_attempts.get(pid, 0) + 1
+    _prefetch_last_attempt_at[pid] = time.monotonic()
+
+
+def _mark_prefetch_succeeded(pid: str) -> None:
+    _prefetch_attempts.pop(pid, None)
+    _prefetch_last_attempt_at.pop(pid, None)
 
 
 def _track_task(task: asyncio.Task) -> None:
@@ -60,6 +92,8 @@ def schedule_prefetch_editorial(pid: str, *, run_agent: bool = True) -> None:
     """Start translating editorial when a new problem is set."""
     pid = (pid or "").strip()
     if not pid or not _prefetch_needed(pid):
+        return
+    if _prefetch_backoff_remaining(pid) > 0:
         return
     existing = _prefetch_tasks.get(pid)
     if existing is not None and not existing.done():
@@ -164,16 +198,20 @@ async def _run_prefetch_editorial(pid: str, *, run_agent: bool) -> None:
         await prefetch_editorial_zh(pid, run_agent=run_agent)
         elapsed = time.monotonic() - started
         if has_cached_editorial_zh(pid):
+            _mark_prefetch_succeeded(pid)
             logger.info("editorial prefetch ready for %s in %.1fs (cached)", pid, elapsed)
         elif is_no_official_editorial(pid):
+            _mark_prefetch_succeeded(pid)
             logger.info("editorial prefetch: no editorial for %s (%.1fs)", pid, elapsed)
         else:
+            _mark_prefetch_failed(pid)
             logger.warning(
                 "editorial prefetch finished for %s in %.1fs without cache",
                 pid,
                 elapsed,
             )
     except Exception as e:
+        _mark_prefetch_failed(pid)
         logger.warning(
             "editorial prefetch failed for %s: %s",
             pid,

--- a/tests/test_editorial_followup.py
+++ b/tests/test_editorial_followup.py
@@ -1,0 +1,84 @@
+"""Tests for editorial prefetch exponential backoff."""
+
+import asyncio
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import kouhai_bot.editorial_followup as ef
+
+PID = "1000A"
+
+
+def _reset():
+    ef._prefetch_attempts.pop(PID, None)
+    ef._prefetch_last_attempt_at.pop(PID, None)
+    ef._prefetch_tasks.pop(PID, None)
+
+
+def test_backoff_starts_allowed():
+    _reset()
+    assert ef._prefetch_backoff_remaining(PID) == 0.0
+
+
+def test_backoff_after_failure_and_reset_on_success():
+    _reset()
+    ef._mark_prefetch_failed(PID)
+    remaining = ef._prefetch_backoff_remaining(PID)
+    assert 0.0 < remaining <= ef._PREFETCH_BACKOFF_BASE_SEC
+
+    ef._mark_prefetch_succeeded(PID)
+    assert ef._prefetch_backoff_remaining(PID) == 0.0
+    assert ef._prefetch_attempts.get(PID) is None
+
+
+def test_backoff_grows_exponentially():
+    _reset()
+    expected = [60.0, 120.0, 240.0, 480.0]
+    for idx, want in enumerate(expected):
+        ef._mark_prefetch_failed(PID)
+        remaining = ef._prefetch_backoff_remaining(PID)
+        assert want - 1.0 < remaining <= want, f"attempt {idx}: {remaining}"
+
+
+def test_backoff_caps_at_max():
+    _reset()
+    ef._prefetch_attempts[PID] = 100
+    ef._prefetch_last_attempt_at[PID] = time.monotonic()
+    remaining = ef._prefetch_backoff_remaining(PID)
+    assert ef._PREFETCH_BACKOFF_MAX_SEC - 1.0 < remaining <= ef._PREFETCH_BACKOFF_MAX_SEC
+
+
+def test_schedule_skips_during_backoff(monkeypatch):
+    _reset()
+    monkeypatch.setattr(ef, "_prefetch_needed", lambda pid: True)
+
+    def boom(*_args, **_kwargs):
+        raise AssertionError("create_task must not run during backoff")
+
+    monkeypatch.setattr(ef.asyncio, "create_task", boom)
+    ef._mark_prefetch_failed(PID)
+    ef.schedule_prefetch_editorial(PID)  # must not raise
+
+
+def test_schedule_creates_task_when_allowed(monkeypatch):
+    _reset()
+    monkeypatch.setattr(ef, "_prefetch_needed", lambda pid: True)
+    calls = []
+
+    def fake_create_task(coro, *, name=None):
+        calls.append(name)
+        return asyncio.Future()
+
+    monkeypatch.setattr(ef.asyncio, "create_task", fake_create_task)
+    monkeypatch.setattr(ef, "_track_task", lambda task: None)
+
+    async def _run():
+        ef.schedule_prefetch_editorial(PID)
+        await asyncio.sleep(0)
+
+    asyncio.run(_run())
+    assert len(calls) == 1
+    assert PID in calls[0]


### PR DESCRIPTION
## Problem

Incomplete prefetch results (challenge pages, LLM outages, extractor failures) were re-scheduled on every maintenance tick (~60s per tick, task restarts as soon as it finishes ≈ every 2-3 min). A pid that keeps failing would be re-crawled forever — burning Codeforces requests and general-model quota — instead of settling.

This becomes visible after #79: challenge pages now correctly produce `AgentIncomplete` (retryable) instead of a permanent `no_editorial` marker, so the no-backoff retry loop is now the failure mode to avoid.

## Fix

In-memory exponential backoff in `editorial_followup.py`:
- `_prefetch_backoff_remaining(pid)`: 60s → 2m → 4m → … capped at 6h
- `schedule_prefetch_editorial` skips pids still in backoff
- `_run_prefetch_editorial` marks failure on incomplete/exception, resets on terminal state (verified cache or no-editorial marker)

Restart resets the in-memory state — the first attempt after a restart is immediate, then backoff applies, which is the desired behavior.

## Verification

`uv run pytest` → **437 passed** (6 new backoff tests: initial allowed, failure→60s, exponential growth, 6h cap, schedule skipped during backoff, schedule creates task when allowed)