### PR TITLE
feat: smart_model provider 难度范围限制 (min_rating/max_rating)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Bot 根据任务类型路由到不同的模型队列：
 - `send_thinking`（可选，默认 true）：是否发送 thinking 参数
 - `temperature`（可选）：温度参数
 - `extra_body`（可选）：额外的请求体字段
+- `min_rating` / `max_rating`（可选，int）：仅对 `smart_model` 的判题或复盘生效；当前题 rating 不在范围内时跳过该模型，继续尝试队列中的下一个
 
 > DashScope/阿里云百炼的 provider 会自动使用 SSE 流式传输，无需手动设置 `stream: true`。
 

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -122,6 +122,15 @@ def _log_preview(value: object, limit: int = 240) -> str:
     return text[:limit] + "..."
 
 
+def _coerce_problem_rating(value: object) -> int | None:
+    if value in (None, "", "?"):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
 CLARIFY_PROMPT = """你是一个算法竞赛群的选手，群友对当前题目有疑问，需要你帮他澄清题目细节。
 
 ## 你的任务
@@ -287,9 +296,15 @@ async def _judge_llm_limited(
     problem_text: str,
     submission: str,
     history: list[dict] | None = None,
+    problem_rating: int | None = None,
 ):
     async with _compute_limit():
-        return await judge_submission_result(problem_text, submission, history)
+        return await judge_submission_result(
+            problem_text,
+            submission,
+            history,
+            problem_rating=problem_rating,
+        )
 
 
 async def _second_judge_llm_limited(
@@ -301,6 +316,7 @@ async def _second_judge_llm_limited(
     editorial_source: str = "",
     provider_name: str = "",
     model: str = "",
+    problem_rating: int | None = None,
 ):
     async with _compute_limit():
         return await second_judge_submission_result(
@@ -312,6 +328,7 @@ async def _second_judge_llm_limited(
             editorial_source,
             provider_name=provider_name,
             model=model,
+            problem_rating=problem_rating,
         )
 
 
@@ -794,7 +811,15 @@ class GroupCoordinator:
             req.user_id,
             len(history),
         )
-        result = await _judge_llm_limited(problem_text, req.payload, history)
+        problem_rating = _coerce_problem_rating(
+            (req.submit_problem or {}).get("rating")
+        )
+        result = await _judge_llm_limited(
+            problem_text,
+            req.payload,
+            history,
+            problem_rating=problem_rating,
+        )
         if not result.text:
             logger.warning(
                 "[group_%s] first judge failed pid=%s seq=%s provider=%s model=%s failure=%s",
@@ -859,6 +884,7 @@ class GroupCoordinator:
                     parsed,
                     editorial.text,
                     source,
+                    problem_rating=problem_rating,
                 )
                 if second.text:
                     second_parsed, _second_repair_tag = await parse_json_with_llm_repair(
@@ -969,6 +995,15 @@ class GroupCoordinator:
         if not problem_text:
             return {"kind": "no_statement", "pid": pid}
 
+        problem_rating = load_known_problem_ratings(
+            req.group_id,
+            {pid},
+        ).get(pid)
+        if problem_rating is None and req.is_private:
+            private_problem = get_private_current_problem(req.user_id)
+            if private_problem and str(private_problem.get("today", "") or "") == pid:
+                problem_rating = _coerce_problem_rating(private_problem.get("rating"))
+
         history = await self._load_user_problem_history_for_request(req, pid)
         history_str = _build_review_history(history)
 
@@ -1011,6 +1046,7 @@ class GroupCoordinator:
             task="review",
             timeout=cfg.review_timeout_sec,
             thinking={"type": "enabled"},
+            problem_rating=problem_rating,
         )
         if not result.text:
             return {"kind": result.failure_kind or "error", "pid": pid}

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -46,6 +46,7 @@ async def call_chat_completion_result(
     response_format: dict | None = None,
     thinking: dict | None = None,
     provider_name: str = "",
+    problem_rating: int | None = None,
 ) -> ChatCompletionResult:
     """Call the configured chat-completions provider and keep terminal failure metadata."""
     return await chat_completion(
@@ -57,6 +58,7 @@ async def call_chat_completion_result(
         response_format=response_format,
         thinking=thinking,
         provider_name=provider_name,
+        problem_rating=problem_rating,
     )
 
 
@@ -69,6 +71,7 @@ async def call_chat_completion(
     response_format: dict | None = None,
     thinking: dict | None = None,
     provider_name: str = "",
+    problem_rating: int | None = None,
 ) -> str | None:
     """Call the configured chat-completions provider. Returns response text or None."""
     result = await call_chat_completion_result(
@@ -80,6 +83,7 @@ async def call_chat_completion(
         response_format=response_format,
         thinking=thinking,
         provider_name=provider_name,
+        problem_rating=problem_rating,
     )
     return result.text
 
@@ -1116,6 +1120,7 @@ async def judge_submission_result(
     problem_text: str,
     submission: str,
     history: list[dict] | None = None,
+    problem_rating: int | None = None,
 ) -> ChatCompletionResult:
     """Judge a submission and preserve terminal LLM failure metadata."""
     cfg = get_config()
@@ -1126,6 +1131,7 @@ async def judge_submission_result(
         timeout=cfg.judge_timeout_sec,
         response_format={"type": "json_object"},
         thinking={"type": "enabled"},
+        problem_rating=problem_rating,
     )
 
 
@@ -1138,6 +1144,7 @@ async def second_judge_submission_result(
     editorial_source: str = "",
     provider_name: str = "",
     model: str = "",
+    problem_rating: int | None = None,
 ) -> ChatCompletionResult:
     """Re-check a first-pass correct verdict with official editorial context."""
     cfg = get_config()
@@ -1157,6 +1164,7 @@ async def second_judge_submission_result(
         response_format={"type": "json_object"},
         thinking={"type": "enabled"},
         provider_name=provider_name,
+        problem_rating=problem_rating,
     )
 
 
@@ -1164,9 +1172,15 @@ async def judge_submission(
     problem_text: str,
     submission: str,
     history: list[dict] | None = None,
+    problem_rating: int | None = None,
 ) -> dict | None:
     """Judge a submission. Returns {correct, reason, reaction, reply} or None."""
-    result = await judge_submission_result(problem_text, submission, history)
+    result = await judge_submission_result(
+        problem_text,
+        submission,
+        history,
+        problem_rating=problem_rating,
+    )
     if not result.text:
         return None
     parsed, _repair_tag = await parse_json_with_llm_repair(

--- a/src/kouhai_bot/llm.py
+++ b/src/kouhai_bot/llm.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 import aiohttp
 
 from .config import get_config
+from .llm_config import LlmProviderConfig
 
 logger = logging.getLogger("kouhai-bot.llm")
 
@@ -128,6 +129,39 @@ def _provider_is_dashscope(provider_name: str, base_url: str) -> bool:
         or host.endswith(".dashscope.aliyuncs.com")
         or host.endswith(".maas.aliyuncs.com")
     )
+
+
+def _apply_rating_gate(
+    providers: list[LlmProviderConfig],
+    problem_rating: int | None,
+    *,
+    task_name: str,
+    provider_name_pinned: bool,
+) -> list[LlmProviderConfig]:
+    """Return smart providers eligible for the problem rating.
+
+    The helper deliberately has no logging or fallback behavior so the gate can
+    be unit-tested independently of the transport.  Callers decide what to do
+    when every provider is outside its configured range.
+    """
+    if (
+        problem_rating is None
+        or task_name not in {"judge", "review"}
+        or provider_name_pinned
+    ):
+        return list(providers)
+    return [
+        provider
+        for provider in providers
+        if (
+            provider.min_rating is None
+            or problem_rating >= provider.min_rating
+        )
+        and (
+            provider.max_rating is None
+            or problem_rating <= provider.max_rating
+        )
+    ]
 
 
 
@@ -527,6 +561,7 @@ async def chat_completion(
     thinking: dict | None = None,
     provider_name: str = "",
     send_reasoning_effort: bool = True,
+    problem_rating: int | None = None,
 ) -> ChatCompletionResult:
     """Call providers in fallback order; first success wins.
 
