### PR TITLE
feat: only remind rated contests (filter type CF/ICPC)

### DIFF
--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -1931,20 +1931,21 @@ async def check_contests_for_group(group_id: int) -> None:
             continue
         if c.get("type") not in ("CF", "ICPC"):
             continue
-        name = str(c.get("name", ""))
+        name = c.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
         if any(keyword in name.lower() for keyword in ("unrated", "mirror", "april fools", "kotlin", "practice")):
             continue
         start = datetime.fromtimestamp(c["startTimeSeconds"], tz=TZ)
         if start <= cutoff:
-            upcoming.append((start, c, phase))
+            upcoming.append((start, c, phase, name))
 
     if not upcoming:
         return
 
     upcoming.sort(key=lambda x: x[0])
     lines = ["🏆 Codeforces 比赛提醒！"]
-    for start, c, phase in upcoming:
-        name = c["name"]
+    for start, c, phase, name in upcoming:
         dur_h = c["durationSeconds"] // 3600
         dur_m = (c["durationSeconds"] % 3600) // 60
         dur_str = f"{dur_h}h" if dur_m == 0 else f"{dur_h}h{dur_m}m"

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -1931,6 +1931,9 @@ async def check_contests_for_group(group_id: int) -> None:
             continue
         if c.get("type") not in ("CF", "ICPC"):
             continue
+        name = str(c.get("name", ""))
+        if any(keyword in name.lower() for keyword in ("unrated", "mirror", "april fools", "kotlin", "practice")):
+            continue
         start = datetime.fromtimestamp(c["startTimeSeconds"], tz=TZ)
         if start <= cutoff:
             upcoming.append((start, c, phase))

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -1929,6 +1929,8 @@ async def check_contests_for_group(group_id: int) -> None:
         phase = c.get("phase", "")
         if phase not in ("BEFORE", "CODING"):
             continue
+        if c.get("type") not in ("CF", "ICPC"):
+            continue
         start = datetime.fromtimestamp(c["startTimeSeconds"], tz=TZ)
         if start <= cutoff:
             upcoming.append((start, c, phase))

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -356,6 +356,29 @@ def test_contest_check_includes_rated_icpc_contest_within_24_hours():
     assert "Rated ICPC" in message
 
 
