### PR TITLE
feat: /sp 支持按难度范围选题 (e.g. /sp 2500-2600)

### DIFF
--- a/src/kouhai_bot/handlers/cmd/setproblem.py
+++ b/src/kouhai_bot/handlers/cmd/setproblem.py
@@ -31,6 +31,8 @@ from ..shared import get_problem_card_ref_pid, get_today_problem
 logger = logging.getLogger("kouhai-bot.cmd.setproblem")
 
 _RANDOM_ARGS = {"random", "rand", "r"}
+_RATING_RANGE_RE = re.compile(r"^(\d{3,4})-(\d{3,4})$")
+_RATING_RANGE_SHAPE_RE = re.compile(r"^\d+-\d+$")
 _UNKNOWN_CARD_REPLY = (
     "这条引用我认不出对应哪道题哦，可能不是题目卡片，"
     "也可能卡片太久了～你可以直接发 /sp 当前群题、/sp random，或者发 CF 题号/链接。"
@@ -43,6 +45,13 @@ def _strip_command(raw_text: str) -> str:
     if not match:
         return ""
     return text[match.end():].strip()
+
+
+def _parse_rating_range(arg: str) -> tuple[int, int] | None:
+    match = _RATING_RANGE_RE.fullmatch(str(arg or ""))
+    if not match:
+        return None
+    return int(match.group(1)), int(match.group(2))
 
 
 def _reply_to_message_id(segments: list) -> str:
@@ -103,12 +112,66 @@ async def handle(group_id: int, user_id: int, sender: dict,
                 "随机题目暂时拉不到，可能是 Codeforces 或题面缓存不太稳定，稍后再试试？"
             ))
             return
+    elif _RATING_RANGE_SHAPE_RE.fullmatch(arg):
+        rating_range = _parse_rating_range(arg)
+        if rating_range is None:
+            await send_private_msg(user_id, build_plain_message(
+                "难度范围格式是 两个3~4位数字、中间用减号，比如 /sp 2500-2600～"
+            ))
+            return
+        min_rating, max_rating = rating_range
+        if min_rating > max_rating:
+            await send_private_msg(user_id, build_plain_message(
+                "范围好像写反啦～应该是小的在前，比如 /sp 2500-2600 而不是 /sp 2600-2500。"
+            ))
+            return
+        await send_private_msg(user_id, build_plain_message(
+            f"正在按 {min_rating}-{max_rating} 难度随机挑题，稍等一下～"
+        ))
+        try:
+            problem = await asyncio.to_thread(
+                resolve_random_problem,
+                group_id,
+                (min_rating, max_rating),
+            )
+        except RuntimeError as e:
+            if "no random candidates" in str(e):
+                await send_private_msg(user_id, build_plain_message(
+                    "这个难度区间暂时没挑到合适的题（可能题目太少或题面缓存问题），换个范围试试？比如 /sp 2000-2500"
+                ))
+            else:
+                logger.warning(
+                    "private rating-range random problem failed for %s-%s: %s",
+                    min_rating,
+                    max_rating,
+                    e,
+                    exc_info=True,
+                )
+                await send_private_msg(user_id, build_plain_message(
+                    "随机题目暂时拉不到，可能是 Codeforces 或题面缓存不太稳定，稍后再试试？"
+                ))
+            return
+        except Exception as e:
+            logger.warning(
+                "private rating-range random problem failed for %s-%s: %s",
+                min_rating,
+                max_rating,
+                e,
+                exc_info=True,
+            )
+            await send_private_msg(user_id, build_plain_message(
+                "随机题目暂时拉不到，可能是 Codeforces 或题面缓存不太稳定，稍后再试试？"
+            ))
+            return
     else:
         parsed = parse_problem_ref(arg)
         if not parsed:
+            extra_hint = ""
+            if re.fullmatch(r"\d+", arg):
+                extra_hint = "\n如果你是想按难度随机选题，格式是 /sp 2500-2600（难度范围）～"
             await send_private_msg(user_id, build_plain_message(
                 "我没认出这道题～可以发 CF2234B、2234B、Codeforces 题目链接，"
-                "或者 /contest/2233/problem/F 这样的路径。"
+                "或者 /contest/2233/problem/F 这样的路径。" + extra_hint
             ))
             return
         pid = problem_id_from_ref(*parsed)
