### PR TITLE
fix: stable sample extraction against CF template variants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,15 @@ NapCat (QQ) ──WS──> worker.py
   retryable instead of writing a permanent `no_editorial` marker. The Playwright path uses the async API, derives its user agent
   from the bundled Chromium major version, and keeps synchronous compatibility callers
   safe when an asyncio loop is already running. `picker.fetch_statement()`
-  fetches each uncached statement once and passes that HTML into
-  `fetcher.process_problem()` for image/text extraction as well as metadata parsing.
+  fetches each uncached statement once (with one retry when the page is usable
+  but the sample container yields nothing — CF serves template variants where
+  sample `<pre>` tags may carry an `id` and multi-line inputs render as
+  `test-example-line` divs) and passes that HTML into
+  `fetcher.process_problem()` for image/text extraction as well as metadata
+  parsing. Samples are extracted from the page-unique `.sample-test` container
+  by `.input`/`.output` class pairs (not bare `<pre>` scanning), and the
+  `problem-statement` block itself is located by div-depth counting since the
+  `</div><script` terminator is not present in every template variant.
 - **Stale cache detection**: `picker.py:fetch_statement()` detects caches created before image metadata via `_images_collected`. Stale caches with images are re-fetched so image metadata is available for multimodal tasks.
 - **No hermes cron involvement**: The bot runs its own scheduler loop (`scheduler/engine.py`), not hermes cron jobs.
 - **Single worker runtime**: `worker.py` keeps the NapCat reverse-WS connection,