+def test_contest_check_skips_missing_name_without_dropping_other_contests():
+    now = int(time.time())
+    missing_name = _contest(name="unused", contest_type="CF", start_time_seconds=now + 1800)
+    missing_name.pop("name")
+    sent = _run_contest_check([
+        missing_name,
+        _contest(name="Rated CF", contest_type="CF", start_time_seconds=now + 3600),
+    ])
+
+    assert sent.await_count == 1
+    message = sent.await_args.args[1][1]["data"]["text"]
+    assert "Rated CF" in message
+
+
+def test_contest_check_skips_blank_name():
+    now = int(time.time())
+    sent = _run_contest_check([
+        _contest(name="   ", contest_type="CF", start_time_seconds=now + 3600),
+    ])
+
+    assert sent.await_count == 0
+
+
 def test_contest_check_excludes_cf_contest_named_unrated():
     now = int(time.time())
     sent = _run_contest_check([

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -334,6 +334,17 @@ def test_contest_check_includes_rated_cf_contest_within_24_hours():
     assert "Rated CF" in message
 
 
+def test_contest_check_includes_normal_rated_cf_contest_within_24_hours():
+    now = int(time.time())
+    sent = _run_contest_check([
+        _contest(name="Codeforces Round 2000 (Div. 1)", contest_type="CF", start_time_seconds=now + 3600),
+    ])
+
+    assert sent.await_count == 1
+    message = sent.await_args.args[1][1]["data"]["text"]
+    assert "Codeforces Round 2000 (Div. 1)" in message
+
+
 def test_contest_check_includes_rated_icpc_contest_within_24_hours():
     now = int(time.time())
     sent = _run_contest_check([
@@ -343,6 +354,33 @@ def test_contest_check_includes_rated_icpc_contest_within_24_hours():
     assert sent.await_count == 1
     message = sent.await_args.args[1][1]["data"]["text"]
     assert "Rated ICPC" in message
+
+
+def test_contest_check_excludes_cf_contest_named_unrated():
+    now = int(time.time())
+    sent = _run_contest_check([
+        _contest(name="Codeforces Round 1092 (Unrated)", contest_type="CF", start_time_seconds=now + 3600),
+    ])
+
+    assert sent.await_count == 0
+
+
+def test_contest_check_excludes_icpc_contest_named_mirror():
+    now = int(time.time())
+    sent = _run_contest_check([
+        _contest(name="2026 ICPC Asia Pacific Championship - Online Mirror", contest_type="ICPC", start_time_seconds=now + 3600),
+    ])
+
+    assert sent.await_count == 0
+
+
+def test_contest_check_excludes_kotlin_heroes_contest():
+    now = int(time.time())
+    sent = _run_contest_check([
+        _contest(name="Kotlin Heroes: Episode 14", contest_type="ICPC", start_time_seconds=now + 3600),
+    ])
+
+    assert sent.await_count == 0
 
 
 def test_contest_check_excludes_ioi_contest_within_24_hours():

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import sys
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -23,6 +24,7 @@ from kouhai_bot.handlers.shared import (
     call_chat_completion,
     get_judge_prompt,
     call_chat_completion_result,
+    check_contests_for_group,
     doublecheck_problem_summary,
     get_problem_summary,
     judge_submission,
@@ -297,6 +299,77 @@ def _openai_cfg(**overrides):
     for key, value in overrides.items():
         setattr(cfg, key, value)
     return cfg
+
+
+def _contest(*, name, contest_type, start_time_seconds):
+    return {
+        "name": name,
+        "type": contest_type,
+        "phase": "BEFORE",
+        "startTimeSeconds": start_time_seconds,
+        "durationSeconds": 7200,
+    }
+
+
+def _run_contest_check(contests):
+    response = _DummyResponse(
+        json_data={"status": "OK", "result": contests},
+    )
+    sent = AsyncMock()
+    with patch("aiohttp.ClientSession.get", return_value=response), \
+            patch("kouhai_bot.napcat.client.send_group_msg", sent), \
+            patch("asyncio.sleep", new=AsyncMock()):
+        asyncio.run(check_contests_for_group(123))
+    return sent
+
+
+def test_contest_check_includes_rated_cf_contest_within_24_hours():
+    now = int(time.time())
+    sent = _run_contest_check([
+        _contest(name="Rated CF", contest_type="CF", start_time_seconds=now + 3600),
+    ])
+
+    assert sent.await_count == 1
+    message = sent.await_args.args[1][1]["data"]["text"]
+    assert "Rated CF" in message
+
+
+def test_contest_check_includes_rated_icpc_contest_within_24_hours():
+    now = int(time.time())
+    sent = _run_contest_check([
+        _contest(name="Rated ICPC", contest_type="ICPC", start_time_seconds=now + 3600),
+    ])
+
+    assert sent.await_count == 1
+    message = sent.await_args.args[1][1]["data"]["text"]
+    assert "Rated ICPC" in message
+
+
+def test_contest_check_excludes_ioi_contest_within_24_hours():
+    now = int(time.time())
+    sent = _run_contest_check([
+        _contest(name="Huawei Challenge", contest_type="IOI", start_time_seconds=now + 3600),
+    ])
+
+    assert sent.await_count == 0
+
+
+def test_contest_check_excludes_other_contest_within_24_hours():
+    now = int(time.time())
+    sent = _run_contest_check([
+        _contest(name="Other Challenge", contest_type="Other", start_time_seconds=now + 3600),
+    ])
+
+    assert sent.await_count == 0
+
+
+def test_contest_check_excludes_rated_contests_beyond_24_hours():
+    now = int(time.time())
+    sent = _run_contest_check([
+        _contest(name="Tomorrow CF", contest_type="CF", start_time_seconds=now + 25 * 3600),
+    ])
+
+    assert sent.await_count == 0
 
 
 def test_provider_model_for_uses_provider_model_and_explicit_override():


### PR DESCRIPTION
## 需求
比赛提醒只提醒 rated 比赛——当前华为挑战赛（type=IOI）也会提醒，用户不需要。

## 改动
- `shared.py: check_contests_for_group()`：phase 过滤后增加 `type in ("CF", "ICPC")` 过滤（Codeforces API 无显式 rated 字段，45 天样本 14/14 验证这两种 type 全部有 rating 变化；IOI/Other 如 Huawei Challenge 无）
- 消息格式、24h 窗口、静默失败处理均不变

## 测试
- 新增 5 个用例（mock aiohttp + send_group_msg）：CF/ICPC 24h 内提醒、IOI/Other 排除、超 24h 排除
- 全量 `464 passed`