@@ -180,8 +243,8 @@ def register() -> None:
     registry.register(CommandDef(
         name="setproblem",
         aliases=["sp"],
-        description="设置 private judge 当前题（题号/链接/random；空参数或引用题目卡片）",
-        usage="[题号|链接|random]",
+        description="设置 private judge 当前题（题号/链接/random/2500-2600 按难度选题；空参数或引用题目卡片）",
+        usage="[题号|链接|random|难度范围]",
         handler=handle,
         cooldown=3,
     ))

--- a/src/kouhai_bot/handlers/cmd/setproblem.py
+++ b/src/kouhai_bot/handlers/cmd/setproblem.py
@@ -31,6 +31,7 @@ from ..shared import get_problem_card_ref_pid, get_today_problem
 logger = logging.getLogger("kouhai-bot.cmd.setproblem")
 
 _RANDOM_ARGS = {"random", "rand", "r"}
+_RATING_EXACT_RE = re.compile(r"^\d{3,4}$")
 _RATING_RANGE_RE = re.compile(r"^(\d{3,4})-(\d{3,4})$")
 _RATING_RANGE_SHAPE_RE = re.compile(r"^\d+-\d+$")
 _UNKNOWN_CARD_REPLY = (
@@ -112,8 +113,11 @@ async def handle(group_id: int, user_id: int, sender: dict,
                 "随机题目暂时拉不到，可能是 Codeforces 或题面缓存不太稳定，稍后再试试？"
             ))
             return
-    elif _RATING_RANGE_SHAPE_RE.fullmatch(arg):
-        rating_range = _parse_rating_range(arg)
+    elif _RATING_EXACT_RE.fullmatch(arg) or _RATING_RANGE_SHAPE_RE.fullmatch(arg):
+        if _RATING_EXACT_RE.fullmatch(arg):
+            rating_range = (int(arg), int(arg))
+        else:
+            rating_range = _parse_rating_range(arg)
         if rating_range is None:
             await send_private_msg(user_id, build_plain_message(
                 "难度范围格式是 两个3~4位数字、中间用减号，比如 /sp 2500-2600～"
@@ -125,8 +129,13 @@ async def handle(group_id: int, user_id: int, sender: dict,
                 "范围好像写反啦～应该是小的在前，比如 /sp 2500-2600 而不是 /sp 2600-2500。"
             ))
             return
+        rating_label = (
+            str(min_rating)
+            if min_rating == max_rating
+            else f"{min_rating}-{max_rating}"
+        )
         await send_private_msg(user_id, build_plain_message(
-            f"正在按 {min_rating}-{max_rating} 难度随机挑题，稍等一下～"
+            f"正在按 {rating_label} 难度随机挑题，稍等一下～"
         ))
         try:
             problem = await asyncio.to_thread(
@@ -167,8 +176,8 @@ async def handle(group_id: int, user_id: int, sender: dict,
         parsed = parse_problem_ref(arg)
         if not parsed:
             extra_hint = ""
-            if re.fullmatch(r"\d+", arg):
-                extra_hint = "\n如果你是想按难度随机选题，格式是 /sp 2500-2600（难度范围）～"
+            if re.fullmatch(r"\d{1,2}", arg):
+                extra_hint = "\n如果你是想按难度随机选题，可以发 /sp 2500 或 /sp 2500-2600～"
             await send_private_msg(user_id, build_plain_message(
                 "我没认出这道题～可以发 CF2234B、2234B、Codeforces 题目链接，"
                 "或者 /contest/2233/problem/F 这样的路径。" + extra_hint

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -459,10 +459,17 @@ def resolve_problem_by_pid(pid: str) -> dict:
     return state
 
 
-def resolve_random_problem(group_id: int) -> dict:
+def resolve_random_problem(
+    group_id: int,
+    rating_range: tuple[int, int] | None = None,
+) -> dict:
     from .problem_preparation import effective_rating_range
 
-    min_rating, max_rating = effective_rating_range(group_id)
+    min_rating, max_rating = (
+        rating_range
+        if rating_range is not None
+        else effective_rating_range(group_id)
+    )
     candidates: list[dict] = []
     for item in _fetch_problemset():
         if not isinstance(item, dict):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3003,7 +3003,7 @@ def test_private_help_only_shows_private_judge_commands():
         seg.get("data", {}).get("text", "")
         for seg in msg if isinstance(seg, dict) and seg.get("type") == "text"
     )
-    assert "/setproblem(/sp) [题号|链接|random] — 设置 private judge 当前题" in text, text
+    assert "/setproblem(/sp) [题号|链接|random|难度范围] — 设置 private judge 当前题" in text, text
     assert "/sync — 在群聊和 private judge 间同步当前群题记录" in text, text
     assert "/testcd — 查看当前群题提交 CD" in text, text
     assert "/newproblem(/np)" not in text, text
@@ -4572,6 +4572,88 @@ def test_private_setproblem_explicit_arg_wins_over_referenced_card():
     print("✅ private setproblem: explicit arg wins over referenced card")
 
 
+def test_private_setproblem_rating_range_picks_problem_and_sends_card():
+    _reset_state()
+    problem = {
+        "today": "1234C",
+        "contestId": 1234,
+        "index": "C",
+        "name": "Range Problem",
+        "rating": 2550,
+        "tags": ["dp"],
+    }
+
+    with _all_patches(), \
+        patch(
+            "kouhai_bot.handlers.cmd.setproblem.resolve_random_problem",
+            return_value=problem,
+        ) as resolve, \
+        patch(
+            "kouhai_bot.handlers.cmd.setproblem.send_problem_card_private",
+            new=AsyncMock(return_value=True),
+        ) as send_card:
+        from kouhai_bot.handlers.cmd.setproblem import handle
+
+        asyncio.run(handle(**_kwargs(_make_private_event("/sp 2500-2600"))))
+
+    resolve.assert_called_once_with(GID, (2500, 2600))
+    send_card.assert_awaited_once()
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent)
+    assert "正在按 2500-2600 难度随机挑题" in private_text, private_text
+    _cleanup()
+    print("✅ private setproblem: rating range picks and sends problem")
+
+
+def test_private_setproblem_reversed_rating_range_is_rejected():
+    _reset_state()
+
+    with _all_patches(), \
+        patch("kouhai_bot.handlers.cmd.setproblem.resolve_random_problem") as resolve:
+        from kouhai_bot.handlers.cmd.setproblem import handle
+
+        asyncio.run(handle(**_kwargs(_make_private_event("/sp 2600-2500"))))
+
+    resolve.assert_not_called()
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent)
+    assert "范围好像写反啦" in private_text, private_text
+    _cleanup()
+    print("✅ private setproblem: reversed rating range is rejected")
+
+
+def test_private_setproblem_invalid_rating_range_shows_format_hint():
+    _reset_state()
+
+    with _all_patches(), \
+        patch("kouhai_bot.handlers.cmd.setproblem.resolve_random_problem") as resolve:
+        from kouhai_bot.handlers.cmd.setproblem import handle
+
+        asyncio.run(handle(**_kwargs(_make_private_event("/sp 2500-26000"))))
+
+    resolve.assert_not_called()
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent)
+    assert "难度范围格式是 两个3~4位数字" in private_text, private_text
+    _cleanup()
+    print("✅ private setproblem: invalid rating range shows format hint")
+
+
+def test_private_setproblem_plain_digits_stays_on_problem_ref_path():
+    _reset_state()
+
+    with _all_patches(), \
+        patch("kouhai_bot.handlers.cmd.setproblem.resolve_random_problem") as random_resolve, \
+        patch("kouhai_bot.handlers.cmd.setproblem.resolve_problem_by_pid") as resolve:
+        from kouhai_bot.handlers.cmd.setproblem import handle
+
+        asyncio.run(handle(**_kwargs(_make_private_event("/sp 2500"))))
+
+    resolve.assert_not_called()
+    random_resolve.assert_not_called()
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent)
+    assert "如果你是想按难度随机选题" in private_text, private_text
+    _cleanup()
+    print("✅ private setproblem: plain digits use problem-ref path")
+
+
 def test_resolve_problem_by_pid_revalidates_cached_statement():
     _reset_state()
     _write_statement(PID, {
@@ -4626,6 +4708,28 @@ def test_resolve_random_problem_revalidates_cached_statement():
     assert state["today"] == PID, state
     _cleanup()
     print("✅ private setproblem random: revalidates cached statements")
+
+
+def test_resolve_random_problem_honors_explicit_rating_range():
+    _reset_state()
+    candidates = [
+        {"contestId": 1, "index": "A", "name": "Low", "rating": 1800, "tags": []},
+        {"contestId": 2, "index": "A", "name": "Mid", "rating": 2400, "tags": []},
+        {"contestId": 3, "index": "A", "name": "High", "rating": 2600, "tags": []},
+        {"contestId": 4, "index": "A", "name": "Top", "rating": 3000, "tags": []},
+    ]
+
+    with _all_patches(), \
+        patch("kouhai_bot.private_judge._fetch_problemset", return_value=candidates), \
+        patch("kouhai_bot.private_judge.random.shuffle", lambda items: None), \
+        patch("kouhai_bot.private_judge._ensure_statement", return_value={"name": "validated"}):
+        from kouhai_bot.private_judge import resolve_random_problem
+
+        state = resolve_random_problem(GID, (2500, 3000))
+
+    assert 2500 <= int(state["rating"]) <= 3000, state
+    _cleanup()
+    print("✅ private setproblem random: explicit rating range filters candidates")
 
 
 def test_private_setproblem_non_formula_image_hint():

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4636,7 +4636,72 @@ def test_private_setproblem_invalid_rating_range_shows_format_hint():
     print("✅ private setproblem: invalid rating range shows format hint")
 
 
-def test_private_setproblem_plain_digits_stays_on_problem_ref_path():
+def test_private_setproblem_plain_digits_picks_exact_rating_and_sends_card():
+    _reset_state()
+    problem = {
+        "today": "2500A",
+        "contestId": 2500,
+        "index": "A",
+        "name": "Exact Rating Problem",
+        "rating": 2500,
+        "tags": ["math"],
+    }
+
+    with _all_patches(), \
+        patch(
+            "kouhai_bot.handlers.cmd.setproblem.resolve_random_problem",
+            return_value=problem,
+        ) as random_resolve, \
+        patch(
+            "kouhai_bot.handlers.cmd.setproblem.send_problem_card_private",
+            new=AsyncMock(return_value=True),
+        ) as send_card, \
+        patch("kouhai_bot.handlers.cmd.setproblem.resolve_problem_by_pid") as resolve:
+        from kouhai_bot.handlers.cmd.setproblem import handle
+
+        asyncio.run(handle(**_kwargs(_make_private_event("/sp 2500"))))
+
+    resolve.assert_not_called()
+    random_resolve.assert_called_once_with(GID, (2500, 2500))
+    send_card.assert_awaited_once()
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent)
+    assert "正在按 2500 难度随机挑题" in private_text, private_text
+    _cleanup()
+    print("✅ private setproblem: plain digits pick exact rating and send problem")
+
+
+def test_private_setproblem_equal_rating_range_uses_exact_rating_message():
+    _reset_state()
+    problem = {
+        "today": "2500A",
+        "contestId": 2500,
+        "index": "A",
+        "name": "Exact Range Problem",
+        "rating": 2500,
+        "tags": ["math"],
+    }
+
+    with _all_patches(), \
+        patch(
+            "kouhai_bot.handlers.cmd.setproblem.resolve_random_problem",
+            return_value=problem,
+        ) as random_resolve, \
+        patch(
+            "kouhai_bot.handlers.cmd.setproblem.send_problem_card_private",
+            new=AsyncMock(return_value=True),
+        ):
+        from kouhai_bot.handlers.cmd.setproblem import handle
+
+        asyncio.run(handle(**_kwargs(_make_private_event("/sp 2500-2500"))))
+
+    random_resolve.assert_called_once_with(GID, (2500, 2500))
+    private_text = "\n".join(_last_text_item(item) for item in _private_sent)
+    assert "正在按 2500 难度随机挑题" in private_text, private_text
+    assert "正在按 2500-2500 难度随机挑题" not in private_text, private_text
+    _cleanup()
+
+
+def test_private_setproblem_two_digit_hint_mentions_exact_and_range_forms():
     _reset_state()
 
     with _all_patches(), \
@@ -4644,14 +4709,13 @@ def test_private_setproblem_plain_digits_stays_on_problem_ref_path():
         patch("kouhai_bot.handlers.cmd.setproblem.resolve_problem_by_pid") as resolve:
         from kouhai_bot.handlers.cmd.setproblem import handle
 
-        asyncio.run(handle(**_kwargs(_make_private_event("/sp 2500"))))
+        asyncio.run(handle(**_kwargs(_make_private_event("/sp 25"))))
 
     resolve.assert_not_called()
     random_resolve.assert_not_called()
     private_text = "\n".join(_last_text_item(item) for item in _private_sent)
-    assert "如果你是想按难度随机选题" in private_text, private_text
+    assert "可以发 /sp 2500 或 /sp 2500-2600～" in private_text, private_text
     _cleanup()
-    print("✅ private setproblem: plain digits use problem-ref path")
 
 
 def test_resolve_problem_by_pid_revalidates_cached_statement():


### PR DESCRIPTION
## Summary
- support private-judge random selection with explicit rating ranges such as /sp 2500-2600
- add friendly validation and failure messages for malformed, reversed, empty, and plain-digit inputs
- preserve the existing shared set-problem/card/history/editorial flow
- add command and picker regression tests

## Tests
- uv run pytest (475 passed, 2 existing warnings)