@@ -541,6 +576,33 @@ async def chat_completion(
         providers = cfg.llm_multimodal_providers
     else:
         providers = cfg.llm_general_providers
+    unfiltered_providers = providers
+    gated_providers = _apply_rating_gate(
+        providers,
+        problem_rating,
+        task_name=task_name,
+        provider_name_pinned=bool(provider_name),
+    )
+    if gated_providers != providers:
+        for skipped in providers:
+            if skipped in gated_providers:
+                continue
+            logger.info(
+                "Skipping LLM provider '%s' for problem rating %s "
+                "(min_rating=%s, max_rating=%s)",
+                skipped.name,
+                problem_rating,
+                skipped.min_rating,
+                skipped.max_rating,
+            )
+        if not gated_providers:
+            logger.warning(
+                "All smart_model providers were outside the rating gate for "
+                "problem rating %s; falling back to the unfiltered queue",
+                problem_rating,
+            )
+            gated_providers = unfiltered_providers
+    providers = gated_providers
     if provider_name:
         providers = [p for p in providers if p.name == provider_name]
     if not providers:

--- a/src/kouhai_bot/llm_config.py
+++ b/src/kouhai_bot/llm_config.py
@@ -39,6 +39,8 @@ class LlmProviderConfig:
     send_thinking: bool = True
     temperature: float | None = None
     extra_body: dict[str, Any] = field(default_factory=dict)
+    min_rating: int | None = None
+    max_rating: int | None = None
 
     def model_for(self, explicit_model: str = "") -> str:
         """Resolve the model name for this provider.
@@ -108,6 +110,28 @@ def _build_provider_list(raw: Any, *, section_name: str) -> list[LlmProviderConf
                 f"LLM provider '{name}' in llm.{section_name} has non-mapping extra_body"
             )
 
+        rating_bounds: dict[str, int | None] = {}
+        for bound_name in ("min_rating", "max_rating"):
+            value = p.get(bound_name)
+            if value is None:
+                rating_bounds[bound_name] = None
+                continue
+            try:
+                rating_bounds[bound_name] = int(value)
+            except (TypeError, ValueError, OverflowError) as exc:
+                raise RuntimeError(
+                    f"LLM provider '{name}' in llm.{section_name} has invalid "
+                    f"{bound_name}: expected an int, got {value!r}"
+                ) from exc
+
+        min_rating = rating_bounds["min_rating"]
+        max_rating = rating_bounds["max_rating"]
+        if min_rating is not None and max_rating is not None and min_rating > max_rating:
+            raise RuntimeError(
+                f"LLM provider '{name}' in llm.{section_name} has min_rating "
+                f"greater than max_rating ({min_rating} > {max_rating})"
+            )
+
         providers.append(
             LlmProviderConfig(
                 name=name,
@@ -120,6 +144,8 @@ def _build_provider_list(raw: Any, *, section_name: str) -> list[LlmProviderConf
                 send_thinking=_parse_bool(p.get("send_thinking", True), default=True),
                 temperature=temperature,
                 extra_body=dict(extra_body),
+                min_rating=min_rating,
+                max_rating=max_rating,
             )
         )
     return providers

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -145,7 +145,7 @@ async def _mock_deepseek(messages, model="", task="", temperature=0.7, timeout=1
 
 
 async def _mock_chat_completion_result(messages, model="", task="", temperature=0.7, timeout=120,
-                                       response_format=None, thinking=None):
+                                       response_format=None, thinking=None, problem_rating=None):
     result = await _mock_deepseek(
         messages,
         model=model,
@@ -161,7 +161,7 @@ async def _mock_chat_completion_result(messages, model="", task="", temperature=
     return ChatCompletionResult(text=result, failure_kind=None)
 
 
-async def _mock_judge_result(problem_text, submission, history=None):
+async def _mock_judge_result(problem_text, submission, history=None, problem_rating=None):
     return await _mock_chat_completion_result(
         [{}, {"content": submission}],
         task="judge",

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -295,7 +295,7 @@ async def _mock_deepseek(messages, model="", task="", temperature=0.7, timeout=1
 
 
 async def _mock_chat_completion_result(messages, model="", task="", temperature=0.7, timeout=120,
-                                       response_format=None, thinking=None):
+                                       response_format=None, thinking=None, problem_rating=None):
     result = await _mock_deepseek(
         messages,
         model=model,
@@ -315,7 +315,7 @@ async def _mock_chat_completion_result(messages, model="", task="", temperature=
     )
 
 
-async def _mock_judge_result(problem_text, submission, history=None):
+async def _mock_judge_result(problem_text, submission, history=None, problem_rating=None):
     result = await _mock_chat_completion_result(
         [
             {"role": "system", "content": ""},
@@ -338,6 +338,7 @@ async def _mock_second_judge_result(
     editorial_source="",
     provider_name="",
     model="",
+    problem_rating=None,
 ):
     _second_judge_calls.append({
         "problem_text": problem_text,
@@ -397,6 +398,7 @@ def _dialogue_has_assistant_text(dialogue, content):
 
 def _wrap_llm_result(fn, failure_kind="service_unavailable"):
     async def _wrapped(*args, **kwargs):
+        kwargs.pop("problem_rating", None)  # consumed by chat_completion layer, never reaches provider
         result = await fn(*args, **kwargs)
         if result is None:
             return ChatCompletionResult(text=None, failure_kind=failure_kind)
@@ -405,7 +407,7 @@ def _wrap_llm_result(fn, failure_kind="service_unavailable"):
 
 
 def _wrap_deepseek_as_judge_result(fn, failure_kind="service_unavailable"):
-    async def _wrapped(problem_text, submission, history=None):
+    async def _wrapped(problem_text, submission, history=None, problem_rating=None):
         result = await fn(
             [{}, {"content": json.dumps({"submission": submission, "history": history})}],
             task="judge",
@@ -1397,7 +1399,7 @@ def test_submit_llm_failure_shows_admin_message():
     _setup_problem()
     _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
 
-    async def _fail_judge(problem_text, submission, history=None):
+    async def _fail_judge(problem_text, submission, history=None, problem_rating=None):
         return ChatCompletionResult(text=None, failure_kind="service_unavailable")
 
     with _all_patches(), patch("kouhai_bot.handlers.cmd.submit.judge_submission_result", _fail_judge):
@@ -1421,7 +1423,7 @@ def test_submit_timeout_is_saved_as_context():
     _setup_problem()
     _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
 
-    async def _timeout_judge(problem_text, submission, history=None):
+    async def _timeout_judge(problem_text, submission, history=None, problem_rating=None):
         return ChatCompletionResult(text=None, failure_kind="timeout")
 
     with _all_patches(), patch("kouhai_bot.handlers.cmd.submit.judge_submission_result", _timeout_judge):

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,199 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from kouhai_bot.config import BotConfig
+from kouhai_bot.llm import (
+    ChatCompletionResult,
+    _ChatCompletionAttempt,
+    _apply_rating_gate,
+    chat_completion,
+)
+from kouhai_bot.llm_config import LlmProviderConfig, build_provider_queues_from_yaml
+
+
+def _provider(name: str, *, min_rating=None, max_rating=None) -> LlmProviderConfig:
+    return LlmProviderConfig(
+        name=name,
+        api_key=f"key-{name}",
+        base_url="http://localhost/v1",
+        model=f"model-{name}",
+        min_rating=min_rating,
+        max_rating=max_rating,
+    )
+
+
+def _queues(smart_model):
+    return {
+        "smart_model": smart_model,
+        "general_model": [{"name": "general", "api_key": "key", "model": "general"}],
+    }
+
+
+def test_provider_rating_bounds_parse_from_yaml():
+    smart, _general, _multimodal = build_provider_queues_from_yaml(_queues([
+        {
+            "name": "bounded",
+            "api_key": "key",
+            "model": "smart",
+            "min_rating": "2200",
+            "max_rating": 2800,
+        }
+    ]))
+
+    assert smart[0].min_rating == 2200
+    assert smart[0].max_rating == 2800
+
+
+@pytest.mark.parametrize("field", ["min_rating", "max_rating"])
+def test_invalid_provider_rating_bound_raises(field):
+    raw = {
+        "name": "bounded",
+        "api_key": "key",
+        "model": "smart",
+        field: "not-an-int",
+    }
+
+    with pytest.raises(RuntimeError, match=r"bounded.*smart_model.*invalid"):
+        build_provider_queues_from_yaml(_queues([raw]))
+
+
+def test_provider_rating_min_must_not_exceed_max():
+    with pytest.raises(RuntimeError, match=r"bounded.*smart_model.*min_rating"):
+        build_provider_queues_from_yaml(_queues([
+            {
+                "name": "bounded",
+                "api_key": "key",
+                "model": "smart",
+                "min_rating": 2800,
+                "max_rating": 2200,
+            }
+        ]))
+
+
+@pytest.mark.parametrize(
+    ("rating", "expected"),
+    [
+        (1900, ["unset", "upper"]),
+        (2200, ["unset", "lower", "upper", "both"]),
+        (2600, ["unset", "lower", "upper", "both"]),
+        (2900, ["unset", "lower"]),
+    ],
+)
+def test_rating_gate_filters_provider_bounds(rating, expected):
+    providers = [
+        _provider("unset"),
+        _provider("lower", min_rating=2200),
+        _provider("upper", max_rating=2800),
+        _provider("both", min_rating=2200, max_rating=2800),
+    ]
+
+    result = _apply_rating_gate(
+        providers,
+        rating,
+        task_name="judge",
+        provider_name_pinned=False,
+    )
+
+    assert [provider.name for provider in result] == expected
+
+
+@pytest.mark.asyncio
+async def test_rating_gate_empty_result_falls_back_to_unfiltered_queue(caplog, monkeypatch):
+    only = _provider("only", min_rating=2200)
+    cfg = BotConfig(
+        llm_smart_providers=[only],
+        llm_general_providers=[_provider("general")],
+        llm_max_retries=0,
+    )
+    attempts = []
+
+    async def fake_once(_session, **kwargs):
+        attempts.append(kwargs["provider_name"])
+        return _ChatCompletionAttempt(text="available", retryable=False, retry_after_sec=None)
+
+    monkeypatch.setattr("kouhai_bot.llm.get_config", lambda: cfg)
+    monkeypatch.setattr("kouhai_bot.llm.aiohttp.ClientSession", _DummySession)
+    monkeypatch.setattr("kouhai_bot.llm._post_chat_completion_once", fake_once)
+
+    with caplog.at_level("WARNING", logger="kouhai-bot.llm"):
+        result = await chat_completion(
+            [{"role": "user", "content": "judge"}],
+            task="judge",
+            problem_rating=1800,
+        )
+
+    assert result.text == "available"
+    assert attempts == ["only"]
+    assert any("unfiltered" in record.message for record in caplog.records)
+
+
+def test_rating_gate_bypass_and_noop_cases():
+    providers = [_provider("bounded", min_rating=2200)]
+
+    assert _apply_rating_gate(
+        providers,
+        1800,
+        task_name="judge",
+        provider_name_pinned=True,
+    ) == providers
+    assert _apply_rating_gate(
+        providers,
+        None,
+        task_name="judge",
+        provider_name_pinned=False,
+    ) == providers
+    assert _apply_rating_gate(
+        providers,
+        1800,
+        task_name="clarify",
+        provider_name_pinned=False,
+    ) == providers
+
+
+class _DummySession:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_skips_out_of_range_provider_without_attempt(monkeypatch):
+    first = _provider("first", min_rating=2200)
+    second = _provider("second", max_rating=2000)
+    cfg = BotConfig(
+        llm_smart_providers=[first, second],
+        llm_general_providers=[_provider("general")],
+        llm_max_retries=0,
+    )
+    attempts = []
+
+    async def fake_once(_session, **kwargs):
+        attempts.append(kwargs["provider_name"])
+        return _ChatCompletionAttempt(
+            text="second response",
+            retryable=False,
+            retry_after_sec=None,
+        )
+
+    monkeypatch.setattr("kouhai_bot.llm.get_config", lambda: cfg)
+    monkeypatch.setattr("kouhai_bot.llm.aiohttp.ClientSession", _DummySession)
+    monkeypatch.setattr("kouhai_bot.llm._post_chat_completion_once", fake_once)
+
+    result = await chat_completion(
+        [{"role": "user", "content": "judge"}],
+        task="judge",
+        problem_rating=2000,
+    )
+
+    assert isinstance(result, ChatCompletionResult)
+    assert result.text == "second response"
+    assert attempts == ["second"]


### PR DESCRIPTION
## 功能

给 smart_model 队列的每个 provider 增加可选的 `min_rating` / `max_rating` 配置。判题(/submit)或复盘(/review)时，若当前题的 CF rating 不在某 provider 的范围内，该 provider 会被**直接跳过**（不发任何 API 请求），fallback 继续尝试队列中的下一个模型。

## 实现

- `llm_config.py`: LlmProviderConfig 新增 min_rating/max_rating 字段 + YAML 解析（非法 int、min>max 均报 RuntimeError）
- `llm.py`: 新增纯函数 `_apply_rating_gate`；`chat_completion` 增加 `problem_rating` kwarg，仅对 task=judge/review 且未显式 pin provider 时生效；被跳过模型打 INFO 日志；全部被过滤时 WARN 并回退原队列
- rating 透传：submit 一审/二审、review（群+私聊）从当前题 state 取 rating 传入；rating 未知(缺省/? )→ 不过滤
- 显式 `provider_name` pin（回测/指定模型）绕过门槛
- README provider 字段列表补充说明

## 测试

tests/test_llm.py 新增 7 项：YAML 解析、非法值/min>max 报错、边界过滤矩阵、空队列回退、pin 绕过、rating=None/非 judge 任务不过滤、端到端保证（范围外 provider 零调用）。全量 503 passed。