### PR TITLE
feat: /bad 标记对 AI 最新回复不满意，落盘 bad_reports 供维护回放

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -534,7 +534,7 @@ No repository-local runtime queue is used.
 | `/setproblem` (`/sp`) | setproblem.py | `handle` | ❌ | — | Private-only; set current private problem from current group problem, CF pid/link, `random`, or a quoted problem card. Supports rating range (e.g. `/sp 2500-2600`) for targeted difficulty selection |
 | `/sync` | sync.py | `handle` | ✅ short group state lock for group writes | — | Sync current group problem history between group and private judge; empty source aborts without overwrite |
 | `/testcd` | testcd.py | `handle` | ❌ | — | Private-only; show whether this user can submit the current group problem or how long remains in dynamic submit CD |
-| `/bad` | bad.py | `handle` | ✅ short group state lock for group writes | — | Mark dissatisfaction with the AI's latest DELIVERED reply in the current scope, regardless of problem (works after `/newproblem` and survives `/clear`) — resolved from the per-user last-interaction cache, falling back to a full-history scan for pre-cache replies; markable = any record whose live message was delivered (LLM answers incl. reason-fallback incorrect verdicts, and failure notices timeout/service_unavailable/no_statement/image_unsupported), only pending/superseded are skipped; appends a verbatim record snapshot to `bad_reports.json` (group and private stores are separate; `/sync` never moves them); success acks 👌 (128076) exactly like `/clear` (private gets the fallback message); write-only — no in-chat view command yet |
+| `/bad` | bad.py | `handle` | ✅ short group state lock for group writes | — | Mark dissatisfaction with the AI's latest DELIVERED reply in the current scope, regardless of problem (works after `/newproblem` and survives `/clear`) — resolved exclusively from the per-user last-interaction cache; markable = any record whose live message was delivered (LLM answers incl. reason-fallback incorrect verdicts, and failure notices timeout/service_unavailable/no_statement/image_unsupported), only pending/superseded are skipped; appends a verbatim record snapshot to `bad_reports.json` (group and private stores are separate; `/sync` never moves reports); success acks 👌 (128076) exactly like `/clear` (private gets the fallback message); write-only — no in-chat view command yet |
 
 ### Stateful Command Runtime
 
@@ -1065,12 +1065,16 @@ Rules:
 - Targeting (scope-local, crosses problem switches, survives `/clear`): the
   per-user last-interaction cache (`groups/<gid>/last_interaction.json` keyed by
   uid / `private_judge/last_interaction/<uid>.json`, shape `{"record": {...}}`)
-  is authoritative; if empty/corrupt, /bad falls back to scanning the user's
-  full stored history across all problems. The cache is a CACHE: corrupt files
-  read as missing (warn + None), unlike bad_reports which raise. It is updated
-  inside `_save_context_record` (under the coordinator lock, after the
-  clear-watermark guard) whenever a record with a replied result is persisted —
-  so `/clear` never wipes it and stale in-flight finalizes never resurrect it.
+  is the ONLY source — /bad never scans stored history. The cache is a CACHE:
+  corrupt/missing files read as empty (warn + None), unlike bad_reports which
+  raise. It is updated inside `_save_context_record` (under the coordinator
+  lock, after the clear-watermark guard) whenever a record with a replied
+  result is persisted — so `/clear` never wipes it and stale in-flight
+  finalizes never resurrect it.
+- `/sync` carries the source side's cache entry to the target side together
+  with the history (same "source wins" semantics), but only when the cached
+  record is actually part of what the sync copies: same pid, and clarify-only
+  when a CD-limited starred user syncs clarifies. Reports are never moved.
 - "Replied" = the live message was delivered: results
   `correct/incorrect/clarify/review` (an empty-reply incorrect verdict fell back
   to `reason` live) plus the failure notices

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -494,8 +494,8 @@ groups/<gid>/problem_summaries.json # verified, source-bound Chinese summaries k
 groups/<gid>/used.json       # used problem IDs
 groups/<gid>/groupctx_*.json # group message context
 groups/<gid>/problem_ratings.json # cached problem rating by pid for weighted scoreboard totals
-private_judge/users/<uid>.json # per-user private judge current problem, history, solved markers, redirect state
 groups/<gid>/bad_reports.json  # /bad feedback reports for the group scope (append-only, see Data Format)
+private_judge/users/<uid>.json # per-user private judge current problem, history, solved markers, redirect state
 private_judge/bad_reports/<uid>.json # /bad feedback reports for a user's private-judge scope (append-only)
 annotations/pending/<gid>/<pid>.json # pending human-label bundle for solved problems
 annotations/labeled/<gid>/<pid>.json # completed human-label bundle for solved problems

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -532,7 +532,7 @@ No repository-local runtime queue is used.
 | `/setproblem` (`/sp`) | setproblem.py | `handle` | ❌ | — | Private-only; set current private problem from current group problem, CF pid/link, `random`, or a quoted problem card. Supports rating range (e.g. `/sp 2500-2600`) for targeted difficulty selection |
 | `/sync` | sync.py | `handle` | ✅ short group state lock for group writes | — | Sync current group problem history between group and private judge; empty source aborts without overwrite |
 | `/testcd` | testcd.py | `handle` | ❌ | — | Private-only; show whether this user can submit the current group problem or how long remains in dynamic submit CD |
-| `/bad` | bad.py | `handle` | ✅ short group state lock for group writes | — | Mark dissatisfaction with the AI's latest replied interaction for the current problem in the current scope (skips pending/superseded/failed tails); appends a verbatim record snapshot to `bad_reports.json` (group and private stores are separate; `/sync` never moves them); success acks 👌 (128076) exactly like `/clear` (private gets the fallback message); write-only — no in-chat view command yet |
+| `/bad` | bad.py | `handle` | ✅ short group state lock for group writes | — | Mark dissatisfaction with the AI's latest replied interaction for the current problem in the current scope — any record whose live message was delivered (LLM answers incl. reason-fallback incorrect verdicts, and failure notices timeout/service_unavailable/no_statement/image_unsupported); only pending/superseded tails are skipped; appends a verbatim record snapshot to `bad_reports.json` (group and private stores are separate; `/sync` never moves them); success acks 👌 (128076) exactly like `/clear` (private gets the fallback message); write-only — no in-chat view command yet |
 
 ### Stateful Command Runtime
 
@@ -627,7 +627,8 @@ Read-only commands (`/problem`, `/tag`, `/scoreboard`, `/help`, `/status`) still
 not enter the state scheduler.
 Private dispatch maps DMs to `CURRENT_GROUP`, requires the sender to be a member of that
 service group, and only allows the private command whitelist: `/setproblem`, `/problem`,
-`/tag`, `/submit`, `/clarify`, `/review`, `/clear`, `/sync`, `/testcd`, `/status`, and `/help`.
+`/tag`, `/submit`, `/clarify`, `/review`, `/bad`, `/clear`, `/sync`, `/testcd`, `/status`,
+and `/help`.
 Private commands do not require @mentions and should not send @ segments back.
 
 Friend request events are not commands and are not logged to command event logs.
@@ -1057,8 +1058,19 @@ Rules:
 - Group and private `/bad` stores are separate; `/sync` never moves reports.
 - Writes are atomic (`atomic_write_json` in `handlers/shared.py`: tempfile +
   fsync + `os.replace`); group appends run under `run_group_state_update`.
+- "Replied" = the live message was delivered: results
+  `correct/incorrect/clarify/review` (an empty-reply incorrect verdict fell back
+  to `reason` live) plus the failure notices
+  `timeout/service_unavailable/no_statement/image_unsupported`. Only `pending`
+  and `superseded` records are unmarkable. Classification goes through
+  `shared.record_kind` (single source of truth, also used by
+  `_build_review_history`).
+- To keep `/bad` from seeing a sent-but-unsaved pending tail, the clarify/review
+  finalize paths save the record BEFORE delivering the reply (same order as
+  submit) — preserve that ordering.
 - A corrupt bad_reports file makes `load_bad_reports*` raise instead of resetting
   to empty — a silent reset would destroy the report history on the next append.
+  (A dict missing the `reports` key is tolerated; the next append repairs the shape.)
 - `target.record` is a full verbatim snapshot (`reply`/`reason` keep model tags),
   so reports stay replayable even after the underlying history is cleared/synced.
 
@@ -1216,8 +1228,10 @@ could leak.
 
 ### 29. Private judge state writes must be atomic
 `private_judge/users/<uid>.json` is user history, not a disposable cache. Write it via a
-same-directory temp file and `os.replace`, and log JSON/IO load failures before falling
-back to defaults so corruption or permission problems are diagnosable.
+same-directory temp file and `os.replace` (implemented once in
+`shared.atomic_write_json`, which `save_private_state` delegates to), and log JSON/IO
+load failures before falling back to defaults so corruption or permission problems are
+diagnosable.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -495,6 +495,8 @@ groups/<gid>/used.json       # used problem IDs
 groups/<gid>/groupctx_*.json # group message context
 groups/<gid>/problem_ratings.json # cached problem rating by pid for weighted scoreboard totals
 private_judge/users/<uid>.json # per-user private judge current problem, history, solved markers, redirect state
+groups/<gid>/bad_reports.json  # /bad feedback reports for the group scope (append-only, see Data Format)
+private_judge/bad_reports/<uid>.json # /bad feedback reports for a user's private-judge scope (append-only)
 annotations/pending/<gid>/<pid>.json # pending human-label bundle for solved problems
 annotations/labeled/<gid>/<pid>.json # completed human-label bundle for solved problems
 statements/<pid>.json        # cached problem statements
@@ -530,6 +532,7 @@ No repository-local runtime queue is used.
 | `/setproblem` (`/sp`) | setproblem.py | `handle` | ❌ | — | Private-only; set current private problem from current group problem, CF pid/link, `random`, or a quoted problem card. Supports rating range (e.g. `/sp 2500-2600`) for targeted difficulty selection |
 | `/sync` | sync.py | `handle` | ✅ short group state lock for group writes | — | Sync current group problem history between group and private judge; empty source aborts without overwrite |
 | `/testcd` | testcd.py | `handle` | ❌ | — | Private-only; show whether this user can submit the current group problem or how long remains in dynamic submit CD |
+| `/bad` | bad.py | `handle` | ✅ short group state lock for group writes | — | Mark dissatisfaction with the AI's latest replied interaction for the current problem in the current scope (skips pending/superseded/failed tails); appends a verbatim record snapshot to `bad_reports.json` (group and private stores are separate; `/sync` never moves them); success acks 👌 (128076) exactly like `/clear` (private gets the fallback message); write-only — no in-chat view command yet |
 
 ### Stateful Command Runtime
 
@@ -1018,6 +1021,46 @@ Private judge submission records use the same record shape inside
 `private_judge/users/<uid>.json.user_submissions` so group/private history can be copied
 without conversion. Do not add private-only fields to individual history records unless
 all sync paths intentionally preserve or strip them.
+
+### bad_reports.json (/bad feedback reports)
+
+`groups/<gid>/bad_reports.json` and `private_judge/bad_reports/<uid>.json` —
+append-only stores of `/bad` reports, one entry per invocation (repeat `/bad` on the
+same reply appends a new entry). Shape:
+
+```json
+{
+  "version": 1,
+  "reports": [
+    {
+      "id": 1,                          // max(existing ids)+1 per file; reports never move between files
+      "scope": "group",                 // "group" | "private" — the scope where /bad was issued
+      "group_id": 999999,               // private scope stores cfg.current_group (dispatcher rewrite)
+      "user_id": 42,
+      "reported_at": "2026-09-11T21:03:14.512345+08:00",
+      "note": "复杂度分析说错了",          // optional user note, stripped, capped at 500 chars
+      "cmd_message_id": "msg_001",
+      "target": {
+        "problem": "542D",
+        "record_index": 3,              // 0-based position in the pid-filtered history at report time
+        "record": { /* verbatim snapshot of the submission record, incl. request_id/model_tag */ }
+      }
+    }
+  ]
+}
+```
+
+Rules:
+
+- Never embed `/bad` fields inside `user_submissions` records — that format is
+  frozen (legacy compatibility + `/sync` copies records verbatim between scopes).
+- Group and private `/bad` stores are separate; `/sync` never moves reports.
+- Writes are atomic (`atomic_write_json` in `handlers/shared.py`: tempfile +
+  fsync + `os.replace`); group appends run under `run_group_state_update`.
+- A corrupt bad_reports file makes `load_bad_reports*` raise instead of resetting
+  to empty — a silent reset would destroy the report history on the next append.
+- `target.record` is a full verbatim snapshot (`reply`/`reason` keep model tags),
+  so reports stay replayable even after the underlying history is cleared/synced.
 
 ## Pitfalls & Lessons Learned
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -495,8 +495,10 @@ groups/<gid>/used.json       # used problem IDs
 groups/<gid>/groupctx_*.json # group message context
 groups/<gid>/problem_ratings.json # cached problem rating by pid for weighted scoreboard totals
 groups/<gid>/bad_reports.json  # /bad feedback reports for the group scope (append-only, see Data Format)
+groups/<gid>/last_interaction.json # per-user latest delivered interaction record (per-scope /bad targeting cache)
 private_judge/users/<uid>.json # per-user private judge current problem, history, solved markers, redirect state
 private_judge/bad_reports/<uid>.json # /bad feedback reports for a user's private-judge scope (append-only)
+private_judge/last_interaction/<uid>.json # latest delivered interaction record (private-scope /bad targeting cache)
 annotations/pending/<gid>/<pid>.json # pending human-label bundle for solved problems
 annotations/labeled/<gid>/<pid>.json # completed human-label bundle for solved problems
 statements/<pid>.json        # cached problem statements
@@ -532,7 +534,7 @@ No repository-local runtime queue is used.
 | `/setproblem` (`/sp`) | setproblem.py | `handle` | ❌ | — | Private-only; set current private problem from current group problem, CF pid/link, `random`, or a quoted problem card. Supports rating range (e.g. `/sp 2500-2600`) for targeted difficulty selection |
 | `/sync` | sync.py | `handle` | ✅ short group state lock for group writes | — | Sync current group problem history between group and private judge; empty source aborts without overwrite |
 | `/testcd` | testcd.py | `handle` | ❌ | — | Private-only; show whether this user can submit the current group problem or how long remains in dynamic submit CD |
-| `/bad` | bad.py | `handle` | ✅ short group state lock for group writes | — | Mark dissatisfaction with the AI's latest replied interaction for the current problem in the current scope — any record whose live message was delivered (LLM answers incl. reason-fallback incorrect verdicts, and failure notices timeout/service_unavailable/no_statement/image_unsupported); only pending/superseded tails are skipped; appends a verbatim record snapshot to `bad_reports.json` (group and private stores are separate; `/sync` never moves them); success acks 👌 (128076) exactly like `/clear` (private gets the fallback message); write-only — no in-chat view command yet |
+| `/bad` | bad.py | `handle` | ✅ short group state lock for group writes | — | Mark dissatisfaction with the AI's latest DELIVERED reply in the current scope, regardless of problem (works after `/newproblem` and survives `/clear`) — resolved from the per-user last-interaction cache, falling back to a full-history scan for pre-cache replies; markable = any record whose live message was delivered (LLM answers incl. reason-fallback incorrect verdicts, and failure notices timeout/service_unavailable/no_statement/image_unsupported), only pending/superseded are skipped; appends a verbatim record snapshot to `bad_reports.json` (group and private stores are separate; `/sync` never moves them); success acks 👌 (128076) exactly like `/clear` (private gets the fallback message); write-only — no in-chat view command yet |
 
 ### Stateful Command Runtime
 
@@ -1043,9 +1045,11 @@ same reply appends a new entry). Shape:
       "cmd_message_id": "msg_001",
       "target": {
         "problem": "542D",
-        "record_index": 3,              // 0-based position in the pid-filtered history at report time
         "record": { /* verbatim snapshot of the submission record, incl. request_id/model_tag */ }
       }
+      // NOTE: reports written before the last-interaction cache also carry
+      // target.record_index (0-based position in the then-current history) —
+      // legacy field, no longer written.
     }
   ]
 }
@@ -1058,6 +1062,15 @@ Rules:
 - Group and private `/bad` stores are separate; `/sync` never moves reports.
 - Writes are atomic (`atomic_write_json` in `handlers/shared.py`: tempfile +
   fsync + `os.replace`); group appends run under `run_group_state_update`.
+- Targeting (scope-local, crosses problem switches, survives `/clear`): the
+  per-user last-interaction cache (`groups/<gid>/last_interaction.json` keyed by
+  uid / `private_judge/last_interaction/<uid>.json`, shape `{"record": {...}}`)
+  is authoritative; if empty/corrupt, /bad falls back to scanning the user's
+  full stored history across all problems. The cache is a CACHE: corrupt files
+  read as missing (warn + None), unlike bad_reports which raise. It is updated
+  inside `_save_context_record` (under the coordinator lock, after the
+  clear-watermark guard) whenever a record with a replied result is persisted —
+  so `/clear` never wipes it and stale in-flight finalizes never resurrect it.
 - "Replied" = the live message was delivered: results
   `correct/incorrect/clarify/review` (an empty-reply incorrect verdict fell back
   to `reason` live) plus the failure notices

