### PR TITLE
fix: add timeout to aiohttp session

### DIFF
--- a/src/kouhai_bot/napcat/client.py
+++ b/src/kouhai_bot/napcat/client.py
@@ -28,7 +28,8 @@ _session: aiohttp.ClientSession | None = None
 async def _get_session() -> aiohttp.ClientSession:
     global _session
     if _session is None:
-        _session = aiohttp.ClientSession()
+        timeout = aiohttp.ClientTimeout(total=10)
+        _session = aiohttp.ClientSession(timeout=timeout)
     return _session
 
 


### PR DESCRIPTION
给 aiohttp session 添加 10 秒超时配置，防止 HTTP 请求无限挂起导致事件循环阻塞。

问题：get_doubt_friends_add_request 等 API 调用没有超时限制，可能无限挂起，阻塞事件循环。
解决：添加 aiohttp.ClientTimeout(total=10) 配置。