### PR TITLE
fix: retry statement fetch when parse fails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,9 @@ NapCat (QQ) ──WS──> worker.py
   fetches each uncached statement once (with one retry when the page is usable
   but the sample container yields nothing — CF serves template variants where
   sample `<pre>` tags may carry an `id` and multi-line inputs render as
-  `test-example-line` divs) and passes that HTML into
+  `test-example-line` divs — and one retry when the statement block cannot be
+  parsed at all, e.g. a challenge/redirect page slipped through) and passes that
+  HTML into
   `fetcher.process_problem()` for image/text extraction as well as metadata
   parsing. Samples are extracted from the page-unique `.sample-test` container
   by `.input`/`.output` class pairs (not bare `<pre>` scanning), and the

--- a/src/kouhai_bot/problems/picker.py
+++ b/src/kouhai_bot/problems/picker.py
@@ -390,6 +390,12 @@ def fetch_statement(problem: dict) -> object:
         )
 
         if "error" in cf_result:
+            if attempt == 0:
+                print(
+                    f"[{pid}] statement parse failed ({cf_result['error']}); retrying fetch",
+                    file=sys.stderr,
+                )
+                continue
             print(f"Warning: {pid} cf_statement error: {cf_result['error']}", file=sys.stderr)
             return None
 

--- a/tests/test_picker_selection.py
+++ b/tests/test_picker_selection.py
@@ -122,6 +122,75 @@ def test_select_problem_raises_when_every_candidate_is_solved(monkeypatch, tmp_p
         picker.select_problem()
 
 
+def test_fetch_statement_retries_after_parse_failure(monkeypatch, tmp_path):
+    """A first attempt that yields an unusable page (challenge/redirect
+    variant) must be retried once before giving up."""
+    _configure_picker_tmp(tmp_path)
+    monkeypatch.setattr(picker, "_multimodal_model_configured", lambda: True)
+    fetch_calls = []
+    process_calls = []
+
+    raw_html = (
+        '<div class="problem-statement">'
+        '<div class="title">A. Retry</div>'
+        '<div class="time-limit">1 second</div>'
+        '<div class="memory-limit">256 megabytes</div>'
+        '<div class="section-title">Input</div>n'
+        '<div class="sample-test">'
+        '<div class="input"><pre>1</pre></div>'
+        '<div class="output"><pre>1</pre></div>'
+        '</div>'
+        "</div><script"
+    )
+
+    def fake_fetch(url):
+        fetch_calls.append(url)
+        return raw_html
+
+    def fake_process(contest_id, index, vl_backend="none", *, html=None):
+        process_calls.append((contest_id, index, html))
+        if len(process_calls) == 1:
+            return {"error": "Could not find problem-statement div", "pid": f"{contest_id}{index}"}
+        return {
+            "pid": f"{contest_id}{index}",
+            "text": "Statement",
+            "formulas_found": 0,
+            "graphics_found": 0,
+            "images": [],
+        }
+
+    monkeypatch.setattr(picker.cf_fetcher, "fetch_html", fake_fetch)
+    monkeypatch.setattr(picker.cf_statement, "process_problem", fake_process)
+
+    stmt = picker.fetch_statement(_problem(1, "A"))
+
+    assert stmt is not None
+    assert len(fetch_calls) == 2
+    assert len(process_calls) == 2
+    assert stmt["samples"] == [{"input": "1", "output": "1"}]
+
+
+def test_fetch_statement_gives_up_after_second_parse_failure(monkeypatch, tmp_path):
+    _configure_picker_tmp(tmp_path)
+    monkeypatch.setattr(picker, "_multimodal_model_configured", lambda: True)
+    fetch_calls = []
+
+    def fake_fetch(url):
+        fetch_calls.append(url)
+        return "<html>homepage</html>"
+
+    def fake_process(contest_id, index, vl_backend="none", *, html=None):
+        return {"error": "Could not find problem-statement div", "pid": f"{contest_id}{index}"}
+
+    monkeypatch.setattr(picker.cf_fetcher, "fetch_html", fake_fetch)
+    monkeypatch.setattr(picker.cf_statement, "process_problem", fake_process)
+
+    stmt = picker.fetch_statement(_problem(1, "A"))
+
+    assert stmt is None
+    assert len(fetch_calls) == 2
+
+
 def test_fetch_statement_skips_image_statement_without_multimodal_model(monkeypatch, tmp_path):
     _configure_picker_tmp(tmp_path)
 


### PR DESCRIPTION
## Problem

Extended batch backtesting (14 pids x 2 runs, problems from 2012-2026) found that `fetch_statement()` intermittently fails (~1/6 of fetches) on a transient challenge/redirect page variant: CF occasionally answers a problem URL with a 302-to-homepage or a challenge page that has no `problem-statement` div. The parser reported `Could not find problem-statement div` and `fetch_statement()` gave up immediately — so a perfectly cachable problem could randomly fail to prepare (no samples, no statement).

(Also learned: contest 1868 has B1/B2, no bare B — a 302 for a nonexistent problem is correct behavior.)

## Fix

The first parse failure now triggers one refetch (same retry policy as the existing sample-missing retry). A second consecutive failure still returns `None` as before.

## Verification

- `uv run pytest`: **443 passed** (+2: retry-after-parse-failure succeeds on 2nd attempt; gives-up-after-2nd-failure)
- Batch backtest 14 pids x 2 fresh-cache runs: **all 28 passed**, sample fingerprints stable across runs