### PR TITLE
docs: 明确 worktree+PR 流程、隐私禁令与 AGENTS.md 维护规则

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,19 @@ Instructions for AI coding assistants working on this codebase.
 
 ## Operational Constraints
 
-- Code changes must be prepared on a branch and merged by PR. Do not make direct
-  code/config edits on the live `master` checkout.
+- All changes (code, config, docs) must be prepared in a **new git worktree** on
+  a branch and merged by PR. Never edit the live `master` checkout directly.
+  Use the `gh` CLI to create the PR; merge only after the owner confirms the PR
+  is correct.
 - The live service checkout must remain on `master`. Do not use `uv run restart`
   or otherwise change live service state unless explicitly asked. Running tests is
   allowed.
+- Never commit private information into git-maintained content: QQ numbers, group
+  chat numbers, and API keys must not appear in commits, branches, PRs, or any
+  tracked file. Use placeholders in examples and docs.
+- `AGENTS.md` is the single agent-instruction file for this repo. Keep it up to
+  date whenever architecture or workflow rules change; do not create `CLAUDE.md`
+  or other parallel instruction files.
 - Judge and review tasks must use the configured highest reasoning capability. Do
   not lower `reasoning_effort`, disable thinking, or switch to a weaker effort to
   work around latency/cost.


### PR DESCRIPTION
## 变更内容

更新 `AGENTS.md` 的 Operational Constraints 一节，固化以下项目规则：

1. **Worktree + PR 流程**：所有改动（代码/配置/文档）必须在新建 git worktree 中准备，通过 PR 合并；用 `gh` 建 PR，用户确认无误后才合并，绝不直接改 live `master` checkout。
2. **隐私禁令**：QQ 号、群聊号、API key 等隐私信息不得进入任何 git 维护的内容（commit/分支/PR/被跟踪文件），示例与文档使用占位符。
3. **AGENTS.md 唯一性**：`AGENTS.md` 是本仓库唯一的 agent 指令文件，架构或工作流规则变化时须及时维护；不创建 `CLAUDE.md` 或其他平行指令文件。

原有的 live 服务保护条款和 judge/review 约束保持不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)