--- a/src/kouhai_bot/handlers/__init__.py
+++ b/src/kouhai_bot/handlers/__init__.py
@@ -29,6 +29,7 @@ _PRIVATE_ALLOWED_COMMANDS = {
     "submit",
     "clarify",
     "review",
+    "bad",
     "clear",
     "sync",
     "testcd",

--- a/src/kouhai_bot/handlers/cmd/bad.py
+++ b/src/kouhai_bot/handlers/cmd/bad.py
@@ -8,7 +8,13 @@ from datetime import datetime
 
 from .. import registry
 from ..registry import CommandDef
-from ..shared import append_bad_report, get_today_problem, record_kind
+from ..shared import (
+    REPLIED_RESULTS,
+    append_bad_report,
+    load_group_last_interaction,
+    load_user_submissions,
+    record_kind,
+)
 from ...napcat.client import (
     build_at,
     build_plain_message,
@@ -23,9 +29,8 @@ from ...private_judge import (
     PRIVATE_SCOPE,
     TZ,
     append_private_bad_report,
-    get_private_current_pid,
-    group_problem_history,
-    load_private_problem_history,
+    load_private_last_interaction,
+    load_private_submissions,
 )
 from .submit import run_group_state_update
 
@@ -34,24 +39,13 @@ logger = logging.getLogger("kouhai-bot.cmd.bad")
 OK_REACTION_ID = "128076"
 NOTE_MAX_LEN = 500
 
-# Results whose live message reached the user: real LLM answers (an
-# incorrect verdict with an empty reply fell back to the reason live, see
-# format_history_records) AND failure notices — timeout /
-# service_unavailable / no_statement / image_unsupported all delivered a
-# message before the record was saved. Only pending and superseded never
-# delivered anything the user could complain about.
-_REPLIED_RESULTS = {
-    "correct", "incorrect", "clarify", "review",
-    "timeout", "service_unavailable", "no_statement", "image_unsupported",
-}
-
 
 def _received_reply(record: dict) -> bool:
     kind = record_kind(record)
     if not kind:
         return False
     result = str(record.get("result", "") or "")
-    if result not in _REPLIED_RESULTS:
+    if result not in REPLIED_RESULTS:
         # pending (still in flight) / superseded (dropped without a reply).
         return False
     if result in {"clarify", "review"} and not str(record.get("reply", "") or "").strip():
@@ -68,6 +62,32 @@ def _find_bad_target(history: list[dict]) -> tuple[int, dict] | None:
         if isinstance(record, dict) and _received_reply(record):
             return idx, record
     return None
+
+
+def _resolve_target(scope: str, group_id: int, user_id: int) -> dict | None:
+    """The latest DELIVERED reply in this scope, regardless of problem.
+
+    Primary source is the per-user last-interaction cache (survives problem
+    switches and /clear); replies older than the cache deployment fall back
+    to a full-history scan across all problems.
+    """
+    entry = (
+        load_private_last_interaction(user_id)
+        if scope == PRIVATE_SCOPE
+        else load_group_last_interaction(group_id, user_id)
+    )
+    record = entry.get("record") if isinstance(entry, dict) else None
+    if isinstance(record, dict) and _received_reply(record):
+        return record
+
+    history = (
+        load_private_submissions(user_id)
+        if scope == PRIVATE_SCOPE
+        else load_user_submissions(group_id, user_id)
+    )
+    history = sorted(history, key=lambda item: str(item.get("timestamp", "")))
+    target = _find_bad_target(history)
+    return target[1] if target else None
 
 
 async def _send_text(scope: str, group_id: int, user_id: int, text: str) -> None:
@@ -106,42 +126,14 @@ async def handle(group_id: int, user_id: int, sender: dict,
         note = note[:NOTE_MAX_LEN]
 
     try:
-        if scope == PRIVATE_SCOPE:
-            pid = get_private_current_pid(user_id)
-        else:
-            problem = get_today_problem(group_id)
-            pid = str(problem.get("today", "") or "") if problem else ""
-
-        if not pid:
-            if scope == PRIVATE_SCOPE:
-                await _send_text(
-                    scope, group_id, user_id,
-                    "当前还没有 private judge 题目～先发 /setproblem 设置一道题吧。",
-                )
-            else:
-                await _send_text(scope, group_id, user_id, "还没有今日题目哦～")
-            return
-
-        if scope == PRIVATE_SCOPE:
-            history = load_private_problem_history(user_id, pid)
-        else:
-            history = group_problem_history(group_id, user_id, pid)
-
-        if not history:
+        record = _resolve_target(scope, group_id, user_id)
+        if record is None:
             await _send_text(
                 scope, group_id, user_id,
-                "这题这边还没有和 AI 的交流记录哦～先 /submit、/clarify 或 /review 一次再 /bad 吧。",
+                "这边还没有可以标注的 AI 回复哦～先 /submit、/clarify 或 /review 一次，"
+                "收到回复后再来 /bad 吧。",
             )
             return
-
-        target = _find_bad_target(history)
-        if target is None:
-            await _send_text(
-                scope, group_id, user_id,
-                "这题最近的交互还没有收到 AI 回复（可能还在处理中），等回复后再 /bad 哦～",
-            )
-            return
-        record_index, record = target
 
         report = {
             "scope": scope,
@@ -151,8 +143,7 @@ async def handle(group_id: int, user_id: int, sender: dict,
             "note": note,
             "cmd_message_id": str(message_id or ""),
             "target": {
-                "problem": pid,
-                "record_index": int(record_index),
+                "problem": str(record.get("problem", "") or ""),
                 "record": dict(record),
             },
         }

--- a/src/kouhai_bot/handlers/cmd/bad.py
+++ b/src/kouhai_bot/handlers/cmd/bad.py
@@ -1,0 +1,194 @@
+"""/bad — mark the AI's latest replied interaction as unsatisfactory for replay/debugging."""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+
+from .. import registry
+from ..registry import CommandDef
+from ..shared import append_bad_report, get_today_problem
+from ...napcat.client import (
+    build_at,
+    build_plain_message,
+    build_private_reaction_message,
+    build_text,
+    react_emoji,
+    send_group_msg,
+    send_private_msg,
+)
+from ...private_judge import (
+    GROUP_SCOPE,
+    PRIVATE_SCOPE,
+    TZ,
+    append_private_bad_report,
+    get_private_current_pid,
+    group_problem_history,
+    load_private_problem_history,
+)
+from .submit import run_group_state_update
+
+logger = logging.getLogger("kouhai-bot.cmd.bad")
+
+OK_REACTION_ID = "128076"
+NOTE_MAX_LEN = 500
+_REPLIED_RESULTS = {"correct", "incorrect", "clarify", "review"}
+
+
+def _record_kind(record: dict) -> str:
+    # Same fallback chain as _build_review_history in submit.py and
+    # _dialogue_kind in shared.py — legacy records predate the "type" field.
+    explicit = record.get("type", "")
+    if explicit in {"submit", "clarify", "review"}:
+        return explicit
+    result = record.get("result", "")
+    if result in {"clarify", "review"}:
+        return result
+    if result in {"correct", "incorrect"}:
+        return "submit"
+    return ""
+
+
+def _received_reply(record: dict) -> bool:
+    kind = _record_kind(record)
+    if not kind:
+        return False
+    if str(record.get("result", "") or "") not in _REPLIED_RESULTS:
+        # pending / superseded / no_statement / image_unsupported /
+        # service_unavailable / timeout never produced a delivered reply.
+        return False
+    if kind in {"clarify", "review"} and not str(record.get("reply", "") or "").strip():
+        # Defensive: a clarify/review result with an empty reply never
+        # reached the user.
+        return False
+    return True
+    # submit + incorrect with an empty reply still counts: the live message
+    # fell back to the reason (see format_history_records in private_judge.py).
+
+
+def _find_bad_target(history: list[dict]) -> tuple[int, dict] | None:
+    """Latest record that actually received a reply (history is timestamp-ascending)."""
+    for idx in range(len(history) - 1, -1, -1):
+        record = history[idx]
+        if isinstance(record, dict) and _received_reply(record):
+            return idx, record
+    return None
+
+
+async def _send_text(scope: str, group_id: int, user_id: int, text: str) -> None:
+    if scope == PRIVATE_SCOPE:
+        await send_private_msg(user_id, build_plain_message(text))
+    else:
+        await send_group_msg(group_id, [build_at(user_id), build_text(f" {text}")])
+
+
+async def _ack_recorded(scope: str, group_id: int, user_id: int, message_id: str) -> None:
+    """Same ack as /clear's success: 👌 reaction in group, fallback message in private."""
+    if scope == PRIVATE_SCOPE:
+        await send_private_msg(user_id, build_private_reaction_message(OK_REACTION_ID))
+        return
+    try:
+        await react_emoji(message_id, OK_REACTION_ID)
+    except Exception as e:
+        logger.warning("failed to react to recorded /bad feedback %s: %s", message_id, e)
+
+
+async def handle(group_id: int, user_id: int, sender: dict,
+                 message_id: str, raw_text: str, segments: list,
+                 event: dict) -> None:
+    scope = PRIVATE_SCOPE if event.get("message_type") == "private" else GROUP_SCOPE
+
+    match = re.fullmatch(r"/bad(?:\s+(.+))?", raw_text.strip(), re.DOTALL)
+    if match is None:
+        await _send_text(scope, group_id, user_id, "用法：/bad [简短备注]～")
+        return
+    note = (match.group(1) or "").strip()
+    if len(note) > NOTE_MAX_LEN:
+        logger.warning(
+            "truncating /bad note from %d to %d chars (user %s)",
+            len(note), NOTE_MAX_LEN, user_id,
+        )
+        note = note[:NOTE_MAX_LEN]
+
+    try:
+        if scope == PRIVATE_SCOPE:
+            pid = get_private_current_pid(user_id)
+        else:
+            problem = get_today_problem(group_id)
+            pid = str(problem.get("today", "") or "") if problem else ""
+
+        if not pid:
+            if scope == PRIVATE_SCOPE:
+                await _send_text(
+                    scope, group_id, user_id,
+                    "当前还没有 private judge 题目～先发 /setproblem 设置一道题吧。",
+                )
+            else:
+                await _send_text(scope, group_id, user_id, "还没有今日题目哦～")
+            return
+
+        if scope == PRIVATE_SCOPE:
+            history = load_private_problem_history(user_id, pid)
+        else:
+            history = group_problem_history(group_id, user_id, pid)
+
+        if not history:
+            await _send_text(
+                scope, group_id, user_id,
+                "这题这边还没有和 AI 的交流记录哦～先 /submit、/clarify 或 /review 一次再 /bad 吧。",
+            )
+            return
+
+        target = _find_bad_target(history)
+        if target is None:
+            await _send_text(
+                scope, group_id, user_id,
+                "这题最近的交互还没有收到 AI 回复（可能还在处理或出错了），等回复后再 /bad 哦～",
+            )
+            return
+        record_index, record = target
+
+        report = {
+            "scope": scope,
+            "group_id": int(group_id),
+            "user_id": int(user_id),
+            "reported_at": datetime.now(TZ).isoformat(),
+            "note": note,
+            "cmd_message_id": str(message_id or ""),
+            "target": {
+                "problem": pid,
+                "record_index": int(record_index),
+                "record": dict(record),
+            },
+        }
+
+        if scope == PRIVATE_SCOPE:
+            # Pure sync load→append→atomic-write; single asyncio loop means
+            # no interleaving is possible and users/<uid>.json is untouched.
+            append_private_bad_report(user_id, report)
+        else:
+            # Group JSON writes go through the per-group state lock.
+            await run_group_state_update(
+                group_id, lambda: append_bad_report(group_id, report),
+            )
+    except Exception:
+        logger.error(
+            "failed to record /bad feedback (scope=%s user=%s)",
+            scope, user_id, exc_info=True,
+        )
+        await _send_text(scope, group_id, user_id, "记录反馈失败了，联系一下管理员帮帮忙吧～")
+        return
+
+    await _ack_recorded(scope, group_id, user_id, message_id)
+
+
+def register() -> None:
+    registry.register(CommandDef(
+        name="bad",
+        aliases=[],
+        description="标记对AI最新回复不满意，记录反馈供维护复盘",
+        usage="[简短备注]",
+        handler=handle,
+        cooldown=3,
+    ))

--- a/src/kouhai_bot/handlers/cmd/bad.py
+++ b/src/kouhai_bot/handlers/cmd/bad.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 from .. import registry
 from ..registry import CommandDef
-from ..shared import append_bad_report, get_today_problem
+from ..shared import append_bad_report, get_today_problem, record_kind
 from ...napcat.client import (
     build_at,
     build_plain_message,
@@ -33,38 +33,32 @@ logger = logging.getLogger("kouhai-bot.cmd.bad")
 
 OK_REACTION_ID = "128076"
 NOTE_MAX_LEN = 500
-_REPLIED_RESULTS = {"correct", "incorrect", "clarify", "review"}
 
-
-def _record_kind(record: dict) -> str:
-    # Same fallback chain as _build_review_history in submit.py and
-    # _dialogue_kind in shared.py — legacy records predate the "type" field.
-    explicit = record.get("type", "")
-    if explicit in {"submit", "clarify", "review"}:
-        return explicit
-    result = record.get("result", "")
-    if result in {"clarify", "review"}:
-        return result
-    if result in {"correct", "incorrect"}:
-        return "submit"
-    return ""
+# Results whose live message reached the user: real LLM answers (an
+# incorrect verdict with an empty reply fell back to the reason live, see
+# format_history_records) AND failure notices — timeout /
+# service_unavailable / no_statement / image_unsupported all delivered a
+# message before the record was saved. Only pending and superseded never
+# delivered anything the user could complain about.
+_REPLIED_RESULTS = {
+    "correct", "incorrect", "clarify", "review",
+    "timeout", "service_unavailable", "no_statement", "image_unsupported",
+}
 
 
 def _received_reply(record: dict) -> bool:
-    kind = _record_kind(record)
+    kind = record_kind(record)
     if not kind:
         return False
-    if str(record.get("result", "") or "") not in _REPLIED_RESULTS:
-        # pending / superseded / no_statement / image_unsupported /
-        # service_unavailable / timeout never produced a delivered reply.
+    result = str(record.get("result", "") or "")
+    if result not in _REPLIED_RESULTS:
+        # pending (still in flight) / superseded (dropped without a reply).
         return False
-    if kind in {"clarify", "review"} and not str(record.get("reply", "") or "").strip():
-        # Defensive: a clarify/review result with an empty reply never
-        # reached the user.
+    if result in {"clarify", "review"} and not str(record.get("reply", "") or "").strip():
+        # Defensive: an LLM-answer result with an empty reply never reached
+        # the user (failure paths store their notice outside the record).
         return False
     return True
-    # submit + incorrect with an empty reply still counts: the live message
-    # fell back to the reason (see format_history_records in private_judge.py).
 
 
 def _find_bad_target(history: list[dict]) -> tuple[int, dict] | None:
@@ -144,7 +138,7 @@ async def handle(group_id: int, user_id: int, sender: dict,
         if target is None:
             await _send_text(
                 scope, group_id, user_id,
-                "这题最近的交互还没有收到 AI 回复（可能还在处理或出错了），等回复后再 /bad 哦～",
+                "这题最近的交互还没有收到 AI 回复（可能还在处理中），等回复后再 /bad 哦～",
             )
             return
         record_index, record = target

--- a/src/kouhai_bot/handlers/cmd/bad.py
+++ b/src/kouhai_bot/handlers/cmd/bad.py
@@ -1,4 +1,10 @@
-"""/bad — mark the AI's latest replied interaction as unsatisfactory for replay/debugging."""
+"""/bad — mark the AI's latest delivered reply as unsatisfactory for replay/debugging.
+
+Targeting reads the per-user last-interaction cache only (written by
+_save_context_record whenever a replied record is persisted): the cache is
+scope-local, crosses problem switches, survives /clear, and /sync carries it
+across sides together with the history.
+"""
 
 from __future__ import annotations
 
@@ -8,13 +14,7 @@ from datetime import datetime
 
 from .. import registry
 from ..registry import CommandDef
-from ..shared import (
-    REPLIED_RESULTS,
-    append_bad_report,
-    load_group_last_interaction,
-    load_user_submissions,
-    record_kind,
-)
+from ..shared import append_bad_report, load_group_last_interaction
 from ...napcat.client import (
     build_at,
     build_plain_message,
@@ -30,7 +30,6 @@ from ...private_judge import (
     TZ,
     append_private_bad_report,
     load_private_last_interaction,
-    load_private_submissions,
 )
 from .submit import run_group_state_update
 
@@ -38,56 +37,6 @@ logger = logging.getLogger("kouhai-bot.cmd.bad")
 
 OK_REACTION_ID = "128076"
 NOTE_MAX_LEN = 500
-
-
-def _received_reply(record: dict) -> bool:
-    kind = record_kind(record)
-    if not kind:
-        return False
-    result = str(record.get("result", "") or "")
-    if result not in REPLIED_RESULTS:
-        # pending (still in flight) / superseded (dropped without a reply).
-        return False
-    if result in {"clarify", "review"} and not str(record.get("reply", "") or "").strip():
-        # Defensive: an LLM-answer result with an empty reply never reached
-        # the user (failure paths store their notice outside the record).
-        return False
-    return True
-
-
-def _find_bad_target(history: list[dict]) -> tuple[int, dict] | None:
-    """Latest record that actually received a reply (history is timestamp-ascending)."""
-    for idx in range(len(history) - 1, -1, -1):
-        record = history[idx]
-        if isinstance(record, dict) and _received_reply(record):
-            return idx, record
-    return None
-
-
-def _resolve_target(scope: str, group_id: int, user_id: int) -> dict | None:
-    """The latest DELIVERED reply in this scope, regardless of problem.
-
-    Primary source is the per-user last-interaction cache (survives problem
-    switches and /clear); replies older than the cache deployment fall back
-    to a full-history scan across all problems.
-    """
-    entry = (
-        load_private_last_interaction(user_id)
-        if scope == PRIVATE_SCOPE
-        else load_group_last_interaction(group_id, user_id)
-    )
-    record = entry.get("record") if isinstance(entry, dict) else None
-    if isinstance(record, dict) and _received_reply(record):
-        return record
-
-    history = (
-        load_private_submissions(user_id)
-        if scope == PRIVATE_SCOPE
-        else load_user_submissions(group_id, user_id)
-    )
-    history = sorted(history, key=lambda item: str(item.get("timestamp", "")))
-    target = _find_bad_target(history)
-    return target[1] if target else None
 
 
 async def _send_text(scope: str, group_id: int, user_id: int, text: str) -> None:
@@ -126,8 +75,13 @@ async def handle(group_id: int, user_id: int, sender: dict,
         note = note[:NOTE_MAX_LEN]
 
     try:
-        record = _resolve_target(scope, group_id, user_id)
-        if record is None:
+        entry = (
+            load_private_last_interaction(user_id)
+            if scope == PRIVATE_SCOPE
+            else load_group_last_interaction(group_id, user_id)
+        )
+        record = entry.get("record") if entry else None
+        if not isinstance(record, dict):
             await _send_text(
                 scope, group_id, user_id,
                 "这边还没有可以标注的 AI 回复哦～先 /submit、/clarify 或 /review 一次，"

--- a/src/kouhai_bot/handlers/cmd/help.py
+++ b/src/kouhai_bot/handlers/cmd/help.py
@@ -10,6 +10,7 @@ _PRIVATE_HELP_COMMANDS = {
     "submit",
     "clarify",
     "review",
+    "bad",
     "clear",
     "sync",
     "testcd",

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -43,7 +43,9 @@ from ..shared import (
     remember_problem_rating,
     parse_json_with_llm_repair,
     record_kind,
+    remember_group_last_interaction,
     remove_user_submission,
+    REPLIED_RESULTS,
     save_scoreboard,
     save_user_submission,
     second_judge_submission_result,
@@ -79,6 +81,7 @@ from ...private_judge import (
     mark_private_solved,
     remove_private_submission,
     replace_private_problem_history,
+    remember_private_last_interaction,
     save_private_submission,
     send_problem_card_private,
     set_private_current_problem,
@@ -735,8 +738,12 @@ class GroupCoordinator:
                 return False
             if req.is_private:
                 save_private_submission(req.user_id, record)
+                if record.get("result") in REPLIED_RESULTS:
+                    remember_private_last_interaction(req.user_id, record)
             else:
                 save_user_submission(req.group_id, req.user_id, record)
+                if record.get("result") in REPLIED_RESULTS:
+                    remember_group_last_interaction(req.group_id, req.user_id, record)
             return True
 
     async def _remove_context_record(self, req: PendingRequest) -> None:

--- a/src/kouhai_bot/handlers/cmd/submit.py
+++ b/src/kouhai_bot/handlers/cmd/submit.py
@@ -42,6 +42,7 @@ from ..shared import (
     rating_to_points,
     remember_problem_rating,
     parse_json_with_llm_repair,
+    record_kind,
     remove_user_submission,
     save_scoreboard,
     save_user_submission,
@@ -376,15 +377,9 @@ def _load_latest_group_summary(group_id: int) -> str:
 
 def _build_review_history(history: list[dict]) -> str:
     def record_type(item: dict) -> str:
-        explicit = item.get("type", "")
-        if explicit in {"submit", "clarify", "review"}:
-            return explicit
-        result = item.get("result", "")
-        if result in {"clarify", "review"}:
-            return result
-        if result in {"correct", "incorrect"}:
-            return "submit"
-        return "unknown"
+        # Canonical classification lives in shared.record_kind; "unknown" is
+        # this formatter's sentinel for records that are none of the three.
+        return record_kind(item) or "unknown"
 
     parts = []
     type_counts = {"clarify": 0, "submit": 0, "review": 0, "unknown": 0}
@@ -1443,13 +1438,16 @@ class GroupCoordinator:
             reply = reply[:500] + "…"
         reply = reply.replace("😅", "❤️")
         model_tag = result.get("model_tag", "")
-        await _send_req_plain(req, append_model_tag(reply, model_tag))
 
-        # Store the raw reply + tag field; the tag is display-only metadata.
+        # Store the raw reply + tag field BEFORE delivering it: the record
+        # must already say "replied" once the user can see the answer, so a
+        # concurrent /bad never sees a sent-but-unsaved pending tail (same
+        # order as _finalize_submit).
         await self._save_context_record(
             req,
             _context_record(req, result="clarify", reply=reply, problem=pid, model_tag=model_tag),
         )
+        await _send_req_plain(req, append_model_tag(reply, model_tag))
         self._log_finished(req, "ok", problem=pid)
         await self._finish_request(req)
 
@@ -1491,6 +1489,15 @@ class GroupCoordinator:
         reply = result.get("reply", "").replace("😅", "❤️")
         model_tag = result.get("model_tag", "")
         display_reply = append_model_tag(reply, model_tag)
+
+        # Store the raw reply + tag field BEFORE the (potentially slow,
+        # forward-card) delivery: the record must already say "replied" once
+        # the user can see the answer, so a concurrent /bad never sees a
+        # sent-but-unsaved pending tail (same order as _finalize_submit).
+        await self._save_context_record(
+            req,
+            _context_record(req, result="review", reply=reply, problem=pid, model_tag=model_tag),
+        )
 
         if len(display_reply) > _REVIEW_FORWARD_THRESHOLD:
             cfg = get_config()
@@ -1596,11 +1603,6 @@ class GroupCoordinator:
             )
             await _send_req_plain(req, display_reply)
 
-        # Store the raw reply + tag field; the tag is display-only metadata.
-        await self._save_context_record(
-            req,
-            _context_record(req, result="review", reply=reply, problem=pid, model_tag=model_tag),
-        )
         self._log_finished(req, "ok", problem=pid)
         await self._finish_request(req)
 

--- a/src/kouhai_bot/handlers/cmd/sync.py
+++ b/src/kouhai_bot/handlers/cmd/sync.py
@@ -19,8 +19,10 @@ from ...private_judge import (
     get_private_current_pid,
     group_problem_history,
     is_group_problem_solved,
+    load_private_last_interaction,
     load_private_problem_history,
     mark_private_solved,
+    remember_private_last_interaction,
     replace_group_problem_clarifies,
     replace_group_problem_history,
     replace_private_problem_clarifies,
@@ -37,9 +39,11 @@ from ..shared import (
     fetch_group_member_nickname_map,
     format_points,
     get_today_problem,
+    load_group_last_interaction,
     load_known_problem_ratings,
     load_scoreboard,
     rating_to_points,
+    remember_group_last_interaction,
 )
 from .submit import (
     _reveal_problem_source,
@@ -219,12 +223,31 @@ async def handle(group_id: int, user_id: int, sender: dict,
         return
 
     records_to_copy = copy_records(source_records)
+
+    # Carry the source side's last-interaction cache across too, so /bad on
+    # this side after a sync targets the same latest reply the user saw on
+    # the other side (sync = the source session wins wholesale). Only when
+    # the cached record is part of what this sync actually copies: same pid,
+    # and clarify-only records when a CD-limited starred user syncs clarifies.
+    source_entry = (
+        load_private_last_interaction(user_id)
+        if source_scope == PRIVATE_SCOPE
+        else load_group_last_interaction(group_id, user_id)
+    )
+    source_record = source_entry.get("record") if isinstance(source_entry, dict) else None
+    carry_cache_record: dict | None = None
+    if isinstance(source_record, dict) and str(source_record.get("problem", "") or "") == pid:
+        if not starred_limited or source_record.get("type") == "clarify":
+            carry_cache_record = dict(source_record)
+
     if target_scope == GROUP_SCOPE:
         def _replace_group_records() -> None:
             if starred_limited:
                 replace_group_problem_clarifies(group_id, user_id, pid, records_to_copy)
             else:
                 replace_group_problem_history(group_id, user_id, pid, records_to_copy)
+            if carry_cache_record is not None:
+                remember_group_last_interaction(group_id, user_id, carry_cache_record)
 
         await run_group_state_update(group_id, _replace_group_records)
     else:
@@ -232,6 +255,8 @@ async def handle(group_id: int, user_id: int, sender: dict,
             replace_private_problem_clarifies(user_id, pid, records_to_copy)
         else:
             replace_private_problem_history(user_id, pid, records_to_copy)
+        if carry_cache_record is not None:
+            remember_private_last_interaction(user_id, carry_cache_record)
         if source_scope == GROUP_SCOPE and is_group_problem_solved(group_id, pid):
             mark_private_solved(user_id, pid, source="group")
 

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -727,6 +727,17 @@ def remember_problem_rating(group_id: int, pid: str, rating) -> None:
 
 # ── /bad feedback reports ────────────────────────────────────────────────
 
+# Results whose live message was delivered to the user: real LLM answers (an
+# incorrect verdict with an empty reply fell back to the reason live) AND
+# failure notices (timeout / service_unavailable / no_statement /
+# image_unsupported all delivered a message before the record was saved).
+# Only pending and superseded never delivered anything. Shared by /bad
+# targeting and the last-interaction cache hook in submit.py.
+REPLIED_RESULTS = {
+    "correct", "incorrect", "clarify", "review",
+    "timeout", "service_unavailable", "no_statement", "image_unsupported",
+}
+
 BAD_REPORTS_FORMAT_VERSION = 1
 
 
@@ -839,6 +850,50 @@ def load_bad_reports(group_id: int) -> dict:
 
 def append_bad_report(group_id: int, report: dict) -> int:
     return append_bad_report_at(_bad_reports_file(group_id), report)
+
+
+# ── last-interaction cache (/bad targeting across problems and /clear) ────
+
+
+def _last_interaction_file(group_id: int) -> Path:
+    cfg = get_config()
+    return Path(cfg.data_dir) / "groups" / str(group_id) / "last_interaction.json"
+
+
+def load_group_last_interaction(group_id: int, user_id: int) -> dict | None:
+    """Latest delivered interaction record of one user in the group scope.
+
+    Unlike bad_reports this is a cache: a corrupt/missing file logs a warning
+    and returns None, and /bad falls back to scanning stored history.
+    """
+    path = _last_interaction_file(group_id)
+    if not path.exists():
+        return None
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as e:
+        logger.warning("failed to load last interaction at %s: %s", path, e)
+        return None
+    entry = data.get(str(user_id)) if isinstance(data, dict) else None
+    return entry if isinstance(entry, dict) and isinstance(entry.get("record"), dict) else None
+
+
+def remember_group_last_interaction(group_id: int, user_id: int, record: dict) -> None:
+    """Record one user's latest delivered interaction (called under the group
+    coordinator lock from _save_context_record — a single writer per group)."""
+    path = _last_interaction_file(group_id)
+    data: dict = {}
+    if path.exists():
+        try:
+            with path.open(encoding="utf-8") as f:
+                loaded = json.load(f)
+            if isinstance(loaded, dict):
+                data = loaded
+        except Exception as e:
+            logger.warning("failed to load last interaction at %s; resetting: %s", path, e)
+    data[str(user_id)] = {"record": dict(record)}
+    atomic_write_json(path, data)
 
 
 def _problem_id_from_problem(problem: dict) -> str:

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -12,6 +12,7 @@ import math
 import os
 import random
 import re
+import tempfile
 import time
 import urllib.request
 from dataclasses import dataclass
@@ -722,6 +723,109 @@ def remember_problem_rating(group_id: int, pid: str, rating) -> None:
         return
     ratings[pid] = rating_value
     save_problem_ratings(group_id, ratings)
+
+
+# ── /bad feedback reports ────────────────────────────────────────────────
+
+BAD_REPORTS_FORMAT_VERSION = 1
+
+
+def atomic_write_json(path: Path | str, payload: dict) -> None:
+    """Atomically replace `path` with `payload`.
+
+    Same discipline as save_private_state in private_judge.py: same-directory
+    tempfile, fsync, os.replace, then fsync the parent directory.
+    """
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp_name = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=target.parent,
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as f:
+            tmp_name = f.name
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_name, target)
+        try:
+            dir_fd = os.open(target.parent, os.O_RDONLY)
+        except OSError:
+            return
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except Exception:
+        if tmp_name:
+            try:
+                os.unlink(tmp_name)
+            except FileNotFoundError:
+                pass
+        raise
+
+
+def _bad_reports_file(group_id: int) -> Path:
+    cfg = get_config()
+    return Path(cfg.data_dir) / "groups" / str(group_id) / "bad_reports.json"
+
+
+def _empty_bad_reports() -> dict:
+    return {"version": BAD_REPORTS_FORMAT_VERSION, "reports": []}
+
+
+def load_bad_reports_at(path: Path) -> dict:
+    """Load a bad-reports store; corrupt files raise instead of resetting.
+
+    A silent reset would make the next append destroy the whole report
+    history, so failures must surface to the caller.
+    """
+    if not path.exists():
+        return _empty_bad_reports()
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as e:
+        logger.warning("failed to load bad reports at %s: %s", path, e)
+        raise ValueError(f"unreadable bad reports file: {path}") from e
+    if not isinstance(data, dict) or not isinstance(data.get("reports"), list):
+        logger.warning("bad reports at %s have unexpected shape", path)
+        raise ValueError(f"malformed bad reports file: {path}")
+    return data
+
+
+def append_bad_report_at(path: Path, report: dict) -> int:
+    """Append one report (assigning the next in-file id) and write atomically."""
+    data = load_bad_reports_at(path)
+    reports = data.setdefault("reports", [])
+    highest = 0
+    for item in reports:
+        if not isinstance(item, dict):
+            continue
+        try:
+            candidate = int(item.get("id", 0))
+        except (TypeError, ValueError):
+            continue
+        highest = max(highest, candidate)
+    entry = dict(report)
+    entry["id"] = highest + 1
+    reports.append(entry)
+    atomic_write_json(path, data)
+    return entry["id"]
+
+
+def load_bad_reports(group_id: int) -> dict:
+    return load_bad_reports_at(_bad_reports_file(group_id))
+
+
+def append_bad_report(group_id: int, report: dict) -> int:
+    return append_bad_report_at(_bad_reports_file(group_id), report)
 
 
 def _problem_id_from_problem(problem: dict) -> str:

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -754,12 +754,17 @@ def atomic_write_json(path: Path | str, payload: dict) -> None:
             f.flush()
             os.fsync(f.fileno())
         os.replace(tmp_name, target)
+        # Durability of the rename itself. A failure here (EINVAL/EBADF on
+        # some FUSE/NFS mounts) must not mask the already-completed replace
+        # as a write failure — the caller would retry and duplicate data.
         try:
             dir_fd = os.open(target.parent, os.O_RDONLY)
         except OSError:
             return
         try:
             os.fsync(dir_fd)
+        except OSError as e:
+            logger.warning("dir fsync failed after atomic write of %s: %s", target, e)
         finally:
             os.close(dir_fd)
     except Exception:
@@ -794,8 +799,16 @@ def load_bad_reports_at(path: Path) -> dict:
     except Exception as e:
         logger.warning("failed to load bad reports at %s: %s", path, e)
         raise ValueError(f"unreadable bad reports file: {path}") from e
-    if not isinstance(data, dict) or not isinstance(data.get("reports"), list):
+    if not isinstance(data, dict):
         logger.warning("bad reports at %s have unexpected shape", path)
+        raise ValueError(f"malformed bad reports file: {path}")
+    reports = data.get("reports")
+    if reports is None:
+        # dict without the key (e.g. operator-created {}): tolerated, the
+        # next append rewrites the file in the proper shape.
+        data["reports"] = []
+    elif not isinstance(reports, list):
+        logger.warning("bad reports at %s have non-list reports", path)
         raise ValueError(f"malformed bad reports file: {path}")
     return data
 
@@ -1086,6 +1099,25 @@ def get_judge_prompt() -> str:
         with open(prompt_path, encoding="utf-8") as f:
             return f.read()
     return "You are a competitive programming judge."
+
+
+def record_kind(record: dict) -> str:
+    """Canonical interaction kind of a history record.
+
+    Explicit "type" wins; legacy records without it fall back to "result"
+    (clarify/review verbatim, correct/incorrect → submit). "" when the record
+    is none of the three interaction kinds. Single source of truth for
+    /bad targeting and _build_review_history — keep them from drifting.
+    """
+    explicit = record.get("type", "")
+    if explicit in {"submit", "clarify", "review"}:
+        return explicit
+    result = record.get("result", "")
+    if result in {"clarify", "review"}:
+        return result
+    if result in {"correct", "incorrect"}:
+        return "submit"
+    return ""
 
 
 def _dialogue_kind(item_type: str, result: str) -> str:

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ..config import get_config
-from ..llm import ChatCompletionResult, append_model_tag, chat_completion, strip_leaked_thinking, strip_model_tags
+from ..llm import ChatCompletionResult, chat_completion, strip_leaked_thinking, strip_model_tags
 from ..problem_content import (
     format_problem_statement_for_llm,
     load_statement_json,

--- a/src/kouhai_bot/handlers/shared.py
+++ b/src/kouhai_bot/handlers/shared.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ..config import get_config
-from ..llm import ChatCompletionResult, chat_completion, strip_leaked_thinking, strip_model_tags
+from ..llm import ChatCompletionResult, append_model_tag, chat_completion, strip_leaked_thinking, strip_model_tags
 from ..problem_content import (
     format_problem_statement_for_llm,
     load_statement_json,

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import random
 import re
-import tempfile
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -20,6 +18,7 @@ from .config import get_config
 from .llm import append_model_tag
 from .handlers.shared import (
     append_bad_report_at,
+    atomic_write_json,
     get_problem_summary,
     get_today_problem,
     high_difficulty_notice,
@@ -139,39 +138,10 @@ def load_private_state(user_id: int) -> dict[str, Any]:
 
 
 def save_private_state(user_id: int, state: dict[str, Any]) -> None:
-    path = _state_file(user_id)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_name = ""
-    try:
-        with tempfile.NamedTemporaryFile(
-            "w",
-            encoding="utf-8",
-            dir=path.parent,
-            prefix=f".{path.name}.",
-            suffix=".tmp",
-            delete=False,
-        ) as f:
-            tmp_name = f.name
-            json.dump(state, f, ensure_ascii=False, indent=2)
-            f.write("\n")
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp_name, path)
-        try:
-            dir_fd = os.open(path.parent, os.O_RDONLY)
-        except OSError:
-            return
-        try:
-            os.fsync(dir_fd)
-        finally:
-            os.close(dir_fd)
-    except Exception:
-        if tmp_name:
-            try:
-                os.unlink(tmp_name)
-            except FileNotFoundError:
-                pass
-        raise
+    # Atomic write discipline lives in shared.atomic_write_json (tempfile +
+    # fsync + os.replace + dir fsync) — the single implementation for all
+    # stores that need crash safety.
+    atomic_write_json(_state_file(user_id), state)
 
 
 def get_private_current_problem(user_id: int) -> dict | None:

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -226,6 +226,34 @@ def append_private_bad_report(user_id: int, report: dict) -> int:
     return append_bad_report_at(_bad_reports_file(user_id), report)
 
 
+def _last_interaction_file(user_id: int) -> Path:
+    return _data_dir() / "private_judge" / "last_interaction" / f"{int(user_id)}.json"
+
+
+def load_private_last_interaction(user_id: int) -> dict | None:
+    """Latest delivered interaction record in this user's private scope.
+
+    A cache (unlike bad_reports): corrupt/missing files log a warning and
+    return None, and /bad falls back to scanning stored history.
+    """
+    path = _last_interaction_file(user_id)
+    if not path.exists():
+        return None
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as e:
+        logger.warning("failed to load last interaction at %s: %s", path, e)
+        return None
+    return data if isinstance(data, dict) and isinstance(data.get("record"), dict) else None
+
+
+def remember_private_last_interaction(user_id: int, record: dict) -> None:
+    """Record the latest delivered interaction (called under the per-user
+    coordinator lock from _save_context_record)."""
+    atomic_write_json(_last_interaction_file(user_id), {"record": dict(record)})
+
+
 def replace_private_problem_history(user_id: int, pid: str, records: list[dict]) -> None:
     state = load_private_state(user_id)
     target = str(pid or "")

--- a/src/kouhai_bot/private_judge.py
+++ b/src/kouhai_bot/private_judge.py
@@ -19,9 +19,11 @@ import cloudscraper
 from .config import get_config
 from .llm import append_model_tag
 from .handlers.shared import (
+    append_bad_report_at,
     get_problem_summary,
     get_today_problem,
     high_difficulty_notice,
+    load_bad_reports_at,
     load_scoreboard,
     multimodal_model_configured,
     save_problem_summary,
@@ -235,6 +237,23 @@ def remove_private_submission(user_id: int, request_id: str) -> None:
         return
     state["user_submissions"] = kept
     save_private_state(user_id, state)
+
+
+def _bad_reports_file(user_id: int) -> Path:
+    return _data_dir() / "private_judge" / "bad_reports" / f"{int(user_id)}.json"
+
+
+def load_private_bad_reports(user_id: int) -> dict:
+    return load_bad_reports_at(_bad_reports_file(user_id))
+
+
+def append_private_bad_report(user_id: int, report: dict) -> int:
+    """Store one /bad report for this user's private-judge scope.
+
+    Deliberately a separate file from users/<uid>.json: the state file shape is
+    compatibility-frozen and /sync never moves /bad reports between scopes.
+    """
+    return append_bad_report_at(_bad_reports_file(user_id), report)
 
 
 def replace_private_problem_history(user_id: int, pid: str, records: list[dict]) -> None:

--- a/tests/test_bad.py
+++ b/tests/test_bad.py
@@ -1,8 +1,10 @@
-"""Tests for /bad — record dissatisfaction with the AI's latest replied interaction.
+"""Tests for /bad — record dissatisfaction with the AI's latest delivered reply.
 
-The report must snapshot the target record verbatim into bad_reports.json
-(group: groups/<gid>/, private: private_judge/bad_reports/<uid>.json), append
-on repeat, and never touch the frozen user_submissions stores.
+Targeting goes through the per-user last-interaction cache (survives problem
+switches and /clear), falling back to a full-history scan for replies older
+than the cache. Reports snapshot the target record verbatim into
+bad_reports.json (group: groups/<gid>/, private: private_judge/bad_reports/)
+and never touch the frozen user_submissions stores.
 """
 
 import sys, os, json, asyncio
@@ -13,12 +15,18 @@ from unittest.mock import patch
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from kouhai_bot.handlers.cmd import bad as bad_cmd
-from kouhai_bot.handlers.shared import append_bad_report, load_bad_reports
+from kouhai_bot.handlers.cmd.submit import PendingRequest, _get_coordinator
+from kouhai_bot.handlers.shared import (
+    append_bad_report,
+    load_bad_reports,
+    load_group_last_interaction,
+    remember_group_last_interaction,
+)
 from kouhai_bot.private_judge import (
     append_private_bad_report,
     load_private_bad_reports,
-    save_private_submission,
-    set_private_current_problem,
+    load_private_last_interaction,
+    remember_private_last_interaction,
 )
 
 GID = 999999
@@ -143,6 +151,20 @@ def _record(ts, *, type_="submit", result="", reply="", reason="", pid=PID,
     return record
 
 
+def _seed_group_cache(tmp_path, record, user_id=UID):
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        remember_group_last_interaction(GID, user_id, record)
+
+
+def _seed_private_cache(tmp_path, record):
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        remember_private_last_interaction(UID, record)
+
+
 def _write_group_state(tmp_path, pid=PID):
     d = tmp_path / "groups" / str(GID)
     d.mkdir(parents=True, exist_ok=True)
@@ -163,12 +185,20 @@ def _group_reports_path(tmp_path):
     return tmp_path / "groups" / str(GID) / "bad_reports.json"
 
 
+def _group_cache_path(tmp_path):
+    return tmp_path / "groups" / str(GID) / "last_interaction.json"
+
+
 def _private_reports_path(tmp_path):
     return tmp_path / "private_judge" / "bad_reports" / f"{UID}.json"
 
 
+def _private_cache_path(tmp_path):
+    return tmp_path / "private_judge" / "last_interaction" / f"{UID}.json"
+
+
 # ═══════════════════════════════════════════════════════════════════════
-# Storage helpers
+# bad_reports storage
 # ═══════════════════════════════════════════════════════════════════════
 
 def test_append_bad_report_assigns_incrementing_ids_and_shape(tmp_path):
@@ -199,6 +229,7 @@ def test_append_private_bad_report_shape_and_state_untouched(tmp_path):
     with ExitStack() as stack:
         for p in _patches(tmp_path):
             stack.enter_context(p)
+        from kouhai_bot.private_judge import save_private_submission
         save_private_submission(UID, {"request_id": "a", "result": "correct", "problem": PID})
         state_before = (tmp_path / "private_judge" / "users" / f"{UID}.json").read_text(encoding="utf-8")
         report_id = append_private_bad_report(UID, {"scope": "private", "note": "判错了"})
@@ -238,18 +269,13 @@ def test_corrupt_bad_reports_raise_and_are_not_overwritten(tmp_path):
     with ExitStack() as stack:
         for p in _patches(tmp_path):
             stack.enter_context(p)
-        try:
-            load_bad_reports(GID)
-            raised = False
-        except ValueError:
-            raised = True
-        assert raised
-        try:
-            append_bad_report(GID, {"scope": "group", "note": ""})
-            append_raised = False
-        except ValueError:
-            append_raised = True
-        assert append_raised
+        for fn in (load_bad_reports, append_bad_report):
+            try:
+                fn(GID) if fn is load_bad_reports else fn(GID, {"scope": "group", "note": ""})
+                raised = False
+            except ValueError:
+                raised = True
+            assert raised
     assert corrupt.read_text(encoding="utf-8") == "{not json"
 
 
@@ -259,14 +285,97 @@ def test_atomic_write_leaves_no_tmp_files(tmp_path):
             stack.enter_context(p)
         append_bad_report(GID, {"scope": "group", "note": ""})
         append_private_bad_report(UID, {"scope": "private", "note": ""})
-    leftovers = list(tmp_path.rglob("*.tmp*")) + [
-        p for p in tmp_path.rglob(".*.tmp*")
-    ]
+    leftovers = list(tmp_path.rglob("*.tmp*"))
     assert not leftovers, leftovers
 
 
 # ═══════════════════════════════════════════════════════════════════════
-# _received_reply / _record_kind
+# last-interaction cache helpers
+# ═══════════════════════════════════════════════════════════════════════
+
+def test_group_last_interaction_is_per_user(tmp_path):
+    record_a = _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="A")
+    record_b = _record("2026-09-11T20:01:03+08:00", type_="submit", result="correct", reply="B")
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        remember_group_last_interaction(GID, 1, record_a)
+        remember_group_last_interaction(GID, 2, record_b)
+        entry_1 = load_group_last_interaction(GID, 1)
+        entry_2 = load_group_last_interaction(GID, 2)
+    assert entry_1["record"]["reply"] == "A"
+    assert entry_2["record"]["reply"] == "B"
+
+
+def test_corrupt_last_interaction_cache_reads_as_missing(tmp_path):
+    _group_cache_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    _group_cache_path(tmp_path).write_text("{not json", encoding="utf-8")
+    _private_cache_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    _private_cache_path(tmp_path).write_text("[1,2]", encoding="utf-8")
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        assert load_group_last_interaction(GID, UID) is None
+        assert load_private_last_interaction(UID) is None
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# _save_context_record hook
+# ═══════════════════════════════════════════════════════════════════════
+
+def _pending_req(*, scope="group", seq=1, command="clarify"):
+    return PendingRequest(
+        kind=command, group_id=GID, user_id=UID,
+        sender={"nickname": "Alice"}, message_id="msg_001", command=command,
+        nickname="Alice", scope=scope, payload="问题", target_pid=PID, seq=seq,
+    )
+
+
+def test_save_context_record_updates_cache_for_replied_results(tmp_path):
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+
+        async def _scenario():
+            coord = _get_coordinator(GID)
+            replied = _record("2026-09-11T20:00:03+08:00", type_="clarify",
+                              result="clarify", reply="J(x) 是…", request_id="local-1")
+            await coord._save_context_record(_pending_req(), replied)
+            pending = _record("2026-09-11T20:00:04+08:00", type_="submit",
+                              result="pending", request_id="local-2")
+            await coord._save_context_record(_pending_req(seq=2, command="submit"), pending)
+            private_rec = _record("2026-09-11T20:00:05+08:00", type_="review",
+                                  result="review", reply="复盘…", request_id="local-3")
+            await coord._save_context_record(_pending_req(scope="private"), private_rec)
+
+        asyncio.run(_scenario())
+        group_cached = load_group_last_interaction(GID, UID)
+        private_cached = load_private_last_interaction(UID)
+    assert group_cached["record"]["request_id"] == "local-1"  # pending write did not replace it
+    assert private_cached["record"]["request_id"] == "local-3"
+
+
+def test_save_context_record_cache_respects_clear_watermark(tmp_path):
+    """A request finalized after /clear must not resurrect a cache entry."""
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+
+        async def _scenario():
+            coord = _get_coordinator(GID)
+            coord.clear_watermarks[("group", GID, UID, PID)] = 5
+            replied = _record("2026-09-11T20:00:03+08:00", type_="clarify",
+                              result="clarify", reply="…", request_id="local-1")
+            return await coord._save_context_record(_pending_req(seq=1), replied)
+
+        ok = asyncio.run(_scenario())
+        cached = load_group_last_interaction(GID, UID)
+    assert ok is False
+    assert cached is None
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# _received_reply classification
 # ═══════════════════════════════════════════════════════════════════════
 
 def test_received_reply_classifies_records():
@@ -298,21 +407,18 @@ def test_received_reply_classifies_records():
 # Handler — group scope
 # ═══════════════════════════════════════════════════════════════════════
 
-def test_bad_group_targets_latest_replied_record(tmp_path):
+def test_bad_group_marks_cached_record_verbatim(tmp_path):
     _reset_captures()
     _write_group_state(tmp_path)
-    records = [
-        _record("2026-09-11T20:00:01+08:00", type_="submit", result="pending",
-                request_id="local-1"),
-        _record("2026-09-11T20:00:02+08:00", type_="submit", result="superseded",
-                request_id="local-2"),
-        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify",
-                reply="J(x) 是特殊因子和…", request_id="local-3", model_tag="deepseek-v4-flash"),
-        _record("2026-09-11T20:00:04+08:00", type_="submit", result="incorrect",
-                reply="", reason="复杂度分析说 O(2^n)", request_id="local-4",
-                model_tag="deepseek-v4-pro", content="我 submission 的内容"),
-    ]
-    _write_scoreboard(tmp_path, records)
+    record = _record(
+        "2026-09-11T20:00:04+08:00", type_="submit", result="incorrect",
+        reply="", reason="复杂度分析说 O(2^n)", request_id="local-4",
+        model_tag="deepseek-v4-pro", content="我 submission 的内容",
+    )
+    _seed_group_cache(tmp_path, record)
+    _write_scoreboard(tmp_path, [
+        _record("2026-09-11T20:00:01+08:00", type_="submit", result="pending", request_id="local-1"),
+    ])
     scoreboard_before = (tmp_path / "groups" / str(GID) / "scoreboard.json").read_text(encoding="utf-8")
 
     with ExitStack() as stack:
@@ -329,17 +435,129 @@ def test_bad_group_targets_latest_replied_record(tmp_path):
     assert report["note"] == "判错了吧"
     assert report["cmd_message_id"] == "msg_001"
     assert report["target"]["problem"] == PID
-    assert report["target"]["record_index"] == 3
-    assert report["target"]["record"] == records[3]  # verbatim snapshot
+    assert report["target"]["record"] == record  # verbatim snapshot
     assert (tmp_path / "groups" / str(GID) / "scoreboard.json").read_text(encoding="utf-8") == scoreboard_before
+
+
+def test_bad_group_crosses_problem_switch(tmp_path):
+    """刷新题后仍可标注上一题的回复。"""
+    _reset_captures()
+    _write_group_state(tmp_path, pid=OTHER_PID)  # problem already refreshed
+    record = _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify",
+                     reply="旧题的回复", pid=PID, request_id="local-1")
+    _seed_group_cache(tmp_path, record)
+
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad 刷题前的回复"))))
+
+    data = json.loads(_group_reports_path(tmp_path).read_text(encoding="utf-8"))
+    assert data["reports"][0]["target"]["problem"] == PID
+    assert data["reports"][0]["target"]["record"]["reply"] == "旧题的回复"
+
+
+def test_bad_group_survives_clear(tmp_path):
+    """/clear 只清 history，不清 last-interaction 缓存。"""
+    _reset_captures()
+    _write_group_state(tmp_path)
+    record = _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify",
+                     reply="clear 前的回复", request_id="local-1")
+    _seed_group_cache(tmp_path, record)
+    # /clear wiped the history: scoreboard has nothing for this user anymore.
+    _write_scoreboard(tmp_path, [])
+
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
+
+    data = json.loads(_group_reports_path(tmp_path).read_text(encoding="utf-8"))
+    assert data["reports"][0]["target"]["record"]["reply"] == "clear 前的回复"
+
+
+def test_bad_group_fallback_scans_history_across_problems(tmp_path):
+    """缓存之前的旧回复（迁移期）：全历史扫描，跨题目取最新已回复。"""
+    _reset_captures()
+    _write_group_state(tmp_path, pid=OTHER_PID)
+    _write_scoreboard(tmp_path, [
+        _record("2026-09-11T19:00:00+08:00", type_="clarify", result="clarify",
+                reply="旧题回复", pid=PID, request_id="local-1"),
+        _record("2026-09-11T20:00:03+08:00", type_="submit", result="correct",
+                reply="新题回复", pid=OTHER_PID, request_id="local-2"),
+        _record("2026-09-11T20:00:04+08:00", type_="submit", result="pending",
+                pid=OTHER_PID, request_id="local-3"),
+    ])
+
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
+
+    data = json.loads(_group_reports_path(tmp_path).read_text(encoding="utf-8"))
+    assert data["reports"][0]["target"]["record"]["request_id"] == "local-2"
+    assert data["reports"][0]["target"]["problem"] == OTHER_PID
+
+
+def test_bad_group_corrupt_cache_falls_back_to_history(tmp_path):
+    _reset_captures()
+    _group_cache_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    _group_cache_path(tmp_path).write_text("{not json", encoding="utf-8")
+    _write_scoreboard(tmp_path, [
+        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify",
+                reply="历史里的回复", request_id="local-1"),
+    ])
+
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
+
+    data = json.loads(_group_reports_path(tmp_path).read_text(encoding="utf-8"))
+    assert data["reports"][0]["target"]["record"]["reply"] == "历史里的回复"
+
+
+def test_bad_group_marks_delivered_failure_notice(tmp_path):
+    """A timeout that delivered '模型服务出故障了' is a markable latest reply."""
+    _reset_captures()
+    _write_group_state(tmp_path)
+    _seed_group_cache(tmp_path, _record(
+        "2026-09-11T20:00:02+08:00", type_="submit", result="timeout", request_id="local-2",
+    ))
+
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad 超时了"))))
+
+    assert _reacted == [("msg_001", "128076")], _reacted
+    data = json.loads(_group_reports_path(tmp_path).read_text(encoding="utf-8"))
+    assert data["reports"][0]["note"] == "超时了"
+    assert data["reports"][0]["target"]["record"]["result"] == "timeout"
+
+
+def test_bad_group_no_target(tmp_path):
+    _reset_captures()
+    # No cache, no replied history (empty and all-never-delivered variants).
+    for records in ([], [
+        _record("2026-09-11T20:00:01+08:00", type_="submit", result="pending", request_id="local-1"),
+        _record("2026-09-11T20:00:02+08:00", type_="submit", result="superseded", request_id="local-2"),
+    ]):
+        _write_scoreboard(tmp_path, records)
+        with ExitStack() as stack:
+            for p in _patches(tmp_path):
+                stack.enter_context(p)
+            asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
+        assert "还没有可以标注的 AI 回复" in _last_group_text(), _sent
+        assert not _group_reports_path(tmp_path).exists()
+        assert not _reacted
 
 
 def test_bad_group_repeat_appends_new_report(tmp_path):
     _reset_captures()
-    _write_group_state(tmp_path)
-    _write_scoreboard(tmp_path, [
-        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="…"),
-    ])
+    _seed_group_cache(tmp_path, _record(
+        "2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="…",
+    ))
     with ExitStack() as stack:
         for p in _patches(tmp_path):
             stack.enter_context(p)
@@ -355,10 +573,9 @@ def test_bad_group_repeat_appends_new_report(tmp_path):
 def test_bad_group_concurrent_reports_get_sequential_ids(tmp_path):
     """Two in-flight /bad must not interleave the read-modify-write of bad_reports.json."""
     _reset_captures()
-    _write_group_state(tmp_path)
-    _write_scoreboard(tmp_path, [
-        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="…"),
-    ])
+    _seed_group_cache(tmp_path, _record(
+        "2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="…",
+    ))
 
     async def _run_two():
         await asyncio.gather(
@@ -377,96 +594,11 @@ def test_bad_group_concurrent_reports_get_sequential_ids(tmp_path):
     assert len(_reacted) == 2
 
 
-def test_bad_group_ignores_other_problem_records(tmp_path):
-    _reset_captures()
-    _write_group_state(tmp_path)
-    records = [
-        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="当前题回复"),
-        _record("2026-09-11T20:30:00+08:00", type_="clarify", result="clarify",
-                reply="别的题更新回复", pid=OTHER_PID),
-    ]
-    _write_scoreboard(tmp_path, records)
-    with ExitStack() as stack:
-        for p in _patches(tmp_path):
-            stack.enter_context(p)
-        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
-    data = json.loads(_group_reports_path(tmp_path).read_text(encoding="utf-8"))
-    assert data["reports"][0]["target"]["record"]["reply"] == "当前题回复"
-    assert data["reports"][0]["target"]["record_index"] == 0
-
-
-def test_bad_group_no_current_problem(tmp_path):
-    _reset_captures()
-    _write_scoreboard(tmp_path, [
-        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="…"),
-    ])
-    with ExitStack() as stack:
-        for p in _patches(tmp_path):
-            stack.enter_context(p)
-        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
-    assert "还没有今日题目哦" in _last_group_text(), _sent
-    assert not _group_reports_path(tmp_path).exists()
-    assert not _reacted
-
-
-def test_bad_group_no_history_for_problem(tmp_path):
-    _reset_captures()
-    _write_group_state(tmp_path, pid=OTHER_PID)
-    _write_scoreboard(tmp_path, [
-        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="…"),
-    ])
-    with ExitStack() as stack:
-        for p in _patches(tmp_path):
-            stack.enter_context(p)
-        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
-    assert "还没有和 AI 的交流记录" in _last_group_text(), _sent
-    assert not _group_reports_path(tmp_path).exists()
-
-
-def test_bad_group_no_replied_records(tmp_path):
-    _reset_captures()
-    _write_group_state(tmp_path)
-    _write_scoreboard(tmp_path, [
-        _record("2026-09-11T20:00:01+08:00", type_="submit", result="pending", request_id="local-1"),
-        _record("2026-09-11T20:00:02+08:00", type_="submit", result="superseded",
-                request_id="local-2"),
-    ])
-    with ExitStack() as stack:
-        for p in _patches(tmp_path):
-            stack.enter_context(p)
-        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
-    assert "还没有收到 AI 回复" in _last_group_text(), _sent
-    assert not _group_reports_path(tmp_path).exists()
-
-
-def test_bad_group_marks_delivered_failure_notice(tmp_path):
-    """A timeout that delivered '模型服务出故障了' is a markable latest reply."""
-    _reset_captures()
-    _write_group_state(tmp_path)
-    _write_scoreboard(tmp_path, [
-        _record("2026-09-11T20:00:01+08:00", type_="clarify", result="clarify",
-                reply="J(x) 是特殊因子和…", request_id="local-1"),
-        _record("2026-09-11T20:00:02+08:00", type_="submit", result="timeout",
-                request_id="local-2"),
-    ])
-    with ExitStack() as stack:
-        for p in _patches(tmp_path):
-            stack.enter_context(p)
-        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad 超时了"))))
-
-    assert _reacted == [("msg_001", "128076")], _reacted
-    data = json.loads(_group_reports_path(tmp_path).read_text(encoding="utf-8"))
-    assert data["reports"][0]["note"] == "超时了"
-    assert data["reports"][0]["target"]["record_index"] == 1
-    assert data["reports"][0]["target"]["record"]["result"] == "timeout"
-
-
 def test_bad_group_corrupt_store_shows_failure(tmp_path):
     _reset_captures()
-    _write_group_state(tmp_path)
-    _write_scoreboard(tmp_path, [
-        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="…"),
-    ])
+    _seed_group_cache(tmp_path, _record(
+        "2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="…",
+    ))
     _group_reports_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
     _group_reports_path(tmp_path).write_text("{not json", encoding="utf-8")
     with ExitStack() as stack:
@@ -482,29 +614,13 @@ def test_bad_group_corrupt_store_shows_failure(tmp_path):
 # Handler — private scope
 # ═══════════════════════════════════════════════════════════════════════
 
-def _setup_private_problem(tmp_path):
-    with ExitStack() as stack:
-        for p in _patches(tmp_path):
-            stack.enter_context(p)
-        set_private_current_problem(UID, {
-            "today": PID, "contestId": 542, "index": "D",
-            "name": "Superhero's Job", "rating": 2600,
-        })
-
-
-def test_bad_private_skips_pending_tail(tmp_path):
+def test_bad_private_marks_cached_record(tmp_path):
     _reset_captures()
-    _setup_private_problem(tmp_path)
-    with ExitStack() as stack:
-        for p in _patches(tmp_path):
-            stack.enter_context(p)
-        save_private_submission(UID, _record(
-            "2026-09-11T20:00:03+08:00", type_="clarify", result="clarify",
-            reply="J(x) 是特殊因子和…", request_id="local-3", model_tag="deepseek-v4-flash",
-        ))
-        save_private_submission(UID, _record(
-            "2026-09-11T20:00:04+08:00", type_="submit", result="pending", request_id="local-4",
-        ))
+    _seed_private_cache(tmp_path, _record(
+        "2026-09-11T20:00:03+08:00", type_="clarify", result="clarify",
+        reply="J(x) 是特殊因子和…", request_id="local-3", model_tag="deepseek-v4-flash",
+    ))
+
     with ExitStack() as stack:
         for p in _patches(tmp_path):
             stack.enter_context(p)
@@ -517,17 +633,16 @@ def test_bad_private_skips_pending_tail(tmp_path):
     assert report["scope"] == "private"
     assert report["group_id"] == GID  # dispatcher rewrites private group_id to current_group
     assert report["note"] == "不对"
-    assert report["target"]["record_index"] == 0
     assert report["target"]["record"]["request_id"] == "local-3"
 
 
-def test_bad_private_no_current_problem(tmp_path):
+def test_bad_private_no_target(tmp_path):
     _reset_captures()
     with ExitStack() as stack:
         for p in _patches(tmp_path):
             stack.enter_context(p)
         asyncio.run(bad_cmd.handle(**_kwargs(_private_event("/bad"))))
-    assert "/setproblem" in _last_private_text(), _private_sent
+    assert "还没有可以标注的 AI 回复" in _last_private_text(), _private_sent
     assert not _private_reports_path(tmp_path).exists()
 
 
@@ -537,11 +652,10 @@ def test_bad_private_no_current_problem(tmp_path):
 
 def test_bad_note_parsing_and_truncation(tmp_path):
     _reset_captures()
-    _write_group_state(tmp_path)
     long_note = "长" * 600
-    _write_scoreboard(tmp_path, [
-        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="…"),
-    ])
+    _seed_group_cache(tmp_path, _record(
+        "2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="…",
+    ))
     with ExitStack() as stack:
         for p in _patches(tmp_path):
             stack.enter_context(p)

--- a/tests/test_bad.py
+++ b/tests/test_bad.py
@@ -217,6 +217,20 @@ def test_load_bad_reports_missing_file_returns_empty(tmp_path):
     assert data == {"version": 1, "reports": []}
 
 
+def test_bad_reports_without_reports_key_are_repaired_by_append(tmp_path):
+    """An operator-created {} file must not permanently brick /bad."""
+    path = tmp_path / "groups" / str(GID) / "bad_reports.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"version": 1}), encoding="utf-8")
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        report_id = append_bad_report(GID, {"scope": "group", "note": "修复形状"})
+        data = load_bad_reports(GID)
+    assert report_id == 1
+    assert [r["note"] for r in data["reports"]] == ["修复形状"]
+
+
 def test_corrupt_bad_reports_raise_and_are_not_overwritten(tmp_path):
     _write_group_state(tmp_path)
     corrupt = tmp_path / "groups" / str(GID) / "bad_reports.json"
@@ -262,19 +276,22 @@ def test_received_reply_classifies_records():
     assert f({"result": "incorrect", "reply": "", "reason": "复杂度错了"})
     assert f({"type": "clarify", "result": "clarify", "reply": "J(x) 是…"})
     assert f({"type": "review", "result": "review", "reply": "复盘…"})
-    # Never-replied outcomes.
+    # Failure notices were delivered to the user, so they are markable.
+    assert f({"type": "submit", "result": "timeout"})
+    assert f({"type": "submit", "result": "service_unavailable"})
+    assert f({"type": "submit", "result": "no_statement"})
+    assert f({"type": "submit", "result": "image_unsupported"})
+    assert f({"type": "clarify", "result": "service_unavailable", "reply": ""})
+    # Never-delivered outcomes.
     assert not f({"type": "submit", "result": "pending"})
     assert not f({"type": "submit", "result": "superseded"})
-    assert not f({"type": "submit", "result": "no_statement"})
-    assert not f({"type": "submit", "result": "service_unavailable"})
-    assert not f({"type": "submit", "result": "timeout"})
-    assert not f({"type": "submit", "result": "image_unsupported"})
-    # Defensive: clarify/review with an empty reply never reached the user.
+    # Defensive: an LLM-answer result with an empty reply never reached the user.
     assert not f({"type": "clarify", "result": "clarify", "reply": ""})
     assert not f({"type": "review", "result": "review", "reply": "   "})
     # Unknown kinds never count.
     assert not f({"type": "clear", "result": "cleared"})
     assert not f({"result": "whatever"})
+    assert not f({"result": "timeout"})  # failure result but not an interaction kind
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -411,7 +428,7 @@ def test_bad_group_no_replied_records(tmp_path):
     _write_group_state(tmp_path)
     _write_scoreboard(tmp_path, [
         _record("2026-09-11T20:00:01+08:00", type_="submit", result="pending", request_id="local-1"),
-        _record("2026-09-11T20:00:02+08:00", type_="submit", result="service_unavailable",
+        _record("2026-09-11T20:00:02+08:00", type_="submit", result="superseded",
                 request_id="local-2"),
     ])
     with ExitStack() as stack:
@@ -420,6 +437,28 @@ def test_bad_group_no_replied_records(tmp_path):
         asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
     assert "还没有收到 AI 回复" in _last_group_text(), _sent
     assert not _group_reports_path(tmp_path).exists()
+
+
+def test_bad_group_marks_delivered_failure_notice(tmp_path):
+    """A timeout that delivered '模型服务出故障了' is a markable latest reply."""
+    _reset_captures()
+    _write_group_state(tmp_path)
+    _write_scoreboard(tmp_path, [
+        _record("2026-09-11T20:00:01+08:00", type_="clarify", result="clarify",
+                reply="J(x) 是特殊因子和…", request_id="local-1"),
+        _record("2026-09-11T20:00:02+08:00", type_="submit", result="timeout",
+                request_id="local-2"),
+    ])
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad 超时了"))))
+
+    assert _reacted == [("msg_001", "128076")], _reacted
+    data = json.loads(_group_reports_path(tmp_path).read_text(encoding="utf-8"))
+    assert data["reports"][0]["note"] == "超时了"
+    assert data["reports"][0]["target"]["record_index"] == 1
+    assert data["reports"][0]["target"]["record"]["result"] == "timeout"
 
 
 def test_bad_group_corrupt_store_shows_failure(tmp_path):

--- a/tests/test_bad.py
+++ b/tests/test_bad.py
@@ -1,0 +1,504 @@
+"""Tests for /bad — record dissatisfaction with the AI's latest replied interaction.
+
+The report must snapshot the target record verbatim into bad_reports.json
+(group: groups/<gid>/, private: private_judge/bad_reports/<uid>.json), append
+on repeat, and never touch the frozen user_submissions stores.
+"""
+
+import sys, os, json, asyncio
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from kouhai_bot.handlers.cmd import bad as bad_cmd
+from kouhai_bot.handlers.shared import append_bad_report, load_bad_reports
+from kouhai_bot.private_judge import (
+    append_private_bad_report,
+    load_private_bad_reports,
+    save_private_submission,
+    set_private_current_problem,
+)
+
+GID = 999999
+UID = 42
+PID = "542D"
+OTHER_PID = "100A"
+
+_sent: list[dict] = []
+_reacted: list[tuple] = []
+_private_sent: list[dict] = []
+
+
+async def _mock_send_group(group_id, message):
+    _sent.append({"group_id": group_id, "message": message})
+    return True
+
+
+async def _mock_react(message_id, emoji_id):
+    _reacted.append((message_id, emoji_id))
+
+
+async def _mock_send_private(user_id, message):
+    _private_sent.append({"user_id": user_id, "message": message})
+    return 1000 + len(_private_sent)
+
+
+def _reset_captures():
+    _sent.clear()
+    _reacted.clear()
+    _private_sent.clear()
+
+
+def _patches(tmp_path):
+    """Patch config paths + the send/react bindings bad.py resolves at import."""
+    cfg = SimpleNamespace(data_dir=str(tmp_path))
+    return [
+        patch("kouhai_bot.handlers.shared.get_config", return_value=cfg),
+        patch("kouhai_bot.private_judge.get_config", return_value=cfg),
+        patch.object(bad_cmd, "send_group_msg", _mock_send_group),
+        patch.object(bad_cmd, "send_private_msg", _mock_send_private),
+        patch.object(bad_cmd, "react_emoji", _mock_react),
+    ]
+
+
+def _group_event(text="/bad", message_id="msg_001"):
+    return {
+        "type": "message",
+        "message_type": "group",
+        "group_id": GID,
+        "user_id": UID,
+        "sender": {"nickname": "Alice", "card": ""},
+        "message_id": message_id,
+        "raw_message": text,
+        "message": [{"type": "text", "data": {"text": text}}],
+    }
+
+
+def _private_event(text="/bad", message_id="priv_001"):
+    return {
+        "type": "message",
+        "message_type": "private",
+        "group_id": GID,
+        "user_id": UID,
+        "sender": {"nickname": "Alice", "card": ""},
+        "message_id": message_id,
+        "raw_message": text,
+        "message": [{"type": "text", "data": {"text": text}}],
+    }
+
+
+def _kwargs(event):
+    return {
+        "group_id": event["group_id"],
+        "user_id": event["user_id"],
+        "sender": event["sender"],
+        "message_id": event["message_id"],
+        "raw_text": event["raw_message"],
+        "segments": event["message"],
+        "event": event,
+    }
+
+
+def _last_group_text() -> str:
+    if not _sent:
+        return ""
+    msg = _sent[-1]["message"]
+    if isinstance(msg, list):
+        return " ".join(
+            seg.get("data", {}).get("text", "")
+            for seg in msg if isinstance(seg, dict) and seg.get("type") == "text"
+        )
+    return str(msg)
+
+
+def _last_private_text() -> str:
+    if not _private_sent:
+        return ""
+    msg = _private_sent[-1]["message"]
+    if isinstance(msg, list):
+        return " ".join(
+            seg.get("data", {}).get("text", "")
+            for seg in msg if isinstance(seg, dict) and seg.get("type") == "text"
+        )
+    return str(msg)
+
+
+def _record(ts, *, type_="submit", result="", reply="", reason="", pid=PID,
+            request_id="", model_tag="", content="用户内容"):
+    record = {
+        "timestamp": ts,
+        "type": type_,
+        "content": content,
+        "result": result,
+        "reason": reason,
+        "reply": reply,
+        "problem": pid,
+    }
+    if request_id:
+        record["request_id"] = request_id
+    if model_tag:
+        record["model_tag"] = model_tag
+    return record
+
+
+def _write_group_state(tmp_path, pid=PID):
+    d = tmp_path / "groups" / str(GID)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "state.json").write_text(json.dumps({"today": pid}), encoding="utf-8")
+
+
+def _write_scoreboard(tmp_path, records, user_id=UID):
+    d = tmp_path / "groups" / str(GID)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "scoreboard.json").write_text(
+        json.dumps({"solves": [], "user_submissions": {str(user_id): records}},
+                   ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _group_reports_path(tmp_path):
+    return tmp_path / "groups" / str(GID) / "bad_reports.json"
+
+
+def _private_reports_path(tmp_path):
+    return tmp_path / "private_judge" / "bad_reports" / f"{UID}.json"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Storage helpers
+# ═══════════════════════════════════════════════════════════════════════
+
+def test_append_bad_report_assigns_incrementing_ids_and_shape(tmp_path):
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        first = append_bad_report(GID, {"scope": "group", "note": ""})
+        second = append_bad_report(GID, {"scope": "group", "note": "第二条"})
+    assert (first, second) == (1, 2)
+    data = json.loads(_group_reports_path(tmp_path).read_text(encoding="utf-8"))
+    assert data["version"] == 1
+    assert [r["id"] for r in data["reports"]] == [1, 2]
+    assert data["reports"][1]["note"] == "第二条"
+
+
+def test_append_bad_report_does_not_touch_scoreboard(tmp_path):
+    _write_scoreboard(tmp_path, [_record("2026-09-11T20:00:00+08:00", result="correct")])
+    before = (tmp_path / "groups" / str(GID) / "scoreboard.json").read_text(encoding="utf-8")
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        append_bad_report(GID, {"scope": "group", "note": ""})
+    after = (tmp_path / "groups" / str(GID) / "scoreboard.json").read_text(encoding="utf-8")
+    assert before == after
+
+
+def test_append_private_bad_report_shape_and_state_untouched(tmp_path):
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        save_private_submission(UID, {"request_id": "a", "result": "correct", "problem": PID})
+        state_before = (tmp_path / "private_judge" / "users" / f"{UID}.json").read_text(encoding="utf-8")
+        report_id = append_private_bad_report(UID, {"scope": "private", "note": "判错了"})
+        loaded = load_private_bad_reports(UID)
+    assert report_id == 1
+    assert loaded["reports"][0]["note"] == "判错了"
+    state_after = (tmp_path / "private_judge" / "users" / f"{UID}.json").read_text(encoding="utf-8")
+    assert state_after == state_before
+
+
+def test_load_bad_reports_missing_file_returns_empty(tmp_path):
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        data = load_bad_reports(GID)
+    assert data == {"version": 1, "reports": []}
+
+
+def test_corrupt_bad_reports_raise_and_are_not_overwritten(tmp_path):
+    _write_group_state(tmp_path)
+    corrupt = tmp_path / "groups" / str(GID) / "bad_reports.json"
+    corrupt.write_text("{not json", encoding="utf-8")
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        try:
+            load_bad_reports(GID)
+            raised = False
+        except ValueError:
+            raised = True
+        assert raised
+        try:
+            append_bad_report(GID, {"scope": "group", "note": ""})
+            append_raised = False
+        except ValueError:
+            append_raised = True
+        assert append_raised
+    assert corrupt.read_text(encoding="utf-8") == "{not json"
+
+
+def test_atomic_write_leaves_no_tmp_files(tmp_path):
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        append_bad_report(GID, {"scope": "group", "note": ""})
+        append_private_bad_report(UID, {"scope": "private", "note": ""})
+    leftovers = list(tmp_path.rglob("*.tmp*")) + [
+        p for p in tmp_path.rglob(".*.tmp*")
+    ]
+    assert not leftovers, leftovers
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# _received_reply / _record_kind
+# ═══════════════════════════════════════════════════════════════════════
+
+def test_received_reply_classifies_records():
+    f = bad_cmd._received_reply
+    # Legacy record without "type" still counts via the result fallback.
+    assert f({"result": "correct", "reply": ""})
+    assert f({"result": "incorrect", "reply": "", "reason": "复杂度错了"})
+    assert f({"type": "clarify", "result": "clarify", "reply": "J(x) 是…"})
+    assert f({"type": "review", "result": "review", "reply": "复盘…"})
+    # Never-replied outcomes.
+    assert not f({"type": "submit", "result": "pending"})
+    assert not f({"type": "submit", "result": "superseded"})
+    assert not f({"type": "submit", "result": "no_statement"})
+    assert not f({"type": "submit", "result": "service_unavailable"})
+    assert not f({"type": "submit", "result": "timeout"})
+    assert not f({"type": "submit", "result": "image_unsupported"})
+    # Defensive: clarify/review with an empty reply never reached the user.
+    assert not f({"type": "clarify", "result": "clarify", "reply": ""})
+    assert not f({"type": "review", "result": "review", "reply": "   "})
+    # Unknown kinds never count.
+    assert not f({"type": "clear", "result": "cleared"})
+    assert not f({"result": "whatever"})
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Handler — group scope
+# ═══════════════════════════════════════════════════════════════════════
+
+def test_bad_group_targets_latest_replied_record(tmp_path):
+    _reset_captures()
+    _write_group_state(tmp_path)
+    records = [
+        _record("2026-09-11T20:00:01+08:00", type_="submit", result="pending",
+                request_id="local-1"),
+        _record("2026-09-11T20:00:02+08:00", type_="submit", result="superseded",
+                request_id="local-2"),
+        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify",
+                reply="J(x) 是特殊因子和…", request_id="local-3", model_tag="deepseek-v4-flash"),
+        _record("2026-09-11T20:00:04+08:00", type_="submit", result="incorrect",
+                reply="", reason="复杂度分析说 O(2^n)", request_id="local-4",
+                model_tag="deepseek-v4-pro", content="我 submission 的内容"),
+    ]
+    _write_scoreboard(tmp_path, records)
+    scoreboard_before = (tmp_path / "groups" / str(GID) / "scoreboard.json").read_text(encoding="utf-8")
+
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad 判错了吧"))))
+
+    assert _reacted == [("msg_001", "128076")], _reacted
+    assert not _sent, _sent  # success ack in group is react-only
+    data = json.loads(_group_reports_path(tmp_path).read_text(encoding="utf-8"))
+    assert len(data["reports"]) == 1
+    report = data["reports"][0]
+    assert report["scope"] == "group"
+    assert report["note"] == "判错了吧"
+    assert report["cmd_message_id"] == "msg_001"
+    assert report["target"]["problem"] == PID
+    assert report["target"]["record_index"] == 3
+    assert report["target"]["record"] == records[3]  # verbatim snapshot
+    assert (tmp_path / "groups" / str(GID) / "scoreboard.json").read_text(encoding="utf-8") == scoreboard_before
+
+
+def test_bad_group_repeat_appends_new_report(tmp_path):
+    _reset_captures()
+    _write_group_state(tmp_path)
+    _write_scoreboard(tmp_path, [
+        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="…"),
+    ])
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad 补充：说错了", message_id="msg_002"))))
+    data = json.loads(_group_reports_path(tmp_path).read_text(encoding="utf-8"))
+    assert [r["id"] for r in data["reports"]] == [1, 2]
+    assert data["reports"][0]["note"] == ""
+    assert data["reports"][1]["note"] == "补充：说错了"
+    assert data["reports"][1]["cmd_message_id"] == "msg_002"
+
+
+def test_bad_group_ignores_other_problem_records(tmp_path):
+    _reset_captures()
+    _write_group_state(tmp_path)
+    records = [
+        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="当前题回复"),
+        _record("2026-09-11T20:30:00+08:00", type_="clarify", result="clarify",
+                reply="别的题更新回复", pid=OTHER_PID),
+    ]
+    _write_scoreboard(tmp_path, records)
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
+    data = json.loads(_group_reports_path(tmp_path).read_text(encoding="utf-8"))
+    assert data["reports"][0]["target"]["record"]["reply"] == "当前题回复"
+    assert data["reports"][0]["target"]["record_index"] == 0
+
+
+def test_bad_group_no_current_problem(tmp_path):
+    _reset_captures()
+    _write_scoreboard(tmp_path, [
+        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="…"),
+    ])
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
+    assert "还没有今日题目哦" in _last_group_text(), _sent
+    assert not _group_reports_path(tmp_path).exists()
+    assert not _reacted
+
+
+def test_bad_group_no_history_for_problem(tmp_path):
+    _reset_captures()
+    _write_group_state(tmp_path, pid=OTHER_PID)
+    _write_scoreboard(tmp_path, [
+        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="…"),
+    ])
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
+    assert "还没有和 AI 的交流记录" in _last_group_text(), _sent
+    assert not _group_reports_path(tmp_path).exists()
+
+
+def test_bad_group_no_replied_records(tmp_path):
+    _reset_captures()
+    _write_group_state(tmp_path)
+    _write_scoreboard(tmp_path, [
+        _record("2026-09-11T20:00:01+08:00", type_="submit", result="pending", request_id="local-1"),
+        _record("2026-09-11T20:00:02+08:00", type_="submit", result="service_unavailable",
+                request_id="local-2"),
+    ])
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
+    assert "还没有收到 AI 回复" in _last_group_text(), _sent
+    assert not _group_reports_path(tmp_path).exists()
+
+
+def test_bad_group_corrupt_store_shows_failure(tmp_path):
+    _reset_captures()
+    _write_group_state(tmp_path)
+    _write_scoreboard(tmp_path, [
+        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="…"),
+    ])
+    _group_reports_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    _group_reports_path(tmp_path).write_text("{not json", encoding="utf-8")
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
+    assert "记录反馈失败了" in _last_group_text(), _sent
+    assert not _reacted
+    assert _group_reports_path(tmp_path).read_text(encoding="utf-8") == "{not json"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Handler — private scope
+# ═══════════════════════════════════════════════════════════════════════
+
+def _setup_private_problem(tmp_path):
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        set_private_current_problem(UID, {
+            "today": PID, "contestId": 542, "index": "D",
+            "name": "Superhero's Job", "rating": 2600,
+        })
+
+
+def test_bad_private_skips_pending_tail(tmp_path):
+    _reset_captures()
+    _setup_private_problem(tmp_path)
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        save_private_submission(UID, _record(
+            "2026-09-11T20:00:03+08:00", type_="clarify", result="clarify",
+            reply="J(x) 是特殊因子和…", request_id="local-3", model_tag="deepseek-v4-flash",
+        ))
+        save_private_submission(UID, _record(
+            "2026-09-11T20:00:04+08:00", type_="submit", result="pending", request_id="local-4",
+        ))
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_private_event("/bad 不对"))))
+
+    assert "收到～" in _last_private_text(), _private_sent  # clear-style private reaction fallback
+    data = json.loads(_private_reports_path(tmp_path).read_text(encoding="utf-8"))
+    assert len(data["reports"]) == 1
+    report = data["reports"][0]
+    assert report["scope"] == "private"
+    assert report["group_id"] == GID  # dispatcher rewrites private group_id to current_group
+    assert report["note"] == "不对"
+    assert report["target"]["record_index"] == 0
+    assert report["target"]["record"]["request_id"] == "local-3"
+
+
+def test_bad_private_no_current_problem(tmp_path):
+    _reset_captures()
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_private_event("/bad"))))
+    assert "/setproblem" in _last_private_text(), _private_sent
+    assert not _private_reports_path(tmp_path).exists()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Note parsing
+# ═══════════════════════════════════════════════════════════════════════
+
+def test_bad_note_parsing_and_truncation(tmp_path):
+    _reset_captures()
+    _write_group_state(tmp_path)
+    long_note = "长" * 600
+    _write_scoreboard(tmp_path, [
+        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="…"),
+    ])
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad   多余空白  ", message_id="msg_002"))))
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event(f"/bad {long_note}", message_id="msg_003"))))
+    data = json.loads(_group_reports_path(tmp_path).read_text(encoding="utf-8"))
+    notes = [r["note"] for r in data["reports"]]
+    assert notes[0] == ""
+    assert notes[1] == "多余空白"
+    assert notes[2] == "长" * 500
+
+
+def test_bad_usage_error_both_scopes(tmp_path):
+    _reset_captures()
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/BAD 大写"))))
+        asyncio.run(bad_cmd.handle(**_kwargs(_private_event("/bad!"))))
+    assert "用法：/bad" in _last_group_text(), _sent
+    assert not _group_reports_path(tmp_path).exists()
+    assert "用法：/bad" in _last_private_text(), _private_sent
+    assert not _private_reports_path(tmp_path).exists()

--- a/tests/test_bad.py
+++ b/tests/test_bad.py
@@ -375,35 +375,6 @@ def test_save_context_record_cache_respects_clear_watermark(tmp_path):
 
 
 # ═══════════════════════════════════════════════════════════════════════
-# _received_reply classification
-# ═══════════════════════════════════════════════════════════════════════
-
-def test_received_reply_classifies_records():
-    f = bad_cmd._received_reply
-    # Legacy record without "type" still counts via the result fallback.
-    assert f({"result": "correct", "reply": ""})
-    assert f({"result": "incorrect", "reply": "", "reason": "复杂度错了"})
-    assert f({"type": "clarify", "result": "clarify", "reply": "J(x) 是…"})
-    assert f({"type": "review", "result": "review", "reply": "复盘…"})
-    # Failure notices were delivered to the user, so they are markable.
-    assert f({"type": "submit", "result": "timeout"})
-    assert f({"type": "submit", "result": "service_unavailable"})
-    assert f({"type": "submit", "result": "no_statement"})
-    assert f({"type": "submit", "result": "image_unsupported"})
-    assert f({"type": "clarify", "result": "service_unavailable", "reply": ""})
-    # Never-delivered outcomes.
-    assert not f({"type": "submit", "result": "pending"})
-    assert not f({"type": "submit", "result": "superseded"})
-    # Defensive: an LLM-answer result with an empty reply never reached the user.
-    assert not f({"type": "clarify", "result": "clarify", "reply": ""})
-    assert not f({"type": "review", "result": "review", "reply": "   "})
-    # Unknown kinds never count.
-    assert not f({"type": "clear", "result": "cleared"})
-    assert not f({"result": "whatever"})
-    assert not f({"result": "timeout"})  # failure result but not an interaction kind
-
-
-# ═══════════════════════════════════════════════════════════════════════
 # Handler — group scope
 # ═══════════════════════════════════════════════════════════════════════
 
@@ -476,47 +447,6 @@ def test_bad_group_survives_clear(tmp_path):
     assert data["reports"][0]["target"]["record"]["reply"] == "clear 前的回复"
 
 
-def test_bad_group_fallback_scans_history_across_problems(tmp_path):
-    """缓存之前的旧回复（迁移期）：全历史扫描，跨题目取最新已回复。"""
-    _reset_captures()
-    _write_group_state(tmp_path, pid=OTHER_PID)
-    _write_scoreboard(tmp_path, [
-        _record("2026-09-11T19:00:00+08:00", type_="clarify", result="clarify",
-                reply="旧题回复", pid=PID, request_id="local-1"),
-        _record("2026-09-11T20:00:03+08:00", type_="submit", result="correct",
-                reply="新题回复", pid=OTHER_PID, request_id="local-2"),
-        _record("2026-09-11T20:00:04+08:00", type_="submit", result="pending",
-                pid=OTHER_PID, request_id="local-3"),
-    ])
-
-    with ExitStack() as stack:
-        for p in _patches(tmp_path):
-            stack.enter_context(p)
-        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
-
-    data = json.loads(_group_reports_path(tmp_path).read_text(encoding="utf-8"))
-    assert data["reports"][0]["target"]["record"]["request_id"] == "local-2"
-    assert data["reports"][0]["target"]["problem"] == OTHER_PID
-
-
-def test_bad_group_corrupt_cache_falls_back_to_history(tmp_path):
-    _reset_captures()
-    _group_cache_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
-    _group_cache_path(tmp_path).write_text("{not json", encoding="utf-8")
-    _write_scoreboard(tmp_path, [
-        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify",
-                reply="历史里的回复", request_id="local-1"),
-    ])
-
-    with ExitStack() as stack:
-        for p in _patches(tmp_path):
-            stack.enter_context(p)
-        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
-
-    data = json.loads(_group_reports_path(tmp_path).read_text(encoding="utf-8"))
-    assert data["reports"][0]["target"]["record"]["reply"] == "历史里的回复"
-
-
 def test_bad_group_marks_delivered_failure_notice(tmp_path):
     """A timeout that delivered '模型服务出故障了' is a markable latest reply."""
     _reset_captures()
@@ -536,21 +466,26 @@ def test_bad_group_marks_delivered_failure_notice(tmp_path):
     assert data["reports"][0]["target"]["record"]["result"] == "timeout"
 
 
-def test_bad_group_no_target(tmp_path):
+def test_bad_group_no_target_without_cache(tmp_path):
+    """Cache-only targeting: stored history alone (e.g. replies that predate
+    the cache) is deliberately NOT consulted — no cache entry, nothing to mark."""
     _reset_captures()
-    # No cache, no replied history (empty and all-never-delivered variants).
-    for records in ([], [
+    _write_group_state(tmp_path)
+    _write_scoreboard(tmp_path, [
         _record("2026-09-11T20:00:01+08:00", type_="submit", result="pending", request_id="local-1"),
         _record("2026-09-11T20:00:02+08:00", type_="submit", result="superseded", request_id="local-2"),
-    ]):
-        _write_scoreboard(tmp_path, records)
-        with ExitStack() as stack:
-            for p in _patches(tmp_path):
-                stack.enter_context(p)
-            asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
-        assert "还没有可以标注的 AI 回复" in _last_group_text(), _sent
-        assert not _group_reports_path(tmp_path).exists()
-        assert not _reacted
+        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify",
+                reply="历史里的回复", request_id="local-3"),
+    ])
+
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(bad_cmd.handle(**_kwargs(_group_event("/bad"))))
+
+    assert "还没有可以标注的 AI 回复" in _last_group_text(), _sent
+    assert not _group_reports_path(tmp_path).exists()
+    assert not _reacted
 
 
 def test_bad_group_repeat_appends_new_report(tmp_path):

--- a/tests/test_bad.py
+++ b/tests/test_bad.py
@@ -335,6 +335,31 @@ def test_bad_group_repeat_appends_new_report(tmp_path):
     assert data["reports"][1]["cmd_message_id"] == "msg_002"
 
 
+def test_bad_group_concurrent_reports_get_sequential_ids(tmp_path):
+    """Two in-flight /bad must not interleave the read-modify-write of bad_reports.json."""
+    _reset_captures()
+    _write_group_state(tmp_path)
+    _write_scoreboard(tmp_path, [
+        _record("2026-09-11T20:00:03+08:00", type_="clarify", result="clarify", reply="…"),
+    ])
+
+    async def _run_two():
+        await asyncio.gather(
+            bad_cmd.handle(**_kwargs(_group_event("/bad 第一条"))),
+            bad_cmd.handle(**_kwargs(_group_event("/bad 第二条", message_id="msg_002"))),
+        )
+
+    with ExitStack() as stack:
+        for p in _patches(tmp_path):
+            stack.enter_context(p)
+        asyncio.run(_run_two())
+
+    data = json.loads(_group_reports_path(tmp_path).read_text(encoding="utf-8"))
+    assert sorted(r["id"] for r in data["reports"]) == [1, 2]
+    assert {r["note"] for r in data["reports"]} == {"第一条", "第二条"}
+    assert len(_reacted) == 2
+
+
 def test_bad_group_ignores_other_problem_records(tmp_path):
     _reset_captures()
     _write_group_state(tmp_path)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3128,6 +3128,43 @@ def test_private_bad_dispatches_and_records_report():
     print("✅ private /bad: allowlist dispatch and report persistence")
 
 
+def test_group_bad_dispatches_and_normalizes_command_case():
+    _reset_state()
+    _setup_problem()
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {str(UID): [
+        {
+            "timestamp": "2026-09-11T20:00:03+08:00",
+            "type": "clarify",
+            "content": "J(x) 是什么",
+            "result": "clarify",
+            "reason": "",
+            "reply": "J(x) 是特殊因子和…",
+            "problem": PID,
+            "request_id": "local-1",
+        },
+    ]}})
+
+    with _all_patches():
+        from kouhai_bot.handlers import process_event
+        from kouhai_bot.handlers.registry import discover_commands
+        from kouhai_bot.handlers.shared import load_bad_reports
+
+        discover_commands()
+        # The dispatcher canonicalizes the command token, so /BAD reaches the
+        # handler as /bad with the note intact.
+        asyncio.run(process_event(_make_event("/BAD 判错了"), spawn_handlers=False))
+
+        assert _reacted == [("msg_001", "128076")], _reacted
+        reports = load_bad_reports(GID)["reports"]
+        assert len(reports) == 1, reports
+        assert reports[0]["scope"] == "group"
+        assert reports[0]["note"] == "判错了"
+        assert reports[0]["target"]["problem"] == PID
+        assert reports[0]["target"]["record"]["request_id"] == "local-1"
+    _cleanup()
+    print("✅ group /bad: dispatch case normalization and report persistence")
+
+
 def test_private_testcd_shows_remaining_for_starred_user():
     _reset_state()
     _setup_problem_for(GID, PID)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3091,16 +3091,11 @@ def test_private_bad_dispatches_and_records_report():
         from kouhai_bot.handlers.registry import discover_commands
         from kouhai_bot.private_judge import (
             load_private_bad_reports,
-            save_private_submission,
-            set_private_current_problem,
+            remember_private_last_interaction,
         )
 
         discover_commands()
-        set_private_current_problem(UID, {
-            "today": PID, "contestId": 542, "index": "D",
-            "name": "Superhero's Job", "rating": 2600,
-        })
-        save_private_submission(UID, {
+        remember_private_last_interaction(UID, {
             "timestamp": "2026-09-11T20:00:03+08:00",
             "type": "clarify",
             "content": "J(x) 是什么",
@@ -3131,8 +3126,17 @@ def test_private_bad_dispatches_and_records_report():
 def test_group_bad_dispatches_and_normalizes_command_case():
     _reset_state()
     _setup_problem()
-    _write_scoreboard(GID, {"solves": [], "user_submissions": {str(UID): [
-        {
+
+    with _all_patches():
+        from kouhai_bot.handlers import process_event
+        from kouhai_bot.handlers.registry import discover_commands
+        from kouhai_bot.handlers.shared import (
+            load_bad_reports,
+            remember_group_last_interaction,
+        )
+
+        discover_commands()
+        remember_group_last_interaction(GID, UID, {
             "timestamp": "2026-09-11T20:00:03+08:00",
             "type": "clarify",
             "content": "J(x) 是什么",
@@ -3141,15 +3145,7 @@ def test_group_bad_dispatches_and_normalizes_command_case():
             "reply": "J(x) 是特殊因子和…",
             "problem": PID,
             "request_id": "local-1",
-        },
-    ]}})
-
-    with _all_patches():
-        from kouhai_bot.handlers import process_event
-        from kouhai_bot.handlers.registry import discover_commands
-        from kouhai_bot.handlers.shared import load_bad_reports
-
-        discover_commands()
+        })
         # The dispatcher canonicalizes the command token, so /BAD reaches the
         # handler as /bad with the note intact.
         asyncio.run(process_event(_make_event("/BAD 判错了"), spawn_handlers=False))
@@ -5449,6 +5445,56 @@ def test_sync_private_correct_current_problem_scores_for_normal_user():
     assert ("msg_001", "128076") in _reacted, _reacted
     _cleanup()
     print("✅ sync: private AC scores current group problem for normal user")
+
+
+def test_sync_carries_last_interaction_cache_to_target_side():
+    _reset_state()
+    _setup_problem_for(GID, PID)
+    _write_scoreboard(GID, {"solves": [], "user_submissions": {}})
+    private_record = {
+        "timestamp": "2026-05-14T12:00:00+08:00",
+        "type": "clarify",
+        "content": "J(x) 是什么",
+        "result": "clarify",
+        "reason": "",
+        "reply": "J(x) 是特殊因子和…",
+        "problem": PID,
+        "request_id": "local-1",
+    }
+
+    with _all_patches():
+        from kouhai_bot.handlers.cmd.sync import handle
+        from kouhai_bot.handlers.shared import load_group_last_interaction
+        from kouhai_bot.private_judge import (
+            remember_private_last_interaction,
+            save_private_submission,
+        )
+
+        save_private_submission(UID, private_record)
+        # What the _save_context_record hook would have cached on the private side.
+        remember_private_last_interaction(UID, private_record)
+        asyncio.run(handle(**_kwargs(_make_event("/sync"))))
+        entry = load_group_last_interaction(GID, UID)
+        assert entry is not None
+        assert entry["record"]["request_id"] == "local-1"
+
+        # A private cache pointing at another problem is NOT carried: that
+        # record is not part of what this sync copies.
+        remember_private_last_interaction(UID, {
+            "timestamp": "2026-05-14T13:00:00+08:00",
+            "type": "clarify",
+            "content": "别的题",
+            "result": "clarify",
+            "reason": "",
+            "reply": "别的题的回复",
+            "problem": "100A",
+            "request_id": "local-2",
+        })
+        asyncio.run(handle(**_kwargs(_make_event("/sync"))))
+        entry = load_group_last_interaction(GID, UID)
+        assert entry["record"]["request_id"] == "local-1"
+    _cleanup()
+    print("✅ sync: carries last-interaction cache to the target side")
 
 
 def test_starred_sync_within_cd_only_syncs_clarify_and_rejects_empty_source():

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -598,6 +598,9 @@ def _all_patches():
     stack.enter_context(patch("kouhai_bot.handlers.cmd.sync.react_emoji", _mock_react))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.testcd.send_group_msg", _mock_send_group))
     stack.enter_context(patch("kouhai_bot.handlers.cmd.testcd.send_private_msg", _mock_send_private))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.bad.send_group_msg", _mock_send_group))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.bad.send_private_msg", _mock_send_private))
+    stack.enter_context(patch("kouhai_bot.handlers.cmd.bad.react_emoji", _mock_react))
     stack.enter_context(patch("kouhai_bot.editorial_followup.send_private_msg", _mock_send_private))
     stack.enter_context(patch("kouhai_bot.editorial_followup.send_group_forward_msg", _mock_send_group_forward))
     stack.enter_context(patch("kouhai_bot.private_judge.send_group_msg", _mock_send_group))
@@ -3025,6 +3028,7 @@ def test_help_shows_short_aliases_and_configured_newproblem_cooldown():
     assert "/tag — 查看当前题目的算法标签" in text, text
     assert "/review(/rv) 你的问题 — 默认复盘上一道已通过题；引用题目卡片可复盘旧题；@群友可带入其上下文" in text, text
     assert "/clarify(/clrf) 你的问题 — 向AI澄清题目细节，只回答题目本身不剧透做法" in text, text
+    assert "/bad [简短备注] — 标记对AI最新回复不满意，记录反馈供维护复盘" in text, text
     assert "/setproblem(/sp)" not in text, text
     assert "/sync —" not in text, text
     assert "/testcd —" not in text, text
@@ -3051,6 +3055,7 @@ def test_private_help_only_shows_private_judge_commands():
         for seg in msg if isinstance(seg, dict) and seg.get("type") == "text"
     )
     assert "/setproblem(/sp) [题号|链接|random|难度范围] — 设置 private judge 当前题" in text, text
+    assert "/bad [简短备注] — 标记对AI最新回复不满意，记录反馈供维护复盘" in text, text
     assert "/sync — 在群聊和 private judge 间同步当前群题记录" in text, text
     assert "/testcd — 查看当前群题提交 CD" in text, text
     assert "/newproblem(/np)" not in text, text
@@ -3075,6 +3080,52 @@ def test_private_testcd_allows_submit_when_no_cooldown_and_dispatches():
     assert "你现在可以提交当前群内的题目！" in private_text, private_text
     _cleanup()
     print("✅ private testcd: no cooldown allows submit")
+
+
+def test_private_bad_dispatches_and_records_report():
+    _reset_state()
+    _setup_problem()
+
+    with _all_patches():
+        from kouhai_bot.handlers import process_event
+        from kouhai_bot.handlers.registry import discover_commands
+        from kouhai_bot.private_judge import (
+            load_private_bad_reports,
+            save_private_submission,
+            set_private_current_problem,
+        )
+
+        discover_commands()
+        set_private_current_problem(UID, {
+            "today": PID, "contestId": 542, "index": "D",
+            "name": "Superhero's Job", "rating": 2600,
+        })
+        save_private_submission(UID, {
+            "timestamp": "2026-09-11T20:00:03+08:00",
+            "type": "clarify",
+            "content": "J(x) 是什么",
+            "result": "clarify",
+            "reason": "",
+            "reply": "J(x) 是特殊因子和…",
+            "problem": PID,
+            "request_id": "local-1",
+            "model_tag": "deepseek-v4-flash",
+        })
+        asyncio.run(process_event(_make_private_event("/bad 判错了"), spawn_handlers=False))
+
+        private_text = "\n".join(
+            _last_text_item(item) for item in _private_sent if item["user_id"] == UID
+        )
+        assert "收到～" in private_text, private_text
+        reports = load_private_bad_reports(UID)["reports"]
+        assert len(reports) == 1, reports
+        assert reports[0]["scope"] == "private"
+        assert reports[0]["note"] == "判错了"
+        assert reports[0]["target"]["problem"] == PID
+        assert reports[0]["target"]["record"]["request_id"] == "local-1"
+        assert reports[0]["target"]["record"]["reply"] == "J(x) 是特殊因子和…"
+    _cleanup()
+    print("✅ private /bad: allowlist dispatch and report persistence")
 
 
 def test_private_testcd_shows_remaining_for_starred_user():

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -15,7 +15,7 @@ def test_discover_commands():
     cmds = all_commands()
     names = {c.name for c in cmds}
     expected = {"help", "newproblem", "submit", "problem",
-                "tag", "clarify", "scoreboard", "setproblem", "sync"}
+                "tag", "clarify", "scoreboard", "setproblem", "sync", "bad"}
     missing = expected - names
     assert not missing, f"Missing commands: {missing}"
     assert len(cmds) >= 7


### PR DESCRIPTION
## 概述

新增 `/bad [<可选简短备注>]` 指令（群聊 + private judge 均可用）：把用户对 AI 最新回复的不满记录落盘，供后续维护 / 回放 / 排查。

- **目标语义**：当前 scope、用户当前题目下，最近一条**实际收到回复**的 submit/clarify/review 记录（判定逻辑与 `_build_review_history` / `format_history_records` 一致：incorrect 空 reply 用 reason 兜底过、算已回复；pending/superseded/no_statement/image_unsupported/service_unavailable/timeout 未回复，跳过；legacy 无 `type` 记录走 result 回退链）。
- **存储**（与用户确认：JSON、追加式、本期仅存储）：
  - 群：`groups/<gid>/bad_reports.json`；私聊：`private_judge/bad_reports/<uid>.json`
  - 每条报告 = 元数据（scope/group_id/user_id/reported_at/note/cmd_message_id）+ 被标注记录的**逐字快照**（含 request_id/model_tag，回放不依赖原 history）
  - 重复 /bad 追加新条目，id 每文件内自增；绝不写进已冻结的 `user_submissions` 记录（sync 逐条拷贝），`/sync` 不搬运报告
  - 损坏文件 load 抛异常而非重置（防止 append 毁掉历史），handler 捕获后提示用户
  - 群侧 append 走 `run_group_state_update` 群锁；私侧纯同步无锁；原子写复用 `save_private_state` 模式抽出 `atomic_write_json`
- **回执**（按需求与 /clear 一致）：群聊成功 → 👌 reaction（128076）；私聊 → 同款回退消息（"收到～"）；备注 strip 后截断 500 字。
- **注册**：`_PRIVATE_ALLOWED_COMMANDS` / `_PRIVATE_HELP_COMMANDS` 加入 `bad`，群聊 /help 自动列出。
- **AGENTS.md**：Data Directory 树、Command Handlers 表、Data Format 新小节（bad_reports.json schema 与规则）。

## 错误路径文案

无当前题目（群/私各一款）、当前题无交互记录、有记录但都未收到回复，三条独立提示，均不落盘。

## 测试

- 新增 `tests/test_bad.py`（18 例）：存储形状/自增 id/原子写无 tmp 残留/损坏不覆盖、群聊定向（跳过 pending/superseded 选最新已回复、快照逐字相等、scoreboard 未动）、私聊跳过 pending 尾、重复追加、备注解析与截断、`_received_reply` 分类、错误路径
- `tests/test_commands.py`：私聊 `process_event` 分发 e2e（白名单生效 + 报告落盘）、群/私 help 断言、`_all_patches` 补 bad 模块 mock
- `tests/test_registry.py`：expected 集合加 bad
- 全量 `uv run pytest`：**551 passed**（基线 532 + 19 新增）

🤖 Generated with [Claude Code](https://claude.com/claude-code)