--- a/src/kouhai_bot/problems/fetcher.py
+++ b/src/kouhai_bot/problems/fetcher.py
@@ -99,12 +99,27 @@ def fetch_problem_html(
 # ── Extract problem statement block ─────────────────────────────────────
 
 def extract_problem_statement(html: str) -> str | None:
-    """Extract the <div class='problem-statement'> HTML block."""
-    m = re.search(
-        r'<div class="problem-statement"[^>]*>([\s\S]*?)</div>\s*<script',
-        html,
-    )
-    return m.group(1) if m else None
+    """Extract the <div class='problem-statement'> HTML block.
+
+    Uses div-depth counting instead of assuming a ``</div><script`` terminator:
+    Codeforces serves template variants where the statement container is not
+    followed by a script tag, and a naive non-greedy regex then truncates or
+    misses the block entirely.
+    """
+    m = re.search(r'<div class="problem-statement"[^>]*>', html)
+    if not m:
+        return None
+    start = m.start()
+    depth = 1
+    pos = m.end()
+    for dm in re.finditer(r"<div\b[^>]*>|</div\s*>", html[pos:], re.I):
+        if dm.group(0).startswith("</"):
+            depth -= 1
+        else:
+            depth += 1
+        if depth <= 0:
+            return html[start : pos + dm.end()]
+    return None
 
 
 # ── Find formula / graphics images ──────────────────────────────────────

--- a/src/kouhai_bot/problems/picker.py
+++ b/src/kouhai_bot/problems/picker.py
@@ -253,6 +253,53 @@ def _normalize_samples(samples: list[dict]) -> tuple[list[dict], bool]:
     return normalized, changed
 
 
+_SAMPLE_TEST_RE = re.compile(
+    r'<div class="sample-test"[^>]*>([\s\S]*?)</div>\s*(?=<div class="note"|</div>\s*<script|$)',
+    re.I,
+)
+_SAMPLE_IO_SPLIT_RE = re.compile(r'<div class="(input|output)"[^>]*>', re.I)
+_SAMPLE_PRE_RE = re.compile(r'<pre[^>]*>([\s\S]*?)</pre>', re.I | re.S)
+
+
+def _extract_samples(ps_html: str) -> list[dict]:
+    """Extract (input, output) sample pairs from a problem-statement fragment.
+
+    Anchors on the stable ``.sample-test`` container and its ``.input`` /
+    ``.output`` children instead of bare ``<pre>`` tags. Codeforces renders
+    samples with template variants — ``<pre>`` with or without an ``id``, and
+    multi-line inputs as ``test-example-line`` divs inside the ``<pre>`` — so
+    tag-shape assumptions break silently. The class hierarchy has been stable
+    across every Codeforces template version.
+
+    Returns an empty list when the page has no sample container (or when every
+    pair comes out empty). A pair whose block contains no ``<pre>`` is skipped.
+    """
+    container = _SAMPLE_TEST_RE.search(ps_html)
+    if not container:
+        return []
+    parts = _SAMPLE_IO_SPLIT_RE.split(container.group(1))
+    # parts[0] is the prefix before the first .input/.output div; afterwards
+    # labels and bodies strictly alternate: [label, body, label, body, ...]
+    labels = parts[1::2]
+    bodies = parts[2::2]
+    samples: list[dict] = []
+    for i in range(0, len(labels) - 1, 2):
+        if labels[i].lower() != "input" or labels[i + 1].lower() != "output":
+            continue
+        pre_m = _SAMPLE_PRE_RE.search(bodies[i])
+        if not pre_m:
+            continue
+        pre_in = _normalize_sample_block(pre_m.group(1))
+        pre_m = _SAMPLE_PRE_RE.search(bodies[i + 1])
+        if not pre_m:
+            continue
+        pre_out = _normalize_sample_block(pre_m.group(1))
+        if not pre_in and not pre_out:
+            continue
+        samples.append({"input": pre_in, "output": pre_out})
+    return samples
+
+
 def fetch_statement(problem: dict) -> object:
     """
     Fetch full problem statement from Codeforces.
@@ -318,102 +365,114 @@ def fetch_statement(problem: dict) -> object:
 
     # Fetch once, then share the same rendered document between statement/image
     # extraction and title/limits/sample parsing.
+    # Fetch + parse with one retry: Codeforces serves template variants that
+    # can silently drop samples (sample <pre> with/without id, statement
+    # container terminator shape). A second fetch frequently hits the other
+    # variant, so retry once when the page is otherwise usable but no samples
+    # were extracted.
     url = f"https://codeforces.com/problemset/problem/{contest_id}/{index}"
-    try:
-        raw_html = cf_fetcher.fetch_html(url)
-    except Exception as e:
-        print(f"Warning: failed to fetch {url}: {e}", file=sys.stderr)
-        return None
+    samples: list[dict] = []
+    result: dict = {}
+    desc = ""
+    for attempt in range(2):
+        try:
+            raw_html = cf_fetcher.fetch_html(url)
+        except Exception as e:
+            print(f"Warning: failed to fetch {url}: {e}", file=sys.stderr)
+            return None
 
-    # Step 1: Process problem text and collect image metadata.
-    cf_result = cf_statement.process_problem(
-        contest_id,
-        index,
-        vl_backend="none",
-        html=raw_html,
-    )
-
-    if "error" in cf_result:
-        print(f"Warning: {pid} cf_statement error: {cf_result['error']}", file=sys.stderr)
-        return None
-
-    images = cf_result.get("images", [])
-    if images and not _multimodal_model_configured():
-        print(
-            f"Warning: {pid} has {len(images)} image(s), but llm.multimodal_model is not configured; skipping",
-            file=sys.stderr,
+        # Step 1: Process problem text and collect image metadata.
+        cf_result = cf_statement.process_problem(
+            contest_id,
+            index,
+            vl_backend="none",
+            html=raw_html,
         )
-        return None
 
-    # Step 2: Parse metadata from that same HTML document.
-    html = raw_html
+        if "error" in cf_result:
+            print(f"Warning: {pid} cf_statement error: {cf_result['error']}", file=sys.stderr)
+            return None
 
-    result = {}
+        images = cf_result.get("images", [])
+        if images and not _multimodal_model_configured():
+            print(
+                f"Warning: {pid} has {len(images)} image(s), but llm.multimodal_model is not configured; skipping",
+                file=sys.stderr,
+            )
+            return None
 
-    # Problem name (from <div class="title">)
-    m = re.search(r'<div class="title">([^<]+)</div>', html)
-    if m:
-        result["name"] = m.group(1).strip()
+        # Step 2: Parse metadata from that same HTML document.
+        html = raw_html
 
-    # Time/memory limits
-    m = re.search(r'(\d+\.?\d*)\s*seconds?\b', html, re.I)
-    if m:
-        result["time_limit"] = m.group(1) + "s"
-    m = re.search(r'(\d+)\s*megabytes?\b', html, re.I)
-    if m:
-        result["memory_limit"] = m.group(1) + "MB"
+        result = {}
 
-    # Description: text with image placeholders; image metadata is stored separately.
-    desc = cf_result.get("text", "")
-    result["description"] = desc
-    result["images"] = images if isinstance(images, list) else []
-    result["has_images"] = bool(result["images"])
+        # Problem name (from <div class="title">)
+        m = re.search(r'<div class="title">([^<]+)</div>', html)
+        if m:
+            result["name"] = m.group(1).strip()
 
-    # Extract Input spec from raw HTML
-    inp_m = re.search(
-        r'<div class="section-title">Input</div>\s*(.*?)(?=<div class="section-title"|</div>\s*<script)',
-        html,
-        re.DOTALL,
-    )
-    if inp_m:
-        inp = re.sub(r'<[^>]+>', '', inp_m.group(1))
-        inp = re.sub(r'\s+', ' ', inp).strip()
-        inp = re.sub(r'\$\$\$|\$\$|\$', '', inp)
-        result["input"] = inp
+        # Time/memory limits
+        m = re.search(r"(\d+\.?\d*)\s*seconds?\b", html, re.I)
+        if m:
+            result["time_limit"] = m.group(1) + "s"
+        m = re.search(r"(\d+)\s*megabytes?\b", html, re.I)
+        if m:
+            result["memory_limit"] = m.group(1) + "MB"
 
-    # Extract samples from <pre> blocks in raw HTML
-    ps_m = re.search(
-        r'<div class="problem-statement"[^>]*>([\s\S]*?)</div>\s*<script',
-        html,
-    )
-    if ps_m:
-        pres = re.findall(r'<pre>([\s\S]*?)</pre>', ps_m.group(1))
-        samples = []
-        for i in range(0, len(pres) - 1, 2):
-            samples.append({
-                "input": _normalize_sample_block(pres[i]),
-                "output": _normalize_sample_block(pres[i + 1]),
-            })
+        # Description: text with image placeholders; image metadata is stored separately.
+        desc = cf_result.get("text", "")
+        result["description"] = desc
+        result["images"] = images if isinstance(images, list) else []
+        result["has_images"] = bool(result["images"])
+
+        # Extract Input spec from raw HTML
+        inp_m = re.search(
+            r'<div class="section-title">Input</div>\s*(.*?)(?=<div class="section-title"|</div>\s*<script)',
+            html,
+            re.DOTALL,
+        )
+        if inp_m:
+            inp = re.sub(r"<[^>]+>", "", inp_m.group(1))
+            inp = re.sub(r"\s+", " ", inp).strip()
+            inp = re.sub(r"\$\$\$|\$\$|\$", "", inp)
+            result["input"] = inp
+
+        # Extract samples from the stable .sample-test container structure instead
+        # of bare <pre> tags: CF templates vary (pre with/without id, multi-line
+        # samples rendered as test-example-line divs), but the
+        # sample-test / input / output class hierarchy is stable across versions.
+        # The container is unique per page, so this deliberately searches the whole
+        # document rather than the (also template-varying) problem-statement div.
+        samples = _extract_samples(html)
         if samples:
             result["samples"] = samples
 
-    # Extract Note
-    if ps_m:
-        note_m = re.search(
-            r'<div class="section-title">Note</div>([\s\S]*?)(?=<div class="section-title"|$)',
-            ps_m.group(1),
-            re.DOTALL,
-        )
-        if note_m:
-            note = re.sub(r'<[^>]+>', '', note_m.group(1))
-            note = re.sub(r'\s+', ' ', note).strip()
-            note = re.sub(r'\$\$\$|\$\$|\$', '', note)
-            result["notes"] = note
+        # Extract Note (from the statement container when available; Notes are
+        # best-effort and their absence does not block caching).
+        ps_html = cf_statement.extract_problem_statement(html)
+        if ps_html:
+            note_m = re.search(
+                r'<div class="section-title">Note</div>([\s\S]*?)(?=<div class="section-title"|$)',
+                ps_html,
+                re.DOTALL,
+            )
+            if note_m:
+                note = re.sub(r"<[^>]+>", "", note_m.group(1))
+                note = re.sub(r"\s+", " ", note).strip()
+                note = re.sub(r"\$\$\$|\$\$|\$", "", note)
+                result["notes"] = note
 
-    # Sanity: reject if description contains raw image URLs
-    if re.search(r'https?://\S+\.(png|jpg|jpeg|gif)', desc, re.I):
-        print(f"Warning: {pid} contains image URL in rendered text, skipping", file=sys.stderr)
-        return None
+        # Sanity: reject if description contains raw image URLs
+        if re.search(r"https?://\S+\.(png|jpg|jpeg|gif)", desc, re.I):
+            print(f"Warning: {pid} contains image URL in rendered text, skipping", file=sys.stderr)
+            return None
+
+        if samples or attempt == 1:
+            break
+        if not _SAMPLE_TEST_RE.search(html):
+            # Page genuinely has no sample container — not a template glitch.
+            break
+        print(f"[{pid}] statement usable but no samples extracted; retrying fetch", file=sys.stderr)
 
     # Cache and return
     result["_vl_processed"] = True

--- a/tests/test_picker_samples.py
+++ b/tests/test_picker_samples.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from kouhai_bot.problems.picker import _normalize_sample_block
+from kouhai_bot.problems.picker import _extract_samples, _normalize_sample_block
 
 
 def test_normalize_sample_block_div_lines():
@@ -19,3 +19,71 @@ def test_normalize_sample_block_div_lines():
 def test_normalize_sample_block_br_lines():
     raw = "5 3 5<br />5 -5 5 1 -4<br />2 1 2<br />"
     assert _normalize_sample_block(raw) == "5 3 5\n5 -5 5 1 -4\n2 1 2"
+
+
+def _legacy_sample_html() -> str:
+    """Old template: plain <pre> without attributes."""
+    return """
+    <div class="sample-tests"><div class="section-title">Example</div>
+    <div class="sample-test">
+      <div class="input"><div class="title">Input</div>
+        <pre>3\n1 2 3</pre></div>
+      <div class="output"><div class="title">Output</div>
+        <pre>6</pre></div>
+      <div class="input"><div class="title">Input</div>
+        <pre>2\n5 5</pre></div>
+      <div class="output"><div class="title">Output</div>
+        <pre>10</pre></div>
+    </div></div>
+    <div class="note"><div class="section-title">Note</div></div>
+    """
+
+
+def _modern_sample_html() -> str:
+    """New template: <pre id=...> with Copy button, multi-line rows as divs."""
+    return """
+    <div class="sample-tests"><div class="section-title">Example</div>
+    <div class="sample-test">
+      <div class="input"><div class="title">Input<div title="Copy" id="c1" class="input-output-copier">Copy</div></div>
+        <pre id="p1"><div class="test-example-line test-example-line-even test-example-line-0">3</div><div class="test-example-line test-example-line-odd test-example-line-1">5</div></pre></div>
+      <div class="output"><div class="title">Output<div title="Copy" id="c2" class="input-output-copier">Copy</div></div>
+        <pre id="p2">4 1 2 3 4 -1 0</pre></div>
+    </div></div>
+    <div class="note"><div class="section-title">Note</div></div>
+    """
+
+
+def test_extract_samples_legacy_template():
+    samples = _extract_samples(_legacy_sample_html())
+    assert samples == [
+        {"input": "3\n1 2 3", "output": "6"},
+        {"input": "2\n5 5", "output": "10"},
+    ]
+
+
+def test_extract_samples_modern_template_with_pre_ids_and_multiline_rows():
+    samples = _extract_samples(_modern_sample_html())
+    assert samples == [
+        {"input": "3\n5", "output": "4 1 2 3 4 -1 0"},
+    ]
+
+
+def test_extract_samples_no_container_returns_empty():
+    assert _extract_samples("<div class='problem-statement'><p>no samples</p></div>") == []
+
+
+def test_extract_samples_skips_pair_without_pre():
+    html = """
+    <div class="sample-test">
+      <div class="input"><div class="title">Input</div>
+        <pre>1</pre></div>
+      <div class="output"><div class="title">Output</div>
+        <p>missing pre here</p></div>
+      <div class="input"><div class="title">Input</div>
+        <pre>2</pre></div>
+      <div class="output"><div class="title">Output</div>
+        <pre>4</pre></div>
+    </div>
+    """
+    samples = _extract_samples(html)
+    assert samples == [{"input": "2", "output": "4"}]


### PR DESCRIPTION
## Problem

Codeforces serves template variants for the same problem page:
- sample `<pre>` may or may not carry an `id` (Copy-button template)
- multi-line inputs render as `test-example-line` divs inside the `<pre>`
- the `problem-statement` container is not always terminated by `</div><script`

The old extractor scanned bare `<pre>` tags inside a regex-delimited problem-statement block. Depending on which template variant a fetch hit, statement caches were silently written **without samples** — published problems then went out without sample messages (observed: 2092D, only 2 forwarded msgs instead of 3).

## Fix

1. `_extract_samples()`: anchor on the **page-unique `.sample-test` container**, split by `.input`/`.output` class pairs — no reliance on pre-tag shape; pre matching allows attributes; `test-example-line` rows already normalize to newlines.
2. `fetch_statement()`: retry the fetch **once** when the page is usable but the sample container yields nothing (template-variant glitch); pages with no sample container are not retried.
3. `extract_problem_statement()`: **div-depth counting** instead of the `</div><script` terminator assumption (the container is now extracted correctly in both variants).

## Verification

- `uv run pytest`: **441 passed** (4 new: legacy plain-`<pre>` template, modern `<pre id>` + multiline template, no-container → empty, pair-without-pre skipped)
- Live E2E via full `fetch_statement()` against real CF (temp cache dir):
  - 2092D: samples=1, multi-line input `3\n5\nTILII…` ✓ (previously missing)
  - 641E: samples=2, **byte-identical to the old cache** ✓ (no regression)
  - 2143D2: samples=1 on the `<pre id>` template variant ✓