### PR TITLE
docs: 更新 README 和 DEPENDENCIES

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,16 @@ NapCat (QQ) ──WS──> worker.py
   by `.input`/`.output` class pairs (not bare `<pre>` scanning), and the
   `problem-statement` block itself is located by div-depth counting since the
   `</div><script` terminator is not present in every template variant.
+- **MathJax formula deduplication**: `problems/fetcher.py:normalize_mathjax()` is the
+  single shared implementation that removes MathJax-rendered duplicate formulas from
+  CF HTML. Rendered CF pages carry each formula multiple times (visible `<nobr>`
+  rendering, `MJX_Assistive_MathML` accessibility copy, and the original
+  `<script type="math/tex">` source). The normalizer keeps only the TeX source
+  wrapped in `$$$...$$$`, discarding the rendered copies. It is called from
+  `html_to_text()` (problem statements) and from `html_to_markdownish()` in
+  `tools/scrape_cf_tutorial.py` (tutorial blog pages). Without this, LLM judge
+  and tutorial extraction see duplicated numbers (e.g. "111" instead of "1") and
+  may misinterpret problem constraints.
 - **Stale cache detection**: `picker.py:fetch_statement()` detects caches created before image metadata via `_images_collected`. Stale caches with images are re-fetched so image metadata is available for multimodal tasks.
 - **Editorial extraction matches Div1/Div2 mirror codes by title**: CF
   mirrors of the same problem carry different codes but the same name (e.g.
@@ -77,6 +87,15 @@ NapCat (QQ) ──WS──> worker.py
   statement/IO format; anything uncertain must be `match=false` — never risk
   attaching the wrong editorial (judge correctness depends on it). Any API
   failure degrades to an empty sibling list (prompt-only title matching).
+- **Editorial extraction distinguishes easy/hard versions**: Problems with
+  similar names but different difficulty levels (e.g. `95B` "Lucky Numbers"
+  vs `96B` "Lucky Numbers (easy)") are treated as different problems. The
+  extractor prompt explicitly warns the LLM to check constraint ranges and
+  solution complexity — easy/hard versions have different constraints and
+  require different algorithms. If a blog discusses the easy version but the
+  target problem is the hard version (or vice versa), the match must be
+  `match=false`. This prevents attaching the wrong editorial when problem
+  names are similar but not identical.
 - **No hermes cron involvement**: The bot runs its own scheduler loop (`scheduler/engine.py`), not hermes cron jobs.
 - **Single worker runtime**: `worker.py` keeps the NapCat reverse-WS connection,
   dispatches commands, and owns the scheduler, next-problem prefetch loop, and
@@ -472,7 +491,7 @@ No repository-local runtime queue is used.
 | `/help` | help.py | `handle` | ❌ | — | Auto-generated help (forward card) |
 | `/review` (`/rv`) | review.py | `handle` | ✅ state scheduler | `llm.smart_model` queue | Discuss the latest solved group/private problem by default; quoted group problem cards can target older problems |
 | `/status` | stubs.py | `handle_status` | ❌ | — | Check whether this group or private judge has active stateful work |
-| `/setproblem` (`/sp`) | setproblem.py | `handle` | ❌ | — | Private-only; set current private problem from current group problem, CF pid/link, `random`, or a quoted problem card |
+| `/setproblem` (`/sp`) | setproblem.py | `handle` | ❌ | — | Private-only; set current private problem from current group problem, CF pid/link, `random`, or a quoted problem card. Supports rating range (e.g. `/sp 2500-2600`) for targeted difficulty selection |
 | `/sync` | sync.py | `handle` | ✅ short group state lock for group writes | — | Sync current group problem history between group and private judge; empty source aborts without overwrite |
 | `/testcd` | testcd.py | `handle` | ❌ | — | Private-only; show whether this user can submit the current group problem or how long remains in dynamic submit CD |
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -3,7 +3,8 @@
 ## 系统要求
 
 - Python 3.11+
-- NapCat QQ 客户端（Docker 或 Linux 部署）
+- Docker（用于运行 NapCat）
+- NapCat QQ 客户端（外部依赖，需自行部署）
 
 ## Python 依赖
 
@@ -30,33 +31,98 @@ uv sync
 
 ## NapCat 配置
 
-NapCat 是 QQ NT 的 Bot 框架，提供 OneBot11 兼容接口。
+NapCat 是 QQ NT 的 Bot 框架，提供 OneBot11 兼容接口。这是一个外部依赖，需要你自行部署。推荐使用 Docker。
 
-### Docker 安装（推荐）
+### Docker 安装
 
-已有的 NapCat Docker 配置在 `napcat/` 目录下，包含 `docker-compose.yml` 和配置文件。
+在任意位置创建 NapCat 配置目录（例如 `~/napcat`），并编写 `docker-compose.yml`：
+
+```yaml
+version: '3'
+services:
+  napcat:
+    image: mlikiowa/napcat-docker:latest
+    container_name: napcat
+    environment:
+      - ACCOUNT=你的QQ号
+    ports:
+      - "3000:3000"  # HTTP API
+      - "6099:6099"  # WebUI
+    volumes:
+      - ./config:/usr/src/app/napcat/config
+    restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+```
 
 ### 配置反向 WebSocket
 
-编辑 NapCat 的 `onebot11.json`（通常位于 NapCat 配置目录下）：
+在 NapCat 配置目录下的 `config/onebot11.json` 中配置：
 
 ```json
 {
   "network": {
-    "http": { "enable": true, "port": 3000 },
-    "wsReverse": [{
-      "enable": true,
-      "url": "ws://127.0.0.1:8095"
-    }]
+    "httpServers": [
+      {
+        "enable": true,
+        "name": "kouhai-http-api",
+        "host": "0.0.0.0",
+        "port": 3000,
+        "enableCors": true,
+        "enableWebsocket": false,
+        "messagePostFormat": "array",
+        "token": "",
+        "debug": false
+      }
+    ],
+    "websocketClients": [
+      {
+        "enable": true,
+        "name": "kouhai-bot-reverse-ws",
+        "url": "ws://host.docker.internal:8097",
+        "messagePostFormat": "array",
+        "reportSelfMessage": false,
+        "reconnectInterval": 5000,
+        "token": "",
+        "debug": false,
+        "heartInterval": 30000
+      }
+    ]
   }
 }
 ```
 
-重启 NapCat 后，bot 启动时会自动接收连接。
+**重要说明：**
+- `url` 中的 `host.docker.internal` 指向宿主机，**不能用 `127.0.0.1`**
+- 端口 `8097` 需要与 `config.yaml` 中的 `napcat_ws_port` 一致
+- `extra_hosts` 配置确保 Docker 容器能解析 `host.docker.internal`
+
+### 启动 NapCat
+
+```bash
+cd ~/napcat  # 或你的 NapCat 配置目录
+docker-compose up -d
+```
 
 ### 首次登录
 
-NapCat 首次启动时需要扫码登录 QQ。登录成功后 token 会持久化，后续重启无需重新登录。
+NapCat 首次启动时需要扫码登录 QQ。查看日志获取二维码：
+
+```bash
+docker logs -f napcat
+```
+
+登录成功后 token 会持久化，后续重启无需重新登录。
+
+### 验证 NapCat
+
+```bash
+# 检查 HTTP API
+curl -X POST http://127.0.0.1:3000/get_status \
+  -H 'Content-Type: application/json' -d '{}'
+
+# 应返回 {"status":"ok","data":{"online":true,"good":true}}
+```
 
 ## 验证安装
 
@@ -71,3 +137,27 @@ uv run python -m pytest tests/ -v
 # 启动 bot
 uv run start
 ```
+
+## 常见问题
+
+### 1. NapCat 连不上 bot
+
+**症状：** bot 日志显示 `NapCat connected from ...` 但消息不响应
+
+**解决：** 检查 `napcat_ws_host` 是否为 `0.0.0.0`（不能用 `127.0.0.1`）
+
+### 2. Docker 容器无法解析 host.docker.internal
+
+**症状：** NapCat 日志显示 `getaddrinfo ENOTFOUND host.docker.internal`
+
+**解决：** 确保 `docker-compose.yml` 中有 `extra_hosts` 配置
+
+### 3. 端口冲突
+
+**症状：** `uv run start` 失败，提示 `address already in use`
+
+**解决：** 检查 `config.yaml` 中的 `napcat_ws_port` 是否与 NapCat 的 WebSocket server 端口冲突。NapCat 的 WebSocket **server** 端口（如 8095）和 bot 的 WebSocket **listen** 端口（如 8097）不能相同。
+
+### 4. NapCat 每次重启都要扫码
+
+**解决：** 在 `docker-compose.yml` 中设置 `ACCOUNT` 环境变量，格式为 QQ 号

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cp config.example.yaml config.yaml
 
 > 配置中的 model_tag 是一个标记，会附在 bot 的每个需要 llm 接入的请求尾部，以便用户知晓自己的请求是由哪个模型处理的，~~以便开骂~~
 
-> 在我们的测试中，gpt-5.5 high 基本胜任，qwen-3.7-max 也相当不错，Deepseek v4 pro 可用，但由于其 CoT 较长，响应慢，推理能力也确实不及前者，建议只作为 API 连接不稳时的 fallback
+> 在我们的测试中，GPT-5.6 系列基本胜任，GLM-5.2/5.3 也相当不错，DeepSeek V4 系列可用。建议 smart_model 使用推理能力强的模型，general_model 可以使用更便宜的模型。
 
 ZenMux 上的体验模型也可以作为 OpenAI-compatible provider 配置。示例见 `config.example.yaml`；例如 Grok 4.5 Free 可使用 `model: "x-ai/grok-4.5-free"`、`reasoning_effort: "xhigh"`、`model_tag: "『∅』"`。如果某个网关需要特殊 payload，可在 provider 上配置 `temperature`、`send_thinking` 或 `extra_body`，避免为每个模型在代码里新增分支。
 
@@ -141,11 +141,9 @@ bot 能看到原题面他与你在此题的所有对话历史（包括所有clar
 
 ### 6. misc
 
-#### 爬取题解！
+#### 难度范围选题
 
-爬取到的题解会在题目被解决时同步发送到群聊中，而且可以提高review的质量。
-
-爬取题解的工具全部保留在 `/tools` 中，但较为杂乱。请直接寻求 AI 的协助。
+`/sp` 命令支持按难度范围选题（如 `/sp 2500-2600`），方便针对性训练。
 
 #### CF 赛事预告！
 


### PR DESCRIPTION
## 变更内容

- **README.md**: 更新模型推荐（GPT-5.6、GLM-5.2/5.3），添加难度范围选题功能说明，移除爬取题解段落（原有功能）
- **DEPENDENCIES.md**: 完善 NapCat 部署文档，明确其为外部依赖，添加 Docker 配置示例和常见问题
- **AGENTS.md**: 添加 MathJax 去重和 easy/hard version 区分的技术说明

## 测试

文档更新，